### PR TITLE
Problem: Inconsistency with using end-dated flags (only being used on Image)

### DIFF
--- a/troposphere/static/js/components/images/detail/availability/AvailabilityView.jsx
+++ b/troposphere/static/js/components/images/detail/availability/AvailabilityView.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import Backbone from "backbone";
 import stores from "stores";
 import Code from "components/common/ui/Code";
+import moment from "moment";
 
 import { copyElement } from "utilities/clipboardFunctions";
 
@@ -51,7 +52,35 @@ export default React.createClass({
 
     render() {
         let { version } = this.props;
+        let endDate = version.get('end_date'),
+            isEndDated = endDate && endDate.isValid();
+        // No availability if the version *OR* parent-image are end-dated.
+        if(!isEndDated) {
+            let image = version.get('image'),
+                end_date = moment(image.end_date);
+            isEndDated = end_date && end_date.isValid();
+        }
 
+        if(isEndDated) {
+            return this.renderEndDated();
+        } else {
+            return this.renderProviders();
+        }
+    },
+    renderEndDated() {
+        return (
+            <div>
+                <h4
+                    className="t-body-2"
+                    style={{ marginBottom: "5px" }}
+                >
+                    Not Available
+                </h4>
+            </div>
+        );
+    },
+    renderProviders() {
+        let { version } = this.props;
         // Get providers this version is available on
         let machines = stores.ProviderMachineStore
             .getMachinesForVersion(version);

--- a/troposphere/static/js/components/images/detail/versions/Version.jsx
+++ b/troposphere/static/js/components/images/detail/versions/Version.jsx
@@ -140,6 +140,7 @@ export default React.createClass({
 
         return (
         <div style={ styles.content }>
+            { this.renderEndDated() }
             { this.renderChangeLog() }
             <div style={ styles.availability }>
                 { providerAvailability }
@@ -166,12 +167,41 @@ export default React.createClass({
 
         return (
         <div style={ styles.content }>
+            { this.renderEndDated() }
             { this.renderChangeLog() }
             <div style={ styles.availability } >
                 { providerAvailability }
             </div>
         </div>
         );
+    },
+
+    renderEndDated() {
+        let endDate = this.props.version.get('end_date');
+        let isEndDated = endDate && endDate.isValid();
+        if(!isEndDated) {
+            let image = this.props.version.get('image'),
+                end_date = moment(image.end_date);
+            isEndDated = end_date && end_date.isValid();
+        }
+        let style = {
+            position: "absolute",
+            top: "3px",
+            left: "0",
+            background: "#F55A5A",
+            display: "inline-block",
+            padding: "3px 5px",
+            color: "white",
+            fontSize: "10px",
+        };
+
+        if (isEndDated) {
+            return (
+                <div style={ style }>
+                    End Dated
+                </div>
+            );
+        }
     },
 
     render() {


### PR DESCRIPTION
## Description
Solution: Show 'End-dated' and 'No Availability' when version/image has been end-dated

## Checklist before merging Pull Requests
- [x] Reviewed and approved by at least one other contributor.
- [x] Create a gif-video to demonstrate the changes made in the PR.
- [x] Manually test and confirm functionality

![Visual Review](https://cloud.githubusercontent.com/assets/2889930/22750575/9030a890-edee-11e6-8246-8de88c763d07.gif)
