### PR TITLE
Problem: newly added images do not appear within projects

### DIFF
--- a/troposphere/static/js/components/images/detail/header/HeaderView.jsx
+++ b/troposphere/static/js/components/images/detail/header/HeaderView.jsx
@@ -18,7 +18,7 @@ export default React.createClass({
         var el = ReactDOM.findDOMNode(this);
         var $el = $(el).find(".tooltip-wrapper");
         $el.tooltip({
-            title: "NEW! You can now add an Image to your project to make launching instances even easier!",
+            title: "You can add an Image to a project to make launching instances easier!",
             placement: "left"
         });
     },

--- a/troposphere/static/js/components/projects/common/SecondaryProjectNavigation.jsx
+++ b/troposphere/static/js/components/projects/common/SecondaryProjectNavigation.jsx
@@ -18,7 +18,7 @@ export default React.createClass({
 
         var project = this.props.project,
             projectInstances = stores.ProjectInstanceStore.getInstancesFor(project),
-            projectImages = stores.ProjectImageStore.getImagesFor(project),
+            projectImages = stores.ProjectImageStore.getImagesCountFor(project),
             projectExternalLinks = stores.ProjectExternalLinkStore.getExternalLinksFor(project),
             projectVolumes = stores.ProjectVolumeStore.getVolumesFor(project);
 

--- a/troposphere/static/js/stores/ProjectImageStore.js
+++ b/troposphere/static/js/stores/ProjectImageStore.js
@@ -51,6 +51,15 @@ var ProjectImageStore = BaseStore.extend({
         }
     },
 
+    getImagesCountFor: function(project) {
+        if (!project.id) return 0;
+        if (!_modelsFor[project.id]) {
+            return this.fetchModelsFor(project.id);
+        }
+
+        return _modelsFor[project.id].length;
+    },
+
     getImagesFor: function(project) {
         var allImages = stores.ImageStore.getForProject(project.id);
         if (!project.id) return;

--- a/troposphere/static/js/stores/ProjectImageStore.js
+++ b/troposphere/static/js/stores/ProjectImageStore.js
@@ -64,7 +64,9 @@ var ProjectImageStore = BaseStore.extend({
         if (!project.id) return;
         if (!_modelsFor[project.id]) return this.fetchModelsFor(project.id);
 
-        let images = this.models.map( (pi) => {
+        let images = this.models.filter( (pi) => {
+            return pi.get("project").id === project.id;
+        }).map( (pi) => {
             return new Image(pi.get("image"), {parse: true});
         });
 

--- a/troposphere/static/js/stores/ProjectImageStore.js
+++ b/troposphere/static/js/stores/ProjectImageStore.js
@@ -61,21 +61,13 @@ var ProjectImageStore = BaseStore.extend({
     },
 
     getImagesFor: function(project) {
-        var allImages = stores.ImageStore.getForProject(project.id);
         if (!project.id) return;
         if (!_modelsFor[project.id]) return this.fetchModelsFor(project.id);
-        if (!allImages) return;
 
-        var images = this.models.filter(function(project_image) {
-            // filter out irrelevant project images (not in target project)
-            return project_image.get("project").id === project.id;
-        }).filter(function(project_image) {
-            // filter out the images that don't exist (not in local cache)
-            return allImages.get(project_image.get("image").id);
-        }).map(function(project_image) {
-            // return the actual images
-            return allImages.get(project_image.get("image").id);
+        let images = this.models.map( (pi) => {
+            return new Image(pi.get("image"), {parse: true});
         });
+
         return new ImageCollection(images);
     },
 


### PR DESCRIPTION
## Description

The previously version of this functionality used ImageStore as a why to "join" the results of "image(s) for a project, by project.id". This gave the result a collection of `models/Image`. 

But, we can use the `/api/v2/project_images?project__id=:id` to satisfy "image(s) for project, by project.id", and we can construct `models/Images`s and return the collection to the caller as expected. 

Part of the root-cause for this is that the ImageStore caches queries for images by queryString. But, when you `ADD_PROJECT_IMAGE`, the cache-by-queryString is not invalidated. 

**Note:** this leverages `{ parse: true }` in the model will be construction. This means the model is created the same way that it is when returned via a response from the model (or collection) url.

See [ATMO-1521](https://pods.iplantcollaborative.org/jira/browse/ATMO-1521)

## Checklist before merging Pull Requests
- [x] Record gif-video demonstrating the problem & the solution
- [x] Reviewed and approved by at least one other contributor.

<Details>

### Example Issue - not rendering

http://g.recordit.co/6w9of5ePgf.gif

### Solution - newly added imaged appear within project views

http://g.recordit.co/YcH6OI4tiY.gif

### Assertion - deleting an image from a project also works

http://recordit.co/6CXwjSzKEN

</Details>
