### PR TITLE
Include ClientCredentials component

### DIFF
--- a/troposphere/static/js/components/modals/ExportCredential.jsx
+++ b/troposphere/static/js/components/modals/ExportCredential.jsx
@@ -2,6 +2,8 @@ import React from "react";
 import moment from "moment";
 
 import BootstrapModalMixin from "components/mixins/BootstrapModalMixin";
+import Glyphicon from "components/common/Glyphicon"
+
 import stores from "stores";
 
 import { hasClipboardAPI,
@@ -23,7 +25,7 @@ function populateOpenRCTemplate(credModel) {
                         "OS_USER_DOMAIN_NAME", "OS_TENANT_NAME", "OS_AUTH_URL",
                         "OS_PROJECT_DOMAIN_NAME", "OS_REGION_NAME", "OS_PASSWORD"];
 
-    let openrc = `# generated on ${exportTime}`;
+    let openrc = `# generated on ${exportTime}\n`;
 
     // produce an "openrc" string that includes only defined values from endpoint
     envVarNames.forEach((env) => {
@@ -210,6 +212,15 @@ export default React.createClass({
                     environment to "export" the necessary information
                     used by command-line interfaces (CLI) for the
                     OpenStack APIs.
+                </p>
+                <p className="alert alert-info">
+                    <Glyphicon name="info-sign" />
+                    {" "}
+                    <strong>PLEASE NOTE</strong><br/>
+                    When using these credentials, ensure that the domain
+                    and port for <span style={{fontFamily: "monospace"}}>$OS_AUTH_URL</span>
+                    {" "}are reachable. Simply using <span style={{fontFamily: "monospace"}}>curl</span>
+                    {" "}or navigating to the base URL will help to determine reachability.
                 </p>
                 <pre id="openrc" ref="openrcExport">
                     {openrc}

--- a/troposphere/static/js/components/settings/AdvancedSettingsPage.jsx
+++ b/troposphere/static/js/components/settings/AdvancedSettingsPage.jsx
@@ -1,7 +1,11 @@
 import React from "react";
+
 import SSHConfiguration from "components/settings/advanced/SSHConfiguration";
+import ClientCredentials from "components/settings/advanced/ClientCredentials";
+
 
 export default React.createClass({
+    displayName: "AdvancedSettingsPages",
 
     getInitialState: function() {
         return {
@@ -22,6 +26,7 @@ export default React.createClass({
     renderMore: function() {
         return (
         <div style={{ marginLeft: "30px" }}>
+            <ClientCredentials/>
             <SSHConfiguration/>
             <button onClick={this.showToggle}>
                 Show Less


### PR DESCRIPTION
During the conflict resolution from `toco-toucan` to `undulating-umbrellabird`, the version of `troposphere/static/js/components/settings/AdvancedSettingsPage.jsx` from (then) master was included over `AdvancedSettingsPage.react.js`

This pull request takes the version from `toco-toucan` into U release.

![client-credential-component](https://cloud.githubusercontent.com/assets/5923/21668636/fdf4c8c8-d2c0-11e6-830f-b0e4e9849273.png)

In addition to bring back `<ClientCredential/>`, this also adds an "info" section to help ensure those using the client tools realize they need to take care to during if the OpenStack services are reachable.

And, a format issue with `OS_USERNAME` being on the generated "comment" line.

![export-credential-modal](https://cloud.githubusercontent.com/assets/5923/21668639/018f5926-d2c1-11e6-88e1-46f80906abb8.png)
