### PR TITLE
Problem: Image Details lack end-dated indicator; allows end-dated "launch"

### DIFF
--- a/troposphere/static/js/components/common/Ribbon.jsx
+++ b/troposphere/static/js/components/common/Ribbon.jsx
@@ -1,0 +1,44 @@
+import _ from "underscore";
+
+import React from "react";
+
+
+/**
+ * Provides a "ribbon" effect over an icon
+ *
+ * @param text - what to string to place in the ribbon
+ * @param styleOverride - overrides to default inline style
+ *
+ * Expectation:
+ * this component will be a child of a container with
+ * `position: "relative"`. If not, the absolute positioning
+ * will cause this to be laid out, by default, in the upper
+ * left corner of the viewport.
+ */
+export default React.createClass({
+    propTypes: {
+        text: React.PropTypes.string.isRequired,
+        styleOverride: React.PropTypes.object
+    },
+
+    render() {
+        let override = this.props.styleOverride || {},
+            style = {
+                position: "absolute",
+                top: "3px",
+                left: "0",
+                background: "#F55A5A",
+                display: "inline-block",
+                padding: "3px 5px",
+                color: "white",
+                fontSize: "10px",
+            },
+            merged = _.extend(style, override);
+
+        return (
+            <div style={ merged }>
+                {this.props.text}
+            </div>
+        );
+    }
+});

--- a/troposphere/static/js/components/images/detail/ViewImageDetails.jsx
+++ b/troposphere/static/js/components/images/detail/ViewImageDetails.jsx
@@ -1,12 +1,16 @@
 import React from "react";
 import Backbone from "backbone";
+
 import TagsView from "./tags/TagsView";
 import CreatedView from "./created/CreatedView";
 import RemovedView from "./removed/RemovedView";
 import AuthorView from "./author/AuthorView";
 import DescriptionView from "./description/DescriptionView";
-import stores from "stores";
 import Gravatar from "components/common/Gravatar";
