### PR TITLE
Remove babel plugin in favor of es6 import rules

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,3 @@
 {
   "presets" : ["es2015", "react", "stage-2"],
-  "plugins": [
-    "add-module-exports"
-  ]
 }

--- a/troposphere/static/js/actions.js
+++ b/troposphere/static/js/actions.js
@@ -1,10 +1,57 @@
-
-// Note: while we could include all the actions here, I'm not going to
-// instead, I'm going to let the application load the actions it needs
-// to use during the bootstrapping process so that the application
-// will throw exceptions if any actions don't exist (which will be the default
-// state for functional tests that need mocked actions)
+import BadgeActions from "actions/BadgeActions";
+import ExternalLinkActions from "actions/ExternalLinkActions";
+import HelpActions from "actions/HelpActions";
+import IdentityMembershipActions from "actions/IdentityMembershipActions";
+import ImageActions from "actions/ImageActions";
+import ImageVersionActions from "actions/ImageVersionActions";
+import ImageVersionMembershipActions from "actions/ImageVersionMembershipActions";
+import ImageVersionLicenseActions from "actions/ImageVersionLicenseActions";
+import ImageVersionScriptActions from "actions/ImageVersionScriptActions";
+import ImageBookmarkActions from "actions/ImageBookmarkActions";
+import InstanceActions from "actions/InstanceActions";
+import InstanceTagActions from "actions/InstanceTagActions";
+import InstanceVolumeActions from "actions/InstanceVolumeActions";
+import LicenseActions from "actions/LicenseActions";
+import ScriptActions from "actions/ScriptActions";
+import NullProjectActions from "actions/NullProjectActions";
+import ProfileActions from "actions/ProfileActions";
+import ProjectActions from "actions/ProjectActions";
+import ProviderMachineActions from "actions/ProviderMachineActions";
+import ProjectExternalLinkActions from "actions/ProjectExternalLinkActions";
+import ProjectImageActions from "actions/ProjectImageActions";
+import ProjectInstanceActions from "actions/ProjectInstanceActions";
+import ProjectVolumeActions from "actions/ProjectVolumeActions";
+import ResourceActions from "actions/ResourceActions";
+import TagActions from "actions/TagActions";
+import UserActions from "actions/UserActions";
+import VolumeActions from "actions/VolumeActions";
 
 export default {
-    // add actions here
+    BadgeActions,
+    ExternalLinkActions,
+    HelpActions,
+    IdentityMembershipActions,
+    ImageActions,
+    ImageVersionActions,
+    ImageVersionMembershipActions,
+    ImageVersionLicenseActions,
+    ImageVersionScriptActions,
+    ImageBookmarkActions,
+    InstanceActions,
+    InstanceTagActions,
+    InstanceVolumeActions,
+    LicenseActions,
+    ScriptActions,
+    NullProjectActions,
+    ProfileActions,
+    ProjectActions,
+    ProviderMachineActions,
+    ProjectExternalLinkActions,
+    ProjectImageActions,
+    ProjectInstanceActions,
+    ProjectVolumeActions,
+    ResourceActions,
+    TagActions,
+    UserActions,
+    VolumeActions,
 };

--- a/troposphere/static/js/actions.js
+++ b/troposphere/static/js/actions.js
@@ -3,25 +3,25 @@ import ExternalLinkActions from "actions/ExternalLinkActions";
 import HelpActions from "actions/HelpActions";
 import IdentityMembershipActions from "actions/IdentityMembershipActions";
 import ImageActions from "actions/ImageActions";
-import ImageVersionActions from "actions/ImageVersionActions";
-import ImageVersionMembershipActions from "actions/ImageVersionMembershipActions";
-import ImageVersionLicenseActions from "actions/ImageVersionLicenseActions";
-import ImageVersionScriptActions from "actions/ImageVersionScriptActions";
 import ImageBookmarkActions from "actions/ImageBookmarkActions";
+import ImageVersionActions from "actions/ImageVersionActions";
+import ImageVersionLicenseActions from "actions/ImageVersionLicenseActions";
+import ImageVersionMembershipActions from "actions/ImageVersionMembershipActions";
+import ImageVersionScriptActions from "actions/ImageVersionScriptActions";
 import InstanceActions from "actions/InstanceActions";
 import InstanceTagActions from "actions/InstanceTagActions";
 import InstanceVolumeActions from "actions/InstanceVolumeActions";
 import LicenseActions from "actions/LicenseActions";
