### PR TITLE
Provide explicit indicators for when delegate system password expired

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -1,3 +1,5 @@
+import json
+
 from django.db import models
 from django.db.models import Q
 from django.db.models.signals import post_save
@@ -123,6 +125,19 @@ class SiteMetadata(SingletonModel):
         max_length=254,
         default=b"http://user.cyverse.org/",
         help_text="Hyperlink in footer to host installation organization or product page.")
+
+    def get_user_portal_as_json(self):
+        """
+        Provides a JSON representation of User Portal information.
+        """
+        up = self.get_user_portal()
+        return json.dumps(up)
+
+    def get_user_portal(self):
+        up = {}
+        up["link"] = str(self.user_portal_link)
+        up["text"] = str(self.user_portal_link_text)
+        return up
 
     class Meta:
         db_table = 'site_metadata'

--- a/troposphere/static/js/bootstrapper.js
+++ b/troposphere/static/js/bootstrapper.js
@@ -101,6 +101,7 @@ actions.VolumeActions = require("actions/VolumeActions");
 import modals from "modals";
 
 modals.BadgeModals = require("modals/BadgeModals");
+modals.ExpiredPasswordModals = require("modals/ExpiredPasswordModals");
 modals.ExternalLinkModals = require("modals/ExternalLinkModals");
 modals.HelpModals = require("modals/HelpModals");
 modals.InstanceModals = require("modals/InstanceModals");