+import Ribbon from "components/common/Ribbon";
+
+import stores from "stores";
+
 
 export default React.createClass({
     displayName: "ViewImageDetails",
@@ -39,11 +43,31 @@ export default React.createClass({
         }
     },
 
+    renderEndDated: function() {
+        let { image } = this.props;
+
+        if (image.isEndDated()) {
+            let ribbon = {
+                top: "-6px",
+                left: "-9px",
+                padding: "3px 7px",
+                fontSize: "11px",
+            };
+
+            return (
+            <Ribbon text={"End Dated"}
+                    styleOverride={ ribbon }/>
+            );
+        }
+    },
+
     render: function() {
-        let { image, tags } = this.props;
-        let type = stores.ProfileStore.get().get("icon_set");
+        let { image, tags } = this.props,
+            type = stores.ProfileStore.get().get("icon_set");
+
         let style = {
             wrapper: {
+                position: "relative",
                 display: "flex",
                 alignItems: "flex-start",
                 marginBottom: "80px",
@@ -63,10 +87,10 @@ export default React.createClass({
         return (
             <div style={ style.wrapper }>
                 <div style={ style.img }>
-                    <Gravatar 
-                        hash={image.get("uuid_hash")} 
-                        size={ 50 } type={type} 
-                    />
+                    <Gravatar
+                        hash={ image.get("uuid_hash") }
+                        size={ 50 } type={ type }/>
+                    { this.renderEndDated() }
                 </div>
                 <div>
                     <div style={ style.details }>
@@ -76,7 +100,7 @@ export default React.createClass({
                         <DescriptionView image={ image } />
                         <TagsView image={ image } tags={ tags } />
                     </div>
-                    {this.renderEditLink()}
+                    { this.renderEditLink() }
                 </div>
             </div>
         );

--- a/troposphere/static/js/components/images/detail/header/HeaderView.jsx
+++ b/troposphere/static/js/components/images/detail/header/HeaderView.jsx
@@ -15,6 +15,7 @@ export default React.createClass({
     },
 
     componentDidMount: function() {
+        // FIXME: use the Tooltip component
         var el = ReactDOM.findDOMNode(this);
         var $el = $(el).find(".tooltip-wrapper");
         $el.tooltip({
@@ -32,7 +33,7 @@ export default React.createClass({
     },
 
     showAddProjectModal: function(e) {
-        e.preventDefault(); // Do i need this?
+        e.preventDefault();
         modals.ProjectModals.addImage(this.props.image);
     },
 
@@ -42,27 +43,29 @@ export default React.createClass({
     },
 
     render: function() {
-        let profile = stores.ProfileStore.get();
-        let buttonGroup;
+        let profile = stores.ProfileStore.get(),
+            { image } = this.props,
+            buttonGroup;
 
         if (profile.id) {
             buttonGroup = (
                 <div>
                     <span style={{ marginRight: "20px" }}>
-                        <Bookmark width="25px" image={ this.props.image }/>
+                        <Bookmark width="25px" image={ image }/>
                     </span>
                     <span
                         className="tooltip-wrapper"
-                        style={{ marginRight: "20px" }}
-                    >
-                        <button className="btn btn-default" onClick={this.showAddProjectModal}>
+                        style={{ marginRight: "20px" }}>
+                        <button className="btn btn-default"
+                                disabled={ image.isEndDated() }
+                                onClick={ this.showAddProjectModal }>
                             <i className="glyphicon glyphicon-plus"></i> Add to Project
                         </button>
                     </span>
                     <button
                         className="btn btn-primary launch-button"
-                        onClick={ this.showLaunchModal }
-                    >
+                        disabled={ image.isEndDated() }
+                        onClick={ this.showLaunchModal }>
                         Launch
                     </button>
                 </div>
@@ -72,23 +75,21 @@ export default React.createClass({
         return (
             <div
                 style={ this.style().header }
-                className="image-header"
-            >
+                className="image-header">
                 <div style={ this.style().titleGroup }>
                     <svg
                         style={ this.style().backButton }
-                        onClick={this.onReturnToPreviousPage}
+                        onClick={ this.onReturnToPreviousPage }
                         fill="#000000"
                         height="24"
                         viewBox="0 0 24 24"
                         width="24"
-                        xmlns="http://www.w3.org/2000/svg"
-                    >
+                        xmlns="http://www.w3.org/2000/svg">
                         <path d="M0 0h24v24H0z" fill="none"/>
                         <path d="M21 11H6.83l3.58-3.59L9 6l-6 6 6 6 1.41-1.41L6.83 13H21z"/>
                     </svg>
                     <h1 className="t-headline">
-                        {this.props.image.get("name")}
+                        {image.get("name")}
                     </h1>
                 </div>
                 { buttonGroup }

--- a/troposphere/static/js/components/images/detail/header/HeaderView.jsx
+++ b/troposphere/static/js/components/images/detail/header/HeaderView.jsx
@@ -18,7 +18,7 @@ export default React.createClass({
         var el = ReactDOM.findDOMNode(this);
         var $el = $(el).find(".tooltip-wrapper");
         $el.tooltip({
-            title: "NEW! You can now add an Image to your project to make launching instances even easier!",
+            title: "You can add an Image to a project to make launching instances easier!",
             placement: "left"
         });
     },

--- a/troposphere/static/js/components/images/detail/versions/Version.jsx
+++ b/troposphere/static/js/components/images/detail/versions/Version.jsx
@@ -1,14 +1,18 @@
 import React from "react";
 import Backbone from "backbone";
+import CryptoJS from "crypto-js";
+
 import Gravatar from "components/common/Gravatar";
+import Ribbon from "components/common/Ribbon";
 import MediaCard from "components/common/ui/MediaCard";
 import AvailabilityView from "../availability/AvailabilityView";
-import CryptoJS from "crypto-js";
+
 import stores from "stores";
 import context from "context";
 import globals from "globals";
 import moment from "moment";
 import showdown from "showdown";
+
 
 export default React.createClass({
     displayName: "Version",
@@ -177,29 +181,11 @@ export default React.createClass({
     },
 
     renderEndDated() {
-        let endDate = this.props.version.get('end_date');
-        let isEndDated = endDate && endDate.isValid();
-        if(!isEndDated) {
-            let image = this.props.version.get('image'),
-                end_date = moment(image.end_date);
-            isEndDated = end_date && end_date.isValid();
-        }
-        let style = {
-            position: "absolute",
-            top: "3px",
-            left: "0",
-            background: "#F55A5A",
-            display: "inline-block",
-            padding: "3px 5px",
-            color: "white",
-            fontSize: "10px",
-        };
+        let { version } = this.props;
 
-        if (isEndDated) {
+        if (version.isEndDated()) {
             return (
-                <div style={ style }>
-                    End Dated
-                </div>
+                <Ribbon text={"End Dated"} />
             );
         }
     },

--- a/troposphere/static/js/components/images/detail/versions/VersionsView.jsx
+++ b/troposphere/static/js/components/images/detail/versions/VersionsView.jsx
@@ -1,8 +1,10 @@
 import React from "react";
 import Backbone from "backbone";
+
+import VersionList from "./VersionList";
+
 import context from "context";
 import stores from "stores";
-import VersionList from "./VersionList";
 
 
 export default React.createClass({
@@ -11,22 +13,27 @@ export default React.createClass({
     propTypes: {
         image: React.PropTypes.instanceOf(Backbone.Model).isRequired
     },
+
     render: function() {
-        var image = this.props.image,
+        let image = this.props.image,
             versions = stores.ImageStore.getVersions(image.id),
-            showAvailableOn = context.hasLoggedInUser();
+            showAvailableOn = context.hasLoggedInUser(),
+            versionElements = null;
 
         if (!versions) {
             return (<div className="loading" />);
         }
-        return (
-        <div className="image-versions image-info-segment row">
-            <h4 className="t-title">Versions</h4>
-            <VersionList image={image}
-                versions={versions}
-                editable={true}
-                showAvailability={showAvailableOn} />
-        </div>
-        );
+
+        if (versions.length > 0) {
+            versionElements = (
+            <div className="image-versions image-info-segment row">
+                <h4 className="t-title">Versions</h4>
+                <VersionList image={image}
+                             versions={versions}
+                             editable={true}
+                             showAvailability={showAvailableOn} />
+            </div>);
+        }
+        return (versionElements);
     }
 });

--- a/troposphere/static/js/components/images/list/common/ImageListCard.jsx
+++ b/troposphere/static/js/components/images/list/common/ImageListCard.jsx
@@ -13,6 +13,9 @@ import moment from "moment";
 import stores from "stores";
 
 
+import Ribbon from "components/common/Ribbon";
+
+
 export default React.createClass({
     displayName: "ImageListCard",
 
@@ -30,22 +33,9 @@ export default React.createClass({
     },
 
     renderEndDated() {
-        let style = {
-            position: "absolute",
-            top: "3px",
-            left: "0",
-            background: "#F55A5A",
-            display: "inline-block",
-            padding: "3px 5px",
-            color: "white",
-            fontSize: "10px",
-        };
-
         if (this.props.isEndDated) {
             return (
-                <div style={ style }>
-                    End Dated
-                </div>
+                <Ribbon text={ "End Dated" }/>
             );
         }
     },

--- a/troposphere/static/js/models/Image.js
+++ b/troposphere/static/js/models/Image.js
@@ -25,4 +25,8 @@ export default Backbone.Model.extend({
         delete attributes["isFavorited"];
         return attributes;
     },
+
+    isEndDated: function() {
+        return this.get("end_date") && this.get("end_date").isValid()
+    }
 });

--- a/troposphere/static/js/models/ImageVersion.js
+++ b/troposphere/static/js/models/ImageVersion.js
@@ -13,4 +13,16 @@ export default Backbone.Model.extend({
 
         return attributes;
     },
+
+    isEndDated: function() {
+        let endDate = this.get("end_date"),
+            image = this.get("image"),
+            result = endDate && endDate.isValid();
+        if (!result) {
+            endDate = moment(image.end_date);
+            result = endDate && endDate.isValid();
+        }
+
+        return result;
+    }
 });


### PR DESCRIPTION
## Description

This builds on the work of #542. 

An end-dated Image will appear with consistent "indicator". 

A `<Ribbon />` component is introduced to _generalize_ the use of "flagging" icons with indicator text (like, "End Dated"). And, this moves the approach for determining if an Image is _"end-dated"_ into the models for `Image` and `ImageVersion`. 

We also use `<Ribbon />` in all three scenarios (Image Detail, Versions within Image Detail, and Image Media Cards). 
Please describe your pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. When linking to an issue, please use `refs #...` in the description of the pull request.

See [ATMO-1698](https://pods.iplantcollaborative.org/jira/browse/ATMO-1698) & [ATMO-1699](https://pods.iplantcollaborative.org/jira/browse/ATMO-1699)

## Checklist before merging Pull Requests
- [x]  Reviewed and approved by at least one other contributor.
- [x] Create a gif-video to demonstrate the changes made in the PR.

<Details>

## Animation Interactions
![ikubfrhh4d](https://cloud.githubusercontent.com/assets/5923/22801606/c0638e60-eeca-11e6-8ea5-14bad2ad7d4d.gif)

## Resolution of ATMO-1698
When an image is end-date, the buttons will appear as _disabled_:
<img width="781" alt="atmo-1698-disabled-buttons-detail" src="https://cloud.githubusercontent.com/assets/5923/22801658/fcaa2064-eeca-11e6-884f-0dd324e22837.png">
The buttons remain in the header to help reinforce their location and purpose:
<img width="938" alt="atmo-1698-disabled-buttons" src="https://cloud.githubusercontent.com/assets/5923/22801660/fcafc55a-eeca-11e6-8bf7-793c659c24b3.png">


## Resolution of ATMO-1699
<img width="866" alt="atmo-1699-resolution" src="https://cloud.githubusercontent.com/assets/5923/22801659/fcabadb2-eeca-11e6-83cb-371ef3b90e6d.png">

</Details>