### PR TITLE
Cherry-pick of django-cyverse-auth

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,4 @@ uWSGI==2.0.13
 newrelic==2.64.0.48
 
 # Ours
-django-iplant-auth==0.1.21
+django-cyverse-auth==1.0.1

--- a/troposphere/settings/default.py
+++ b/troposphere/settings/default.py
@@ -33,7 +33,7 @@ INSTALLED_APPS = (
     'rest_framework',
     'rest_framework.authtoken',
     'webpack_loader', # resolved JS asset + hash for template rendering
-    'iplantauth',
+    'django_cyverse_auth',
     'api',
     'troposphere',
 )
@@ -162,7 +162,7 @@ REST_FRAMEWORK = {
     # ),
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework.authentication.SessionAuthentication',
-        'iplantauth.authBackends.OAuthTokenLoginBackend'
+        'django_cyverse_auth.authBackends.OAuthTokenLoginBackend'
     ),
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
     'PAGE_SIZE': 100,
@@ -178,7 +178,7 @@ REST_FRAMEWORK = {
 
 AUTHENTICATION_BACKENDS = (
     'django.contrib.auth.backends.ModelBackend',
-    'iplantauth.authBackends.OAuthLoginBackend'
+    'django_cyverse_auth.authBackends.OAuthLoginBackend'
 )
 
 # This Method will generate SECRET_KEY and write it to file..

--- a/troposphere/settings/local.py.j2
+++ b/troposphere/settings/local.py.j2
@@ -120,14 +120,14 @@ AUTHENTICATION_BACKENDS = (
     # MOCK - If enabled, Use MockLoginBackend first for single-user access.
     # Helpful for debug/development. Be sure to set Atmosphere to MockLoginBackend.
     {% if AUTH_ENABLE_MOCK -%}
-    'iplantauth.authBackends.MockLoginBackend',
+    'django_cyverse_auth.authBackends.MockLoginBackend',
     {% else -%}
-    # 'iplantauth.authBackends.MockLoginBackend',
+    # 'django_cyverse_auth.authBackends.MockLoginBackend',
     {% endif -%}
     #
     # AuthToken - Allows staff emulation via API
     # by using existing tokens as simple authentication.
-    'iplantauth.authBackends.AuthTokenLoginBackend',
+    'django_cyverse_auth.authBackends.AuthTokenLoginBackend',
     #
     # ModelBackend - Allow traditional username/password. Helpful when using areas
     # of the application that do not work with SSO backends (Globus, OAuth)
@@ -142,10 +142,10 @@ AUTHENTICATION_BACKENDS = (
     # and then authorize a user, (Usually, based on OAuth or some other token exchange)
     {% if AUTH_ENABLE_GLOBUS -%}
     # Globus OAuth
-    'iplantauth.authBackends.GlobusOAuthLoginBackend',
+    'django_cyverse_auth.authBackends.GlobusOAuthLoginBackend',
     {% elif AUTH_ENABLE_CAS or AUTH_ENABLE_OAUTH -%}
     # CAS OAuth implementation of SSO
-    'iplantauth.authBackends.OAuthLoginBackend',
+    'django_cyverse_auth.authBackends.OAuthLoginBackend',
     {% elif AUTH_ENABLE_MOCK -%}
     # Hello developer, you have
     # SSO Disabled but are using Mock configuration.
@@ -158,7 +158,7 @@ AUTHENTICATION_BACKENDS = (
     {% if AUTH_ENABLE_LDAP -%}
     #
     # LDAP - Allow access via LDAP username/password
-    'iplantauth.authBackends.LDAPLoginBackend',
+    'django_cyverse_auth.authBackends.LDAPLoginBackend',
     {% endif -%}
     )
 {% endif -%}
@@ -211,14 +211,14 @@ INSTALLED_APPS += (
 ALWAYS_AUTH_USER = "{{ MOCK_USER }}"
 # Use MockLoginBackend first!
 AUTHENTICATION_BACKENDS += (
-    'iplantauth.authBackends.MockLoginBackend',
+    'django_cyverse_auth.authBackends.MockLoginBackend',
 )
 {% else %}
 # MOCK - Uncomment these lines to allow one-user-only access. Useful for debug/development
 # ALWAYS_AUTH_USER = "test_user"
 # # Use MockLoginBackend first!
 # AUTHENTICATION_BACKENDS += (
-#     'iplantauth.authBackends.MockLoginBackend',
+#     'django_cyverse_auth.authBackends.MockLoginBackend',
 # )
 # Configure authentication plugin
 {% endif %}

--- a/troposphere/urls.py
+++ b/troposphere/urls.py
@@ -11,7 +11,7 @@ ui_urlpatterns = [
     url(r'^tropo-admin/', include(admin.site.urls)),
     url(r'^$', views.root),
     # Authentication endpoints
-    url(r'', include("iplantauth.urls", namespace="iplantauth")),
+    url(r'', include("django_cyverse_auth.urls", namespace="django_cyverse_auth")),
 
     url(r'^application_backdoor', views.application_backdoor,
         name='application'),

--- a/troposphere/views/app.py
+++ b/troposphere/views/app.py
@@ -178,7 +178,7 @@ def _handle_public_application_request(request, maintenance_records, disabled_lo
 def _handle_authenticated_application_request(request, maintenance_records,
         notice_info):
     """
-    Deals with request verified identities via `iplantauth` module.
+    Deals with request verified identities via `django_cyverse_auth` module.
     """
     if notice_info and notice_info[1]:
         notice_info = (notice_info[0], notice_info[1],

--- a/troposphere/views/auth.py
+++ b/troposphere/views/auth.py
@@ -10,8 +10,8 @@ from caslib import OAuthClient as CAS_OAuthClient
 from django.contrib.auth.models import User
 from django.contrib.auth import authenticate, login as auth_login
 
-from iplantauth.authBackends import get_or_create_user, generate_token
-from iplantauth.views import globus_login_redirect, globus_logout_redirect
+from django_cyverse_auth.authBackends import get_or_create_user, generate_token
+from django_cyverse_auth.views import globus_login_redirect, globus_logout_redirect
 
 logger = logging.getLogger(__name__)
 cas_oauth_client = CAS_OAuthClient(settings.CAS_SERVER,
@@ -65,11 +65,11 @@ def login(request):
     # pro-active session cleaning
     request.session.clear_expired()
 
-    if "iplantauth.authBackends.MockLoginBackend" in all_backends:
+    if "django_cyverse_auth.authBackends.MockLoginBackend" in all_backends:
         return _mock_login(request)
-    elif 'iplantauth.authBackends.GlobusOAuthLoginBackend' in all_backends:
+    elif 'django_cyverse_auth.authBackends.GlobusOAuthLoginBackend' in all_backends:
         return _globus_login(request)
-    elif 'iplantauth.authBackends.OAuthLoginBackend' in all_backends:
+    elif 'django_cyverse_auth.authBackends.OAuthLoginBackend' in all_backends:
         return _oauth_login(request)
     elif request.META['REQUEST_METHOD'] is 'POST':
         return _post_login(request)
@@ -93,16 +93,16 @@ def logout(request):
     #Look for 'cas' to be passed on logout.
     request_data = request.GET
     if request_data.get('force', False):
-        if 'iplantauth.authBackends.CASLoginBackend' in all_backends\
-        or 'iplantauth.authBackends.OAuthLoginBackend' in all_backends:
+        if 'django_cyverse_auth.authBackends.CASLoginBackend' in all_backends\
+        or 'django_cyverse_auth.authBackends.OAuthLoginBackend' in all_backends:
             redirect_to = request_data.get("service")
             if not redirect_to:
                 redirect_to = settings.SERVER_URL + reverse('application')
             logout_url = cas_oauth_client.logout(redirect_to)
             logger.info("[CAS] Redirect user to: %s" % logout_url)
             return redirect(logout_url)
-        elif 'iplantauth.authBackends.GlobusLoginBackend' in all_backends\
-          or 'iplantauth.authBackends.GlobusOAuthLoginBackend' in all_backends:
+        elif 'django_cyverse_auth.authBackends.GlobusLoginBackend' in all_backends\
+          or 'django_cyverse_auth.authBackends.GlobusOAuthLoginBackend' in all_backends:
             logger.info("[Globus] Redirect user to logout")
             return globus_logout_redirect(request)
     return redirect('application')

--- a/troposphere/views/emulation.py
+++ b/troposphere/views/emulation.py
@@ -26,7 +26,7 @@ def is_emulated_session(request):
 
 def emulate(request, username):
     if 'access_token' not in request.session:
-        if 'iplantauth.authBackends.OAuthLoginBackend' in settings.AUTHENTICATION_BACKENDS:
+        if 'django_cyverse_auth.authBackends.OAuthLoginBackend' in settings.AUTHENTICATION_BACKENDS:
             return redirect(cas_oauth_client.authorize_url())
         return redirect('/application')
 


### PR DESCRIPTION
This PR will bring django-cyverse-auth into the `voracious-velociraptor` release. The latest version that can be selected without code changes related to renaming in the library is 1.0.3