### PR TITLE
Use date extension file naming for logrotate for easy archiving.

### DIFF
--- a/extras/logrotate.troposphere
+++ b/extras/logrotate.troposphere
@@ -1,10 +1,10 @@
-/opt/dev/troposphere/logs/troposphere.log {
-    su www-data www-data
-    daily
-    rotate 10
-    missingok
-    compress
-    delaycompress
-    notifempty
-    copytruncate
-}
+su www-data www-data
+daily
+rotate 10
+missingok
+compress
+delaycompress
+notifempty
+copytruncate
+dateext
+/opt/dev/troposphere/logs/troposphere.log {}


### PR DESCRIPTION
## Description

### Problem

Current logrotate file naming convention is not conducive to archiving.

### Solution

Add a date to the end of the rotated files. (`dateext` option)

refs [#ATMO-1682](https://pods.iplantcollaborative.org/jira/browse/ATMO-1682)

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature
- [ ] Reviewed and approved by at least one other contributor.
