### PR TITLE
Add missing quotes around string

### DIFF
--- a/troposphere/templates/index.html
+++ b/troposphere/templates/index.html
@@ -113,7 +113,7 @@
 {% endif %}
 
 {% if WEB_DESKTOP_INCLUDE_LINK %}
-    var WEB_DESKTOP_INCLUDE_LINK = "{{ WEB_DESKTOP_INCLUDE_LINK }}"
+    var WEB_DESKTOP_INCLUDE_LINK = "{{ WEB_DESKTOP_INCLUDE_LINK }}";
 {% endif %}
 
 {% if show_public_site %}
@@ -142,8 +142,8 @@
 
 {% if sentry %}
     var SENTRY_ENABLED = true;
-    var SENTRY_RELEASE = {{ sentry.release }}
-    var SENTRY_DSN = {{ sentry.dsn }}
+    var SENTRY_RELEASE = "{{ sentry.release }}";
+    var SENTRY_DSN = "{{ sentry.dsn }}";
 {%  else %}
     var SENTRY_ENABLED = false;
 {% endif %}


### PR DESCRIPTION
This fixes a syntax error in the `index.html`. I found it after my variables were not being set correctly in that file.