### PR TITLE
Add copy ability for select resource details

### DIFF
--- a/troposphere/static/js/components/images/detail/availability/AvailabilityView.jsx
+++ b/troposphere/static/js/components/images/detail/availability/AvailabilityView.jsx
@@ -3,8 +3,7 @@ import Backbone from "backbone";
 import stores from "stores";
 import Code from "components/common/ui/Code";
 
-import { hasClipboardAPI,
-         copyElement } from "utilities/clipboardFunctions";
+import { copyElement } from "utilities/clipboardFunctions";
 
 
 export default React.createClass({
@@ -17,9 +16,7 @@ export default React.createClass({
 
     onClick(e) {
         e.preventDefault();
-        if (hasClipboardAPI()) {
-            copyElement(e.target);
-        }
+        copyElement(e.target);
     },
 
     renderProviderMachine( provider ) {

--- a/troposphere/static/js/components/projects/common/ResourceDetail.jsx
+++ b/troposphere/static/js/components/projects/common/ResourceDetail.jsx
@@ -5,18 +5,33 @@ export default React.createClass({
 
     propTypes: {
         label: React.PropTypes.string.isRequired,
-        children: React.PropTypes.node.isRequired
+        children: React.PropTypes.node.isRequired,
+        onClick: React.PropTypes.func
     },
 
     render: function() {
+        let detailValue;
+
+        if (this.props.onClick) {
+            detailValue = (
+            <div className="detail-value" onClick={this.props.onClick}>
+                {this.props.children}
+            </div>
+            );
+        } else {
+            detailValue = (
+            <div className="detail-value">
+                {this.props.children}
+            </div>
+            );
+        }
+
         return (
         <li className="clearfix">
             <div className="t-body-2 detail-label">
                 {this.props.label + " "}
             </div>
-            <div className="detail-value">
-                {this.props.children}
-            </div>
+            {detailValue}
         </li>
         );
     }

--- a/troposphere/static/js/components/projects/common/ResourceDetail.jsx
+++ b/troposphere/static/js/components/projects/common/ResourceDetail.jsx
@@ -10,18 +10,19 @@ export default React.createClass({
     },
 
     render: function() {
-        let detailValue;
+        let detailValue,
+            { children, label, onClick } = this.props;
 
-        if (this.props.onClick) {
+        if (onClick) {
             detailValue = (
-            <div className="detail-value" onClick={this.props.onClick}>
-                {this.props.children}
+            <div className="detail-value" onClick={onClick}>
+                {children}
             </div>
             );
         } else {
             detailValue = (
             <div className="detail-value">
-                {this.props.children}
+                {children}
             </div>
             );
         }
@@ -29,7 +30,7 @@ export default React.createClass({
         return (
         <li className="clearfix">
             <div className="t-body-2 detail-label">
-                {this.props.label + " "}
+                {label + " "}
             </div>
             {detailValue}
         </li>

--- a/troposphere/static/js/components/projects/resources/instance/details/sections/details/Alias.jsx
+++ b/troposphere/static/js/components/projects/resources/instance/details/sections/details/Alias.jsx
@@ -2,6 +2,9 @@ import React from "react";
 import Backbone from "backbone";
 import ResourceDetail from "components/projects/common/ResourceDetail";
 
+import { copyElement } from "utilities/clipboardFunctions";
+
+
 export default React.createClass({
     displayName: "Alias",
 
@@ -9,9 +12,14 @@ export default React.createClass({
         instance: React.PropTypes.instanceOf(Backbone.Model).isRequired
     },
 
-    render: function() {
+    onClick(e) {
+        e.preventDefault();
+        copyElement(e.target);
+    },
+
+    render() {
         return (
-        <ResourceDetail label="Alias">
+        <ResourceDetail label="Alias" onClick={this.onClick}>
             {this.props.instance.get("uuid")}
         </ResourceDetail>
         );

--- a/troposphere/static/js/components/projects/resources/instance/details/sections/details/Alias.jsx
+++ b/troposphere/static/js/components/projects/resources/instance/details/sections/details/Alias.jsx
@@ -14,7 +14,7 @@ export default React.createClass({
 
     onClick(e) {
         e.preventDefault();
-        copyElement(e.target);
+        copyElement(e.target, { acknowledge: true });
     },
 
     render() {

--- a/troposphere/static/js/components/projects/resources/instance/details/sections/details/IpAddress.jsx
+++ b/troposphere/static/js/components/projects/resources/instance/details/sections/details/IpAddress.jsx
@@ -14,7 +14,7 @@ export default React.createClass({
 
     onClick(e) {
         e.preventDefault();
-        copyElement(e.target);
+        copyElement(e.target, { acknowledge: true });
     },
 
     render() {

--- a/troposphere/static/js/components/projects/resources/instance/details/sections/details/IpAddress.jsx
+++ b/troposphere/static/js/components/projects/resources/instance/details/sections/details/IpAddress.jsx
@@ -2,6 +2,9 @@ import React from "react";
 import Backbone from "backbone";
 import ResourceDetail from "components/projects/common/ResourceDetail";
 
+import { copyElement } from "utilities/clipboardFunctions";
+
+
 export default React.createClass({
     displayName: "IpAddress",
 
@@ -9,18 +12,21 @@ export default React.createClass({
         instance: React.PropTypes.instanceOf(Backbone.Model).isRequired
     },
 
-    render: function() {
+    onClick(e) {
+        e.preventDefault();
+        copyElement(e.target);
+    },
 
-        var instance = this.props.instance;
-
-        var address = instance.get("ip_address");
+    render() {
+        var instance = this.props.instance,
+            address = instance.get("ip_address");
 
         if (!address || address.charAt(0) == "0") {
             address = "N/A";
         }
 
         return (
-        <ResourceDetail label="IP Address">
+        <ResourceDetail label="IP Address" onClick={this.onClick}>
             {address}
         </ResourceDetail>
         );

--- a/troposphere/static/js/components/projects/resources/volume/details/sections/VolumeDetailsSection.jsx
+++ b/troposphere/static/js/components/projects/resources/volume/details/sections/VolumeDetailsSection.jsx
@@ -18,7 +18,7 @@ export default React.createClass({
 
     onClick(e) {
         e.preventDefault();
-        copyElement(e.target);
+        copyElement(e.target, { acknowledge: true });
     },
 
     render() {

--- a/troposphere/static/js/components/projects/resources/volume/details/sections/VolumeDetailsSection.jsx
+++ b/troposphere/static/js/components/projects/resources/volume/details/sections/VolumeDetailsSection.jsx
@@ -6,6 +6,9 @@ import Status from "./details/Status";
 import Size from "./details/Size";
 import Identity from "./details/Identity";
 
+import { copyElement } from "utilities/clipboardFunctions";
+
+
 export default React.createClass({
     displayName: "VolumeDetailsSection",
 
@@ -13,8 +16,13 @@ export default React.createClass({
         volume: React.PropTypes.instanceOf(Backbone.Model).isRequired
     },
 
-    render: function() {
-        var volume = this.props.volume;
+    onClick(e) {
+        e.preventDefault();
+        copyElement(e.target);
+    },
+
+    render() {
+        let volume = this.props.volume;
 
         return (
         <div className="resource-details-section section">
@@ -24,7 +32,7 @@ export default React.createClass({
                 <Size volume={volume} />
                 <Identity volume={volume} />
                 <Id volume={volume} />
-                <ResourceDetail label="Identifier">
+                <ResourceDetail label="Identifier" onClick={this.onClick}>
                     {volume.get("uuid")}
                 </ResourceDetail>
             </ul>

--- a/troposphere/static/js/utilities/clipboardFunctions.js
+++ b/troposphere/static/js/utilities/clipboardFunctions.js
@@ -33,7 +33,8 @@ const copyElement = (element) => {
             // by the "addRange" call below
             selection.removeAllRanges();
 
-            // done for "none" text area or text field elements
+            // done for "non"-textarea or textfield elements
+            // - text DOM elements will have a `select()` method
             range.selectNode(element);
             selection.addRange(range);
 

--- a/troposphere/static/js/utilities/clipboardFunctions.js
+++ b/troposphere/static/js/utilities/clipboardFunctions.js
@@ -1,5 +1,32 @@
+import toastr from "toastr";
 
 // TODO import Raven and log messages
+
+/**
+ *
+ */
+function acknowledge(msg, title) {
+    let toastrDefaults = {
+        "closeButton": false,
+        "debug": false,
+        "newestOnTop": false,
+        "progressBar": false,
+        "positionClass": "toast-bottom-right",
+        "preventDuplicates": false,
+        "onclick": null,
+        "showDuration": "260",
+        "hideDuration": "1000",
+        "timeOut": "1125",
+        "extendedTimeOut": "650",
+        "showEasing": "swing",
+        "hideEasing": "linear",
+        "showMethod": "fadeIn",
+        "hideMethod": "fadeOut"
+    };
+
+    toastr.info(msg, title, toastrDefaults);
+}
+
 
 
 const hasClipboardAPI = () => {
@@ -21,7 +48,7 @@ const hasClipboardAPI = () => {
  *
  * @param element - DOM node to copy
  */
-const copyElement = (element) => {
+const copyElement = (element, options) => {
     let copied = false;
     if (hasClipboardAPI()) {
         let range = document.createRange(),
@@ -42,7 +69,12 @@ const copyElement = (element) => {
             // an error to catch - we could slim it down
             // to just this call
             copied = document.execCommand('copy');
-
+            if (copied && options) {
+                if (options.acknowledge) {
+                    acknowledge("Text has been copied to the clipboard",
+                                "Copied ... ");
+                }
+            }
             // clean up selections ...
             selection.removeAllRanges();
         } catch (e) {


### PR DESCRIPTION
This uses the W3C Clipboard API functions added in #514 for _select_ resource details: 
- Instances (IP Address, Alias)
- Volumes (Identifier)