--- a/troposphere/static/js/components/Header.react.js
+++ b/troposphere/static/js/components/Header.react.js
@@ -142,7 +142,8 @@ let LogoutLink = React.createClass({
             );
             expiredMenuItem = (
                 <li>
-                    <a id="expired_password_link" href="#"
+                    <a id="expired_password_link"
+                       href="#" style={{color: "red"}}
                        onClick={this.onExpiredPassword}>
                         <Glyphicon name="exclamation-sign" />
                         Expired Password</a>

--- a/troposphere/static/js/components/Header.react.js
+++ b/troposphere/static/js/components/Header.react.js
@@ -5,6 +5,7 @@ import toastr from 'toastr';
 
 import modals from 'modals';
 import MaintenanceMessageBanner from './MaintenanceMessageBanner.react';
+import Glyphicon from 'components/common/Glyphicon.react';
 import context from 'context';
 import globals from 'globals';
 
@@ -90,6 +91,11 @@ let LogoutLink = React.createClass({
         modals.VersionModals.showVersion();
     },
 
+    onExpiredPassword: function(e) {
+        e.preventDefault();
+        modals.ExpiredPasswordModals.show();
+    },
+
     render: function() {
         let statusPageEl;
         let username = this.props.username;
@@ -117,12 +123,38 @@ let LogoutLink = React.createClass({
             username = "AnonymousUser"
         }
 
+        let expiredBadge = null,
+            expiredMenuItem = null;
+
+        if (context.hasExpiredPassword()) {
+            let style = {
+                color: "red",
+                background: "white",
+                borderRadius: "50%",
+                marginRight: "3px"
+            };
+            expiredBadge = (
+                // Glyphicon is not attended to accept styles
+                // - so let's create exactly what we want
+                <i className={"glyphicon glyphicon-exclamation-sign"}
+                   style={style} />
+            );
+            expiredMenuItem = (
+                <li>
+                    <a id="expired_password_link" href="#"
+                       onClick={this.onExpiredPassword}>
+                        <Glyphicon name="exclamation-sign" />
+                        Expired Password</a>
+                </li>
+            );
+        }
 
         return (
         <li className="dropdown">
             <a className="dropdown-toggle" href="#" data-toggle="dropdown">
-                {username} <b className="caret"></b></a>
+                {expiredBadge}{username} <b className="caret"></b></a>
             <ul className="dropdown-menu">
+                {expiredMenuItem}
                 <li>
                     <Link to="settings" onClick={trackSettings}> Settings
                     </Link>

--- a/troposphere/static/js/components/Header.react.js
+++ b/troposphere/static/js/components/Header.react.js
@@ -94,6 +94,7 @@ let LogoutLink = React.createClass({
     onExpiredPassword: function(e) {
         e.preventDefault();
         modals.ExpiredPasswordModals.show();
+        trackAction("shown-expired-password-info", {});
     },
 
     render: function() {

--- a/troposphere/static/js/components/modals/ExpiredPassword.react.js
+++ b/troposphere/static/js/components/modals/ExpiredPassword.react.js
@@ -1,0 +1,56 @@
+import React from "react";
+
+import BootstrapModalMixin from "components/mixins/BootstrapModalMixin.react";
+import globals from "globals";
+
+
+export default React.createClass({
+
+    mixins: [BootstrapModalMixin],
+
+    getInitialState() {
+        let link = globals.USER_PORTAL.link(),
+            text = globals.USER_PORTAL.text()
+
+        return {
+            link,
+            text
+        };
+    },
+
+    render() {
+        let { link, text } = this.state;
+
+        return (
+        <div className="modal fade">
+            <div className="modal-dialog" style={{ minWidth: "600px"}}>
+                <div className="modal-content">
+                    <div className="modal-header">
+                        {this.renderCloseButton()}
+                        <h1 className="t-title">Expired Password</h1>
+                    </div>
+                    <div style={{ minHeight: "300px" }} className="modal-body">
+                        <p>
+                            The cryptographically secure password associated with
+                            the cloud providers for your accounts has expired.
+                            This will block further actions, like the launching
+                            new instances.
+                       </p>
+                       <p>
+                           Please visit <a href={link}>{text}</a> to perform
+                           the necessary actions to resolve this problem.
+                       </p>
+                    </div>
+                    <div className="modal-footer">
+                        <button type="button"
+                                className="btn btn-primary"
+                                onClick={this.hide}>
+                            Okay
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+        );
+    }
+});

--- a/troposphere/static/js/components/projects/detail/resources/SubMenu.react.js
+++ b/troposphere/static/js/components/projects/detail/resources/SubMenu.react.js
@@ -1,6 +1,9 @@
 import React from "react";
 import Backbone from "backbone";
+import context from "context";
 import modals from "modals";
+
+import { trackAction } from 'utilities/userActivity';
 
 
 export default React.createClass({
@@ -31,24 +34,72 @@ export default React.createClass({
         });
     },
 
+    onExpiredPassword: function(e) {
+        e.preventDefault();
+        modals.ExpiredPasswordModals.show();
+        trackAction("shown-expired-password-info", {});
+    },
+
     render: function() {
+        let expiredBadge = null,
+            dropdownMenu;
+
+        dropdownMenu = (
+            <ul className="dropdown-menu">
+                <li>
+                    <a id="res-create-instance" href="#"
+                       onClick={this.onCreateInstance}>
+                        <i className={'glyphicon glyphicon-tasks'} /> Instance</a>
+                </li>
+                <li>
+                    <a id="res-create-volume" href="#"
+                       onClick={this.onCreateVolume}>
+                        <i className={'glyphicon glyphicon-hdd'} /> Volume</a>
+                </li>
+                <li>
+                    <a id="res-create-link" href="#"
+                       onClick={this.onCreateExternalLink}>
+                        <i className={'glyphicon glyphicon-globe'} /> Link</a>
+                </li>
+            </ul>
+        );
+
+
+        if (context && context.hasExpiredPassword()) {
+            let style = {
+                position: "absolute",
+                top: "-5px",
+                left: "-5px",
+                color: "red",
+                background: "white",
+                borderRadius: "50%",
+                marginRight: "3px"
+            };
+            expiredBadge = (
+                <i className="glyphicon glyphicon-exclamation-sign" style={style} />
+            );
+            dropdownMenu = (
+                <ul className="dropdown-menu">
+                    <li>
+                        <a id="res-create-instance" href="#"
+                           onClick={this.onExpiredPassword}>
+                            <i className={'glyphicon glyphicon-exclamation-sign'} />
+                            Expired Password</a>
+                    </li>
+                </ul>
+            );
+        }
+
         return (
         <div className="sub-menu">
             <div className="dropdown">
-                <button id="res-new-menu" className="btn btn-primary dropdown-toggle" data-toggle="dropdown">
+                <button id="res-new-menu"
+                        className="btn btn-primary dropdown-toggle"
+                        data-toggle="dropdown">
                     New
                 </button>
-                <ul className="dropdown-menu">
-                    <li>
-                        <a id="res-create-instance" href="#" onClick={this.onCreateInstance}><i className={'glyphicon glyphicon-tasks'} /> Instance</a>
-                    </li>
-                    <li>
-                        <a id="res-create-volume" href="#" onClick={this.onCreateVolume}><i className={'glyphicon glyphicon-hdd'} /> Volume</a>
-                    </li>
-                    <li>
-                        <a id="res-create-link" href="#" onClick={this.onCreateExternalLink}><i className={'glyphicon glyphicon-globe'} /> Link</a>
-                    </li>
-                </ul>
+                {expiredBadge}
+                {dropdownMenu}
             </div>
         </div>
         );

--- a/troposphere/static/js/context.js
+++ b/troposphere/static/js/context.js
@@ -1,4 +1,5 @@
-import { hasLoggedInUser } from "utilities/profilePredicate";
+import { hasLoggedInUser,
+         hasExpiredPassword } from "utilities/profilePredicate";
 
 export default {
     hasMaintenanceNotice: function() {
@@ -9,6 +10,9 @@ export default {
     },
     hasLoggedInUser: function() {
         return hasLoggedInUser(this.profile);
+    },
+    hasExpiredPassword() {
+        return hasExpiredPassword(this.profile);
     },
     profile: null
 };

--- a/troposphere/static/js/globals.js
+++ b/troposphere/static/js/globals.js
@@ -6,6 +6,16 @@ let tz_region = timezone ? timezone.name() : "America/Phoenix";
 let shell_proxy = "https://atmo-proxy.cyverse.org/";
 let default_footer_link = "http://www.cyverse.org/";
 
+let USER_PORTAL = {
+    link() {
+        return window.user_portal && window.user_portal.link || "";
+    },
+    text() {
+        return window.user_portal && window.user_portal.text || "";
+    }
+};
+
+
 export default {
     API_ROOT: window.API_ROOT || "/api/v1",
     API_V2_ROOT: window.API_V2_ROOT || "/api/v2",
@@ -24,5 +34,6 @@ export default {
     BADGES_ENABLED: window.BADGES_ENABLED || false,
     USE_MOCK_DATA: window.USE_MOCK_DATA || false,
     USE_ALLOCATION_SOURCES: window.USE_ALLOCATION_SOURCES,
-    SHOW_INSTANCE_METRICS: window.SHOW_INSTANCE_METRICS
+    SHOW_INSTANCE_METRICS: window.SHOW_INSTANCE_METRICS,
+    USER_PORTAL
 }

--- a/troposphere/static/js/modals/ExpiredPasswordModals.js
+++ b/troposphere/static/js/modals/ExpiredPasswordModals.js
@@ -1,0 +1,5 @@
+import { show } from "./expiredPassword/show";
+
+export default {
+    show
+};

--- a/troposphere/static/js/modals/expiredPassword/show.js
+++ b/troposphere/static/js/modals/expiredPassword/show.js
@@ -1,0 +1,13 @@
+import ModalHelpers from "components/modals/ModalHelpers";
+import ExpiredPasswordModal from 'components/modals/ExpiredPassword.react';
+
+
+let show = function() {
+    ModalHelpers.renderModal(
+        ExpiredPasswordModal,
+        {},
+        function() {}
+    );
+};
+
+export { show }

--- a/troposphere/static/js/models/Profile.js
+++ b/troposphere/static/js/models/Profile.js
@@ -9,6 +9,20 @@ export default Backbone.Model.extend({
 
         attributes.id = response.username;
         attributes.userid = response.username;
+        /**
+         * FIXME: several values are missing from Profile
+         *
+         * ideally, we need to evaluate if the following
+         * should be included in the Profile model
+         *
+         * "email": "lenards@cyverse.org",
+         * "groups": "[<Group: lenards>]",
+         * "is_expired": false,
+         * "is_staff": true,
+         * "is_superuser": true,
+         */
+        attributes.is_expired = response.is_expired;
+
         attributes.ec2_access_key = null;
         attributes.ec2_secret_key = null;
         attributes.ec2_url = null;
@@ -21,6 +35,7 @@ export default Backbone.Model.extend({
         attributes.default_size = response.default_size;
         attributes.quick_launch = response.quick_launch;
         attributes.icon_set = response.icon_set;
+
         attributes.settings = {};
         attributes.settings.background = response.background;
         attributes.settings.default_size = response.default_size;

--- a/troposphere/static/js/utilities/profilePredicate.js
+++ b/troposphere/static/js/utilities/profilePredicate.js
@@ -4,4 +4,8 @@ const hasLoggedInUser = (profile) => {
     return !!(profile && profile.get("username"));
 };
 
-export { hasLoggedInUser };
+const hasExpiredPassword = (profile) => {
+    return hasLoggedInUser(profile) && !!(profile.get("is_expired"));
+}
+
+export { hasLoggedInUser, hasExpiredPassword };

--- a/troposphere/templates/index.html
+++ b/troposphere/templates/index.html
@@ -147,6 +147,9 @@
     };
 {% endif %}
 
+{% if USER_PORTAL %}
+    var user_portal = {{USER_PORTAL | safe}};
+{% endif %}
     </script>
 
 {% if DYNAMIC_ASSET_LOADING %}

--- a/troposphere/views/app.py
+++ b/troposphere/views/app.py
@@ -126,6 +126,8 @@ def _populate_template_params(request, maintenance_records, notice_t, disabled_l
             metadata.status_page_link
         template_params['SITE_FOOTER_LINK'] = \
             metadata.site_footer_link
+        template_params['USER_PORTAL'] = \
+            metadata.get_user_portal_as_json()
 
     if hasattr(settings, "API_ROOT"):
         template_params['API_ROOT'] = settings.API_ROOT


### PR DESCRIPTION
## Background

The CyVerse deployment of Atmosphere leverages Central Authentication Service [(CAS)](https://www.apereo.org/projects/cas) as a Single-Sign On / OAuth provider. But also, delegates to other authentication services within the system. These _delegated_ services can have rules differing from CAS, or may not be related to it directly. This is not only authentication option. Atmosphere uses [a module](https://github.com/iPlantCollaborativeOpenSource/django-iplant-auth) to provide CAS, OAuth, and Globus for given deployments (e.g. installations).

## Problem 
Validation rules outside of the authentication module can cause instance launch failures (i.e. the password for the delegated account has expired, but this fact is not known to the account-holder or community member). 

The reason for the failure needs to be made explicit. 

## Solution
This pull request applies "indicators" for the problem/issue in three areas of the user interface:
- general header (near the username, most obvious)
- launch instance from image catalog
- create new project resource (any action, but notably "launch instance _within_ project")

<details>

## Screen Captures (animated)

Screen captures of three interactions:
- badge & item within "Username" context menu: http://recordit.co/QrWGsSXKIY
- badge & item within Project "NEW" resources: http://recordit.co/rWAoC5VM5A
- badge over "Launch" button within Image Catalog: http://recordit.co/KBkNSWpRgA

## Screenshots

### dashboard

<img width="1234" alt="header for dashboard - full view" src="https://cloud.githubusercontent.com/assets/5923/20582177/2c3a630a-b19c-11e6-9202-fca565d773a2.png">

### general header (username context menu)

<img width="237" alt="screen shot 2016-11-22 at 2 57 37 pm" src="https://cloud.githubusercontent.com/assets/5923/20582173/1bb7feac-b19c-11e6-80ea-f05ab59edaed.png">

- - -

<img width="263" alt="screen shot 2016-11-23 at 3 03 50 pm" src="https://cloud.githubusercontent.com/assets/5923/20582185/361920fa-b19c-11e6-8879-43827db93786.png">

- - -

### project resource view 
<img width="263" alt="screen shot 2016-11-22 at 4 34 31 pm" src="https://cloud.githubusercontent.com/assets/5923/20582175/26d52b2a-b19c-11e6-9c0f-ec9e37b2cf63.png">

<img width="292" alt="screen shot 2016-11-22 at 4 34 47 pm" src="https://cloud.githubusercontent.com/assets/5923/20582176/2934f616-b19c-11e6-9c07-9e95bee586c0.png">

### Image Catalog view (image detail, "Launch" button)
<img width="371" alt="Launch button from image catalog view" src="https://cloud.githubusercontent.com/assets/5923/20582183/336ddfee-b19c-11e6-91f1-1139682cc480.png">




</details>

- - -

See [ATMO-1481](https://pods.iplantcollaborative.org/jira/browse/ATMO-1481)