### PR TITLE
Fix User Menu on Mobile View

### DIFF
--- a/troposphere/static/css/app/app.scss
+++ b/troposphere/static/css/app/app.scss
@@ -22,7 +22,11 @@ $icon-font-path: "~bootstrap-sass/assets/fonts/bootstrap/";
 // toastr, for showing toast notifications
 @import "~toastr/toastr";
 
-// Bootstrap hack to keep Modal footer at bottom on min-height modals
+//
+// Bootstrap hacks
+//
+
+// Keep Modal footer at bottom on min-height modals
 #modal {
   .modal-footer {
     position: absolute;
@@ -35,6 +39,24 @@ $icon-font-path: "~bootstrap-sass/assets/fonts/bootstrap/";
     min-height: 500px;
   }
 }
+
+// This is not ideal, trying to find a better solution.
+// The problem is that bootstrap thinks we want a max-height 
+// and that 340px is the magic value.
+
+.navbar-fixed-top .navbar-collapse {
+    max-height: 900px !important;
+}
+
+@media (max-width: 767px) {
+    .navbar-default .navbar-nav .open .dropdown-menu > li > a {
+        color: #c3e9f3;
+        &:hover {
+            color: white
+        }
+    }
+}
+
 //
 // Application specific styles
 // ---------------------------


### PR DESCRIPTION
This PR overrides some bootstrap styling that caused problems with our User Menu on mobile views.

Normally I would not want to handle it this way but it is a highly specific selector that I doubt will cause trouble for anything else and the alternative is to implement a different User Menu that doesn't use the bootstrap classes. 

[ATMO-1608](https://pods.iplantcollaborative.org/jira/browse/ATMO-1608) suggested that the menu be opened by default. This PR fixes the main problem of the link text being the wrong color and the options being hidden unless you scroll. 

IMO, defaulting to open should only be done if we think there is an issue with users not finding the links under the User Menu. There is a cognitive cost to adding five more menu items to the initial navigation view.  If we do discover that users can't find those items then I'd like to seek out a better solution all around.

## Before
![mobile_logout_missing_from_dropdown](https://cloud.githubusercontent.com/assets/7366338/22040948/24731062-dcc2-11e6-9bb6-3ec77e5dca0d.gif)

## After
![menu](https://cloud.githubusercontent.com/assets/7366338/22040575/856fb156-dcc0-11e6-9c6b-a20d017c76aa.gif)
