### PR TITLE
Fix logrotate permissions error

### DIFF
--- a/extras/logrotate.troposphere
+++ b/extras/logrotate.troposphere
@@ -1,10 +1,11 @@
-su www-data www-data
-daily
-rotate 10
-missingok
-compress
-delaycompress
-notifempty
-copytruncate
-dateext
-/opt/dev/troposphere/logs/troposphere.log {}
+/opt/dev/troposphere/logs/troposphere.log {
+    su www-data www-data
+    daily
+    rotate 10
+    missingok
+    compress
+    delaycompress
+    notifempty
+    copytruncate
+    dateext
+}


### PR DESCRIPTION
Problem: Getting error messages like this:

```
error: error opening /var/log/celery/atmosphere-deploy_7.log: Permission denied
```

Solution: Change the structure of the logrotate config files back to what they
were and just have the `dateext` line added.

## Description

Please describe your pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. When linking to an issue, please use `refs #...` in the description of the pull request.

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature
- [x] Reviewed and approved by at least one other contributor.