-import ScriptActions from "actions/ScriptActions";
 import NullProjectActions from "actions/NullProjectActions";
 import ProfileActions from "actions/ProfileActions";
 import ProjectActions from "actions/ProjectActions";
-import ProviderMachineActions from "actions/ProviderMachineActions";
 import ProjectExternalLinkActions from "actions/ProjectExternalLinkActions";
 import ProjectImageActions from "actions/ProjectImageActions";
 import ProjectInstanceActions from "actions/ProjectInstanceActions";
 import ProjectVolumeActions from "actions/ProjectVolumeActions";
+import ProviderMachineActions from "actions/ProviderMachineActions";
 import ResourceActions from "actions/ResourceActions";
+import ScriptActions from "actions/ScriptActions";
 import TagActions from "actions/TagActions";
 import UserActions from "actions/UserActions";
 import VolumeActions from "actions/VolumeActions";
@@ -32,25 +32,25 @@ export default {
     HelpActions,
     IdentityMembershipActions,
     ImageActions,
-    ImageVersionActions,
-    ImageVersionMembershipActions,
-    ImageVersionLicenseActions,
-    ImageVersionScriptActions,
     ImageBookmarkActions,
+    ImageVersionActions,
+    ImageVersionLicenseActions,
+    ImageVersionMembershipActions,
+    ImageVersionScriptActions,
     InstanceActions,
     InstanceTagActions,
     InstanceVolumeActions,
     LicenseActions,
-    ScriptActions,
     NullProjectActions,
     ProfileActions,
     ProjectActions,
-    ProviderMachineActions,
     ProjectExternalLinkActions,
     ProjectImageActions,
     ProjectInstanceActions,
     ProjectVolumeActions,
+    ProviderMachineActions,
     ResourceActions,
+    ScriptActions,
     TagActions,
     UserActions,
     VolumeActions,

--- a/troposphere/static/js/bootstrapper.js
+++ b/troposphere/static/js/bootstrapper.js
@@ -14,7 +14,6 @@ Object.keys(Backbone.Events).forEach(function(functionName) {
     Backbone.Collection.prototype[functionName] = function() {};
 });
 
-
 Backbone.Collection.prototype.get = function(obj) {
     if (obj == null) return void 0;
     return _.find(this.models, function(model) {
@@ -24,92 +23,6 @@ Backbone.Collection.prototype.get = function(obj) {
 
 // Extend the base collection to include useful functions
 _.extend(Backbone.Collection.prototype, FunctionalCollection);
-
-// Register which stores the image should use
-import stores from "stores";
-
-stores.AllocationStore = require("stores/AllocationStore");
-stores.BadgeStore = require("stores/BadgeStore");
-stores.ExternalLinkStore = require("stores/ExternalLinkStore");
-stores.HelpLinkStore = require("stores/HelpLinkStore");
-stores.ImageStore = require("stores/ImageStore");
-stores.ImageVersionStore = require("stores/ImageVersionStore");
-stores.ImageVersionMembershipStore = require("stores/ImageVersionMembershipStore");
-stores.ImageVersionLicenseStore = require("stores/ImageVersionLicenseStore");
-stores.ImageVersionScriptStore = require("stores/ImageVersionScriptStore");
-stores.IdentityStore = require("stores/IdentityStore");
-stores.ImageBookmarkStore = require("stores/ImageBookmarkStore");
-stores.InstanceHistoryStore = require("stores/InstanceHistoryStore");
-stores.ImageRequestStore = require("stores/ImageRequestStore");
-stores.InstanceStore = require("stores/InstanceStore");
-stores.InstanceTagStore = require("stores/InstanceTagStore");
-stores.LicenseStore = require("stores/LicenseStore");
-stores.ScriptStore = require("stores/ScriptStore");
-stores.MaintenanceMessageStore = require("stores/MaintenanceMessageStore");
-stores.MyBadgeStore = require("stores/MyBadgeStore");
-stores.MembershipStore = require("stores/MembershipStore");
-stores.ProfileStore = require("stores/ProfileStore");
-stores.ProjectStore = require("stores/ProjectStore");
-stores.ProjectExternalLinkStore = require("stores/ProjectExternalLinkStore");
-stores.ProjectImageStore = require("stores/ProjectImageStore");
-stores.ProjectInstanceStore = require("stores/ProjectInstanceStore");
-stores.ProjectVolumeStore = require("stores/ProjectVolumeStore");
-stores.ProviderMachineStore = require("stores/ProviderMachineStore");
-stores.ProviderStore = require("stores/ProviderStore");
-stores.ResourceRequestStore = require("stores/ResourceRequestStore");
-stores.IdentityMembershipStore = require("stores/IdentityMembershipStore");
-stores.StatusStore = require("stores/StatusStore");
-stores.SSHKeyStore = require("stores/SSHKeyStore");
-stores.QuotaStore = require("stores/QuotaStore");
-stores.SizeStore = require("stores/SizeStore");
-stores.TagStore = require("stores/TagStore");
-stores.UserStore = require("stores/UserStore");
-stores.VersionStore = require("stores/VersionStore");
-stores.VolumeStore = require("stores/VolumeStore");
-stores.AllocationSourceStore = require("stores/AllocationSourceStore");
-
-import actions from "actions";
-
-actions.BadgeActions = require("actions/BadgeActions");
-actions.ExternalLinkActions = require("actions/ExternalLinkActions");
-actions.HelpActions = require("actions/HelpActions");
-actions.IdentityMembershipActions = require("actions/IdentityMembershipActions");
-actions.ImageActions = require("actions/ImageActions");
-actions.ImageVersionActions = require("actions/ImageVersionActions");
-actions.ImageVersionMembershipActions = require("actions/ImageVersionMembershipActions");
-actions.ImageVersionLicenseActions = require("actions/ImageVersionLicenseActions");
-actions.ImageVersionScriptActions = require("actions/ImageVersionScriptActions");
-actions.ImageBookmarkActions = require("actions/ImageBookmarkActions");
-actions.InstanceActions = require("actions/InstanceActions");
-actions.InstanceTagActions = require("actions/InstanceTagActions");
-actions.InstanceVolumeActions = require("actions/InstanceVolumeActions");
-actions.LicenseActions = require("actions/LicenseActions");
-actions.ScriptActions = require("actions/ScriptActions");
-actions.NullProjectActions = require("actions/NullProjectActions");
-actions.ProfileActions = require("actions/ProfileActions");
-actions.ProjectActions = require("actions/ProjectActions");
-actions.ProviderMachineActions = require("actions/ProviderMachineActions");
-actions.ProjectExternalLinkActions = require("actions/ProjectExternalLinkActions");
-actions.ProjectImageActions = require("actions/ProjectImageActions");
-actions.ProjectInstanceActions = require("actions/ProjectInstanceActions");
-actions.ProjectVolumeActions = require("actions/ProjectVolumeActions");
-actions.ResourceActions = require("actions/ResourceActions");
-actions.TagActions = require("actions/TagActions");
-actions.UserActions = require("actions/UserActions");
-actions.VolumeActions = require("actions/VolumeActions");
-
-import modals from "modals";
-
-modals.BadgeModals = require("modals/BadgeModals");
-modals.ExternalLinkModals = require("modals/ExternalLinkModals");
-modals.HelpModals = require("modals/HelpModals");
-modals.InstanceModals = require("modals/InstanceModals");
-modals.InstanceVolumeModals = require("modals/InstanceVolumeModals");
-modals.ProjectModals = require("modals/ProjectModals");
-modals.TagModals = require("modals/TagModals");
-modals.VersionModals = require("modals/VersionModals");
-modals.VolumeModals = require("modals/VolumeModals");
-modals.UnsupportedModal = require("modals/UnsupportedModal");
 
 export default {
     run: function() {

--- a/troposphere/static/js/modals.js
+++ b/troposphere/static/js/modals.js
@@ -19,7 +19,7 @@ export default {
     ProjectModals,
     PublicModals,
     TagModals,
-    UnsupportedModal
+    UnsupportedModal,
     VersionModals,
     VolumeModals,
 };

--- a/troposphere/static/js/modals.js
+++ b/troposphere/static/js/modals.js
@@ -1,13 +1,23 @@
-// Note: while we could include all the modals here, I'm not going to
-// instead, I'm going to let the application load the modals it needs
-// to use during the bootstrapping process so that the application
-// will throw exceptions if any actions don't exist (which will be the default
-// state for functional tests that need mocked modals)
+import BadgeModals from "modals/BadgeModals";
+import ExternalLinkModals from "modals/ExternalLinkModals";
+import HelpModals from "modals/HelpModals";
+import InstanceModals from "modals/InstanceModals";
+import InstanceVolumeModals from "modals/InstanceVolumeModals";
+import ProjectModals from "modals/ProjectModals";
+import TagModals from "modals/TagModals";
+import VersionModals from "modals/VersionModals";
+import VolumeModals from "modals/VolumeModals";
+import UnsupportedModal from "modals/UnsupportedModal";
 
-export default function () {
-
-    return {
-        // add modals here
-    }
-}
-;
+export default {
+    BadgeModals,
+    ExternalLinkModals,
+    HelpModals,
+    InstanceModals,
+    InstanceVolumeModals,
+    ProjectModals,
+    TagModals,
+    VersionModals,
+    VolumeModals,
+    UnsupportedModal
+};

--- a/troposphere/static/js/modals.js
+++ b/troposphere/static/js/modals.js
@@ -8,6 +8,7 @@ import TagModals from "modals/TagModals";
 import VersionModals from "modals/VersionModals";
 import VolumeModals from "modals/VolumeModals";
 import UnsupportedModal from "modals/UnsupportedModal";
+import PublicModals from "modals/PublicModals";
 
 export default {
     BadgeModals,
@@ -16,6 +17,7 @@ export default {
     InstanceModals,
     InstanceVolumeModals,
     ProjectModals,
+    PublicModals,
     TagModals,
     VersionModals,
     VolumeModals,

--- a/troposphere/static/js/modals.js
+++ b/troposphere/static/js/modals.js
@@ -4,11 +4,11 @@ import HelpModals from "modals/HelpModals";
 import InstanceModals from "modals/InstanceModals";
 import InstanceVolumeModals from "modals/InstanceVolumeModals";
 import ProjectModals from "modals/ProjectModals";
+import PublicModals from "modals/PublicModals";
 import TagModals from "modals/TagModals";
+import UnsupportedModal from "modals/UnsupportedModal";
 import VersionModals from "modals/VersionModals";
 import VolumeModals from "modals/VolumeModals";
-import UnsupportedModal from "modals/UnsupportedModal";
-import PublicModals from "modals/PublicModals";
 
 export default {
     BadgeModals,
@@ -19,7 +19,7 @@ export default {
     ProjectModals,
     PublicModals,
     TagModals,
+    UnsupportedModal
     VersionModals,
     VolumeModals,
-    UnsupportedModal
 };

--- a/troposphere/static/js/public_site/bootstrapper.react.js
+++ b/troposphere/static/js/public_site/bootstrapper.react.js
@@ -1,23 +1,12 @@
 import React from "react";
 import ReactDOM from "react-dom";
-import Profile from "models/Profile";
 import $ from "jquery";
+
 import Router from "../Router";
+import Profile from "models/Profile";
 import routes from "./AppRoutes.react";
-
-
 import modals from "modals";
-
-modals.PublicModals = require("modals/PublicModals");
-
-// Register which stores the application should use
 import stores from "stores";
-
-stores.ImageStore = require("stores/ImageStore");
-stores.ImageBookmarkStore = require("stores/ImageBookmarkStore");
-stores.ImageVersionStore = require("stores/ImageVersionStore");
-stores.TagStore = require("stores/TagStore");
-stores.HelpLinkStore = require("stores/HelpLinkStore");
 
 // Mock out the profile store with an empty profile
 stores.ProfileStore = {

--- a/troposphere/static/js/public_site/bootstrapper.react.js
+++ b/troposphere/static/js/public_site/bootstrapper.react.js
@@ -5,7 +5,6 @@ import $ from "jquery";
 import Router from "../Router";
 import Profile from "models/Profile";
 import routes from "./AppRoutes.react";
-import modals from "modals";
 import stores from "stores";
 
 // Mock out the profile store with an empty profile

--- a/troposphere/static/js/stores.js
+++ b/troposphere/static/js/stores.js
@@ -1,87 +1,81 @@
-// Note: while we could include all the stores here, I'm not going to
-// instead, I'm going to let the application load the stores it needs
-// to use during the bootstrapping process so that the application
-// will throw exceptions if any stores don't exist (which will be the default
-// state for functional tests that need mocked stores)
-
-import ProfileStore from "stores/ProfileStore";
+import AllocationSourceStore from "stores/AllocationSourceStore";
 import AllocationStore from "stores/AllocationStore";
 import BadgeStore from "stores/BadgeStore";
 import ExternalLinkStore from "stores/ExternalLinkStore";
 import HelpLinkStore from "stores/HelpLinkStore";
-import ImageStore from "stores/ImageStore";
-import ImageVersionStore from "stores/ImageVersionStore";
-import ImageVersionMembershipStore from "stores/ImageVersionMembershipStore";
-import ImageVersionLicenseStore from "stores/ImageVersionLicenseStore";
-import ImageVersionScriptStore from "stores/ImageVersionScriptStore";
+import IdentityMembershipStore from "stores/IdentityMembershipStore";
 import IdentityStore from "stores/IdentityStore";
 import ImageBookmarkStore from "stores/ImageBookmarkStore";
-import InstanceHistoryStore from "stores/InstanceHistoryStore";
 import ImageRequestStore from "stores/ImageRequestStore";
+import ImageStore from "stores/ImageStore";
+import ImageVersionLicenseStore from "stores/ImageVersionLicenseStore";
+import ImageVersionMembershipStore from "stores/ImageVersionMembershipStore";
+import ImageVersionScriptStore from "stores/ImageVersionScriptStore";
+import ImageVersionStore from "stores/ImageVersionStore";
+import InstanceHistoryStore from "stores/InstanceHistoryStore";
 import InstanceStore from "stores/InstanceStore";
 import InstanceTagStore from "stores/InstanceTagStore";
 import LicenseStore from "stores/LicenseStore";
-import ScriptStore from "stores/ScriptStore";
 import MaintenanceMessageStore from "stores/MaintenanceMessageStore";
-import MyBadgeStore from "stores/MyBadgeStore";
 import MembershipStore from "stores/MembershipStore";
-import ProjectStore from "stores/ProjectStore";
+import MyBadgeStore from "stores/MyBadgeStore";
+import ProfileStore from "stores/ProfileStore";
 import ProjectExternalLinkStore from "stores/ProjectExternalLinkStore";
 import ProjectImageStore from "stores/ProjectImageStore";
 import ProjectInstanceStore from "stores/ProjectInstanceStore";
+import ProjectStore from "stores/ProjectStore";
 import ProjectVolumeStore from "stores/ProjectVolumeStore";
 import ProviderMachineStore from "stores/ProviderMachineStore";
 import ProviderStore from "stores/ProviderStore";
-import ResourceRequestStore from "stores/ResourceRequestStore";
-import IdentityMembershipStore from "stores/IdentityMembershipStore";
-import StatusStore from "stores/StatusStore";
-import SSHKeyStore from "stores/SSHKeyStore";
 import QuotaStore from "stores/QuotaStore";
+import ResourceRequestStore from "stores/ResourceRequestStore";
+import ScriptStore from "stores/ScriptStore";
 import SizeStore from "stores/SizeStore";
+import SSHKeyStore from "stores/SSHKeyStore";
+import StatusStore from "stores/StatusStore";
 import TagStore from "stores/TagStore";
 import UserStore from "stores/UserStore";
 import VersionStore from "stores/VersionStore";
 import VolumeStore from "stores/VolumeStore";
-import AllocationSourceStore from "stores/AllocationSourceStore";
 
 export default {
-    ProfileStore,
+    AllocationSourceStore,
     AllocationStore,
     BadgeStore,
     ExternalLinkStore,
     HelpLinkStore,
-    ImageStore,
-    ImageVersionStore,
-    ImageVersionMembershipStore,
-    ImageVersionLicenseStore,
-    ImageVersionScriptStore,
+    IdentityMembershipStore,
     IdentityStore,
     ImageBookmarkStore,
-    InstanceHistoryStore,
     ImageRequestStore,
+    ImageStore,
+    ImageVersionLicenseStore,
+    ImageVersionMembershipStore,
+    ImageVersionScriptStore,
+    ImageVersionStore,
+    InstanceHistoryStore,
     InstanceStore,
     InstanceTagStore,
     LicenseStore,
-    ScriptStore,
     MaintenanceMessageStore,
-    MyBadgeStore,
     MembershipStore,
-    ProjectStore,
+    MyBadgeStore,
+    ProfileStore,
     ProjectExternalLinkStore,
     ProjectImageStore,
     ProjectInstanceStore,
+    ProjectStore,
     ProjectVolumeStore,
     ProviderMachineStore,
     ProviderStore,
-    ResourceRequestStore,
-    IdentityMembershipStore,
-    StatusStore,
-    SSHKeyStore,
     QuotaStore,
+    ResourceRequestStore,
+    ScriptStore,
     SizeStore,
+    SSHKeyStore,
+    StatusStore,
     TagStore,
     UserStore,
     VersionStore,
     VolumeStore,
-    AllocationSourceStore,
 }

--- a/troposphere/static/js/stores.js
+++ b/troposphere/static/js/stores.js
@@ -4,9 +4,84 @@
 // will throw exceptions if any stores don't exist (which will be the default
 // state for functional tests that need mocked stores)
 
-export default function () {
-    return {
-        // add stores here
-    }
+import ProfileStore from "stores/ProfileStore";
+import AllocationStore from "stores/AllocationStore";
+import BadgeStore from "stores/BadgeStore";
+import ExternalLinkStore from "stores/ExternalLinkStore";
+import HelpLinkStore from "stores/HelpLinkStore";
+import ImageStore from "stores/ImageStore";
+import ImageVersionStore from "stores/ImageVersionStore";
+import ImageVersionMembershipStore from "stores/ImageVersionMembershipStore";
+import ImageVersionLicenseStore from "stores/ImageVersionLicenseStore";
+import ImageVersionScriptStore from "stores/ImageVersionScriptStore";
+import IdentityStore from "stores/IdentityStore";
+import ImageBookmarkStore from "stores/ImageBookmarkStore";
+import InstanceHistoryStore from "stores/InstanceHistoryStore";
+import ImageRequestStore from "stores/ImageRequestStore";
+import InstanceStore from "stores/InstanceStore";
+import InstanceTagStore from "stores/InstanceTagStore";
+import LicenseStore from "stores/LicenseStore";
+import ScriptStore from "stores/ScriptStore";
+import MaintenanceMessageStore from "stores/MaintenanceMessageStore";
+import MyBadgeStore from "stores/MyBadgeStore";
+import MembershipStore from "stores/MembershipStore";
+import ProjectStore from "stores/ProjectStore";
+import ProjectExternalLinkStore from "stores/ProjectExternalLinkStore";
+import ProjectImageStore from "stores/ProjectImageStore";
+import ProjectInstanceStore from "stores/ProjectInstanceStore";
+import ProjectVolumeStore from "stores/ProjectVolumeStore";
+import ProviderMachineStore from "stores/ProviderMachineStore";
+import ProviderStore from "stores/ProviderStore";
+import ResourceRequestStore from "stores/ResourceRequestStore";
+import IdentityMembershipStore from "stores/IdentityMembershipStore";
+import StatusStore from "stores/StatusStore";
+import SSHKeyStore from "stores/SSHKeyStore";
+import QuotaStore from "stores/QuotaStore";
+import SizeStore from "stores/SizeStore";
+import TagStore from "stores/TagStore";
+import UserStore from "stores/UserStore";
+import VersionStore from "stores/VersionStore";
+import VolumeStore from "stores/VolumeStore";
+import AllocationSourceStore from "stores/AllocationSourceStore";
+
+export default {
+    ProfileStore,
+    AllocationStore,
+    BadgeStore,
+    ExternalLinkStore,
+    HelpLinkStore,
+    ImageStore,
+    ImageVersionStore,
+    ImageVersionMembershipStore,
+    ImageVersionLicenseStore,
+    ImageVersionScriptStore,
+    IdentityStore,
+    ImageBookmarkStore,
+    InstanceHistoryStore,
+    ImageRequestStore,
+    InstanceStore,
+    InstanceTagStore,
+    LicenseStore,
+    ScriptStore,
+    MaintenanceMessageStore,
+    MyBadgeStore,
+    MembershipStore,
+    ProjectStore,
+    ProjectExternalLinkStore,
+    ProjectImageStore,
+    ProjectInstanceStore,
+    ProjectVolumeStore,
+    ProviderMachineStore,
+    ProviderStore,
+    ResourceRequestStore,
+    IdentityMembershipStore,
+    StatusStore,
+    SSHKeyStore,
+    QuotaStore,
+    SizeStore,
+    TagStore,
+    UserStore,
+    VersionStore,
+    VolumeStore,
+    AllocationSourceStore,
 }
-;


### PR DESCRIPTION
Here is a pr to outline the remaining work of moving to babel 6. The behavior of require changed. Every occurrence of `require` needs to be replaced by an import. 

I need to verify this last commit. (Moving a bunch of imports is error-prone)
