### PR TITLE
ATMO-1710 Stop version card from expanding when edit is clicked

### DIFF
--- a/troposphere/static/js/components/images/detail/versions/Version.jsx
+++ b/troposphere/static/js/components/images/detail/versions/Version.jsx
@@ -46,7 +46,9 @@ export default React.createClass({
         });
     },
 
-    onEditClicked() {
+    onEditClicked(e) {
+        e.stopPropagation();
+        e.preventDefault();
         return this.props.onEditClicked(this.props.version);
     },
 
@@ -163,7 +165,8 @@ export default React.createClass({
             providerAvailability = (
                 <AvailabilityView
                     isSummary={ !isOpen }
-                    version={ version } />
+                    version={ version }
+                />
             );
         } else {
             providerAvailability = "Please login to view available providers.";


### PR DESCRIPTION
## Description
This fixes [ATMO-1710](https://pods.iplantcollaborative.org/jira/browse/ATMO-1710) where on version cards in the image detail, clicking on "edit" under version name wrongly opens the version detail. This is wrong because it could confuse users. 

To reproduce in V-V click "edit" below the version name and observe that the card expands.
Now on this branch do the same to verify that it doesn't expand but the edit modal is still triggered correctly. 

## Before
![before](https://cloud.githubusercontent.com/assets/7366338/23104847/99cd046e-f692-11e6-9180-3fb7cf2497d8.gif)
 
## After
![after](https://cloud.githubusercontent.com/assets/7366338/23104854/a765aae0-f692-11e6-98aa-907308674459.gif)

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature
- [x] Reviewed and approved by at least one other contributor.
