### PR TITLE
Use Copy to Clipboard Button Over Clicking Text

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "format": "esformatter -c .esformatter -i $(git ls-files troposphere/static/js*js)"
   },
   "dependencies": {
-    "troposphere-ui": "1.0.2",
     "babel-polyfill": "^6.16.0",
     "backbone": "^1.2.1",
     "bootstrap-sass": "^3.3.6",

--- a/troposphere/static/js/components/common/ui/CopyButton.jsx
+++ b/troposphere/static/js/components/common/ui/CopyButton.jsx
@@ -166,6 +166,7 @@ export default React.createClass({
         };
         
         const feedback = {
+            fontSize: "12px",
             position: "absolute",
         }
 

--- a/troposphere/static/js/components/common/ui/CopyButton.jsx
+++ b/troposphere/static/js/components/common/ui/CopyButton.jsx
@@ -165,7 +165,6 @@ export default React.createClass({
             marginLeft: "10px",
         };
         
-
         const feedback = {
             position: "absolute",
         }

--- a/troposphere/static/js/components/common/ui/CopyButton.jsx
+++ b/troposphere/static/js/components/common/ui/CopyButton.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import toastr from "toastr";
 import Raven from "raven-js";
 
 /**
@@ -13,7 +14,29 @@ import Raven from "raven-js";
  * where it is *not* available to assist in helping those community
  * members on a newer browerser
  */
+function alertFail(msg, title) {
+    let toastrDefaults = {
+        "closeButton": true,
+        "debug": false,
+        "newestOnTop": false,
+        "progressBar": false,
+        "positionClass": "toast-bottom-right",
+        "preventDuplicates": true,
+        "onclick": null,
+        "showDuration": "260",
+        "hideDuration": "1000",
+        "timeOut": "6000",
+        "extendedTimeOut": "650",
+        "showEasing": "swing",
+        "hideEasing": "linear",
+        "showMethod": "fadeIn",
+        "hideMethod": "fadeOut"
+    };
+
+    toastr.warning(msg, title, toastrDefaults);
+}
 function reportException(ex) {
+    alertFail("Sorry your browser doesn't support this feature", "Can't Copy");
     // take Mulder's advice - trustno1
     if (Raven && Raven.isSetup()) {
         if (Raven.captureException) {
@@ -82,7 +105,7 @@ function copyTextToClipboard(text) {
         var msg = successful ? 'successful' : 'unsuccessful';
         console.log('Copying text was ' + msg);
     } catch (err) {
-        reportException(e);
+        reportException(err);
         console.log('Unable to copy');
     };
 
@@ -113,7 +136,6 @@ export default React.createClass({
                         this.setState({
                             feedbackState: "WAIT"   
                         })
-                        debugger
                     } , 300)
                 })}, 300)
             }
@@ -140,16 +162,15 @@ export default React.createClass({
                 style={ style.button } 
                 onClick = { this.onClick }
             > 
-                <div style={{ 
+                <div 
+                    style={{ 
                         ...style.feedback,
                         ...feedbackStyle() 
                     }}
                 >
                     Copied!
                 </div>
-                <i 
-                    className="glyphicon glyphicon-copy"
-                />
+                Copy
             </div>
         )
     },
@@ -159,9 +180,9 @@ export default React.createClass({
         const button = {
             position: "relative",
             display: "inline-block",
-            fontSize: "16px",
+            fontSize: "11px",
             cursor: "pointer",
-            color: "grey",
+            color: "#0971ab",
             marginLeft: "10px",
         };
         
@@ -180,7 +201,7 @@ export default React.createClass({
         const feedbackShown = {
             opacity: "1",
             top: "-20px",
-            transition: "opacity .3s ease, top .1s ease",
+            transition: "opacity .2s ease, top .15s ease",
         };
 
         const feedbackOut = {

--- a/troposphere/static/js/components/common/ui/CopyButton.jsx
+++ b/troposphere/static/js/components/common/ui/CopyButton.jsx
@@ -135,6 +135,7 @@ export default React.createClass({
             }
         };
 
+        if (!document.execCommand('copy')) return;
         return (
             <div
                 style={ style.button } 

--- a/troposphere/static/js/components/common/ui/CopyButton.jsx
+++ b/troposphere/static/js/components/common/ui/CopyButton.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import toastr from "toastr";
+import { alertFail } from "utilities/toastrHelpers";
 import Raven from "raven-js";
 
 /**
@@ -14,27 +14,6 @@ import Raven from "raven-js";
  * where it is *not* available to assist in helping those community
  * members on a newer browerser
  */
-function alertFail(msg, title) {
-    let toastrDefaults = {
-        "closeButton": true,
-        "debug": false,
-        "newestOnTop": false,
-        "progressBar": false,
-        "positionClass": "toast-bottom-right",
-        "preventDuplicates": true,
-        "onclick": null,
-        "showDuration": "260",
-        "hideDuration": "1000",
-        "timeOut": "6000",
-        "extendedTimeOut": "650",
-        "showEasing": "swing",
-        "hideEasing": "linear",
-        "showMethod": "fadeIn",
-        "hideMethod": "fadeOut"
-    };
-
-    toastr.warning(msg, title, toastrDefaults);
-}
 function reportException(ex) {
     alertFail("Sorry your browser doesn't support this feature", "Can't Copy");
     // take Mulder's advice - trustno1
@@ -124,7 +103,6 @@ export default React.createClass({
 
         // The assumption is that if we have the execCommand method
         // we also have "copy"
-
         try {
             var canCopy = document.execCommand;
             this.setState({

--- a/troposphere/static/js/components/common/ui/CopyButton.jsx
+++ b/troposphere/static/js/components/common/ui/CopyButton.jsx
@@ -1,0 +1,200 @@
+import React from 'react';
+import Raven from "raven-js";
+
+/**
+ * Report exception via Sentry error client (Raven)
+ *
+ * @param ex - Exception to report to Sentry backend
+ *
+ * We want to ensure that we can gain some knowledge into the usage of
+ * this feature and the availability of the Clipboard API in the wild.
+ *
+ * It is highly likely that it is available, but we would like to know
+ * where it is *not* available to assist in helping those community
+ * members on a newer browerser
+ */
+function reportException(ex) {
+    // take Mulder's advice - trustno1
+    if (Raven && Raven.isSetup()) {
+        if (Raven.captureException) {
+            Raven.captureException(ex);
+        }
+    }
+}
+
+/* 
+* This code was found here: http://stackoverflow.com/a/30810322.
+* We should test this but it seems like the most elegant solution 
+* as it is self contained and dosn't depend on external DOM element. 
+* This is better because it reduces the chances of user error. 
+* Just pass it the string you want to copy.
+* 
+* I don't think there is a problem with performence or react as this 
+* appends an element outside #app and removes onClick.
+*/
+
+function copyTextToClipboard(text) {
+    var textArea = document.createElement("textarea");
+
+    //
+    // *** This styling is an extra step which is likely not required. ***
+    //
+    // Why is it here? To ensure:
+    // 1. the element is able to have focus and selection.
+    // 2. if element was to flash render it has minimal visual impact.
+    // 3. less flakyness with selection and copying which **might** occur if
+    //    the textarea element is not visible.
+    //
+    // The likelihood is the element won't even render, not even a flash,
+    // so some of these are just precautions. However in IE the element
+    // is visible whilst the popup box asking the user for permission for
+    // the web page to copy to the clipboard.
+    //
+
+    // Place in top-left corner of screen regardless of scroll position.
+    textArea.style.position = 'fixed';
+    textArea.style.top = 0;
+    textArea.style.left = 0;
+
+    // Ensure it has a small width and height. Setting to 1px / 1em
+    // doesn't work as this gives a negative w/h on some browsers.
+    textArea.style.width = '2em';
+    textArea.style.height = '2em';
+
+    // We don't need padding, reducing the size if it does flash render.
+    textArea.style.padding = 0;
+
+    // Clean up any borders.
+    textArea.style.border = 'none';
+    textArea.style.outline = 'none';
+    textArea.style.boxShadow = 'none';
+
+    // Avoid flash of white box if rendered for any reason.
+    textArea.style.background = 'transparent';
+
+    textArea.value = text;
+
+    document.body.appendChild(textArea);
+
+    textArea.select();
+
+    try {
+        var successful = document.execCommand('copy');
+        var msg = successful ? 'successful' : 'unsuccessful';
+        console.log('Copying text was ' + msg);
+    } catch (err) {
+        reportException(e);
+        console.log('Unable to copy');
+    };
+
+    document.body.removeChild(textArea);
+};
+
+export default React.createClass({
+    getInitialState() {
+        return {
+            feedbackState: "WAIT"
+        }
+    },
+
+    onClick() {
+        const { text } = this.props;
+        copyTextToClipboard(text);
+
+        this.setState({
+            feedbackState: "FLOAT"
+        }, () => {
+            setTimeout( 
+                () => { 
+                    this.setState({
+                        feedbackState: "FADEOUT"
+                }, () => {
+                    setTimeout(
+                    () => {    
+                        this.setState({
+                            feedbackState: "WAIT"   
+                        })
+                    } , 300)
+                })}, 300)
+            }
+        );
+    },
+
+    render() {
+        const { feedbackState } = this.state;
+        const style = this.style();
+
+        const feedbackStyle = () => {
+            switch (feedbackState) {
+                case "WAIT":
+                    return style.feedbackHidden
+                case "FLOAT":
+                    return style.feedbackShown
+                case "FADEOUT":
+                    return style.feedbackOut
+            }
+        };
+
+        return (
+            <div
+                style={ style.button } 
+                onClick = { this.onClick }
+            > 
+                <div style={{ 
+                        ...style.feedback,
+                        ...feedbackStyle() 
+                    }}
+                >
+                    Copied!
+                </div>
+                <i 
+                    className="glyphicon glyphicon-copy"
+                />
+            </div>
+        )
+    },
+    
+    style() {
+        // Base styles
+        const button = {
+            position: "relative",
+            display: "inline-block",
+            fontSize: "16px",
+            cursor: "pointer",
+            color: "grey",
+            marginLeft: "10px",
+        };
+        
+
+        const feedback = {
+            position: "absolute",
+        }
+
+        // Animation step styles
+        const feedbackHidden = {
+            position: "absolute",
+            opacity: "0",
+            top: "0",
+        };
+
+        const feedbackShown = {
+            opacity: "1",
+            top: "-20px",
+            transition: "opacity .3s ease, top .1s ease",
+        };
+
+        const feedbackOut = {
+            opacity: "0",
+            top: "-20px",
+            transition: "opacity .2s ease",
+        };
+       
+        return {
+            button,
+            feedback,
+            feedbackHidden,
+            feedbackShown,
+            feedbackOut,
+        }
+    },
+})

--- a/troposphere/static/js/components/common/ui/CopyButton.jsx
+++ b/troposphere/static/js/components/common/ui/CopyButton.jsx
@@ -32,7 +32,6 @@ function reportException(ex) {
 * I don't think there is a problem with performence or react as this 
 * appends an element outside #app and removes onClick.
 */
-
 function copyTextToClipboard(text) {
     var textArea = document.createElement("textarea");
 
@@ -114,6 +113,7 @@ export default React.createClass({
                         this.setState({
                             feedbackState: "WAIT"   
                         })
+                        debugger
                     } , 300)
                 })}, 300)
             }
@@ -135,7 +135,6 @@ export default React.createClass({
             }
         };
 
-        if (!document.execCommand('copy')) return;
         return (
             <div
                 style={ style.button } 

--- a/troposphere/static/js/components/common/ui/CopyButton.jsx
+++ b/troposphere/static/js/components/common/ui/CopyButton.jsx
@@ -103,10 +103,8 @@ function copyTextToClipboard(text) {
     try {
         var successful = document.execCommand('copy');
         var msg = successful ? 'successful' : 'unsuccessful';
-        console.log('Copying text was ' + msg);
     } catch (err) {
         reportException(err);
-        console.log('Unable to copy');
     };
 
     document.body.removeChild(textArea);
@@ -115,8 +113,29 @@ function copyTextToClipboard(text) {
 export default React.createClass({
     getInitialState() {
         return {
-            feedbackState: "WAIT"
+            feedbackState: "WAIT",
+            canCopy: false,
         }
+    },
+
+    componentDidMount() {
+        // Support for execCommand is good 
+        // http://caniuse.com/#search=document.execCommand
+
+        // The assumption is that if we have the execCommand method
+        // we also have "copy"
+
+        try {
+            var canCopy = document.execCommand;
+            this.setState({
+                canCopy,
+            });
+        } catch (err) {
+            reportException(err);
+            this.setState({
+                canCopy: false,
+            });
+        };
     },
 
     onClick() {
@@ -156,6 +175,8 @@ export default React.createClass({
                     return style.feedbackOut
             }
         };
+
+        if (!this.state.canCopy) return <span/>;
 
         return (
             <div

--- a/troposphere/static/js/components/images/detail/availability/AvailabilityView.jsx
+++ b/troposphere/static/js/components/images/detail/availability/AvailabilityView.jsx
@@ -5,9 +5,6 @@ import Code from "components/common/ui/Code";
 import CopyButton from "components/common/ui/CopyButton";
 import moment from "moment";
 
-import { copyElement } from "utilities/clipboardFunctions";
-
-
 export default React.createClass({
     displayName: "AvailabilityView",
 

--- a/troposphere/static/js/components/images/detail/availability/AvailabilityView.jsx
+++ b/troposphere/static/js/components/images/detail/availability/AvailabilityView.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import Backbone from "backbone";
 import stores from "stores";
 import Code from "components/common/ui/Code";
+import CopyButton from "components/common/ui/CopyButton";
 import moment from "moment";
 
 import { copyElement } from "utilities/clipboardFunctions";
@@ -13,11 +14,6 @@ export default React.createClass({
     propTypes: {
         version: React.PropTypes
             .instanceOf( Backbone.Model ).isRequired
-    },
-
-    onClick(e) {
-        e.preventDefault();
-        copyElement(e.target, { acknowledge: true });
     },
 
     renderProviderMachine( provider ) {
@@ -36,9 +32,12 @@ export default React.createClass({
         let optMachineID;
         if (!isSummary) {
             optMachineID = (
-                <Code mb="10px">
-                    <div onClick={ this.onClick }>{ machineID }</div>
-                </Code>
+                <div>
+                    <Code mb="10px">
+                        { machineID }
+                    </Code>
+                    <CopyButton text={ machineID }/>
+                </div>
             );
         }
 
@@ -57,8 +56,9 @@ export default React.createClass({
         // No availability if the version *OR* parent-image are end-dated.
         if(!isEndDated) {
             let image = version.get('image'),
-                end_date = moment(image.end_date);
-            isEndDated = end_date && end_date.isValid();
+            end_date = moment(image.end_date);
+            isEndDated = end_date && end_date
+            .isValid();
         }
 
         if(isEndDated) {

--- a/troposphere/static/js/components/images/detail/availability/AvailabilityView.jsx
+++ b/troposphere/static/js/components/images/detail/availability/AvailabilityView.jsx
@@ -54,14 +54,13 @@ export default React.createClass({
         let endDate = version.get('end_date'),
             isEndDated = endDate && endDate.isValid();
         // No availability if the version *OR* parent-image are end-dated.
-        if(!isEndDated) {
-            let image = version.get('image'),
-            end_date = moment(image.end_date);
-            isEndDated = end_date && end_date
-            .isValid();
+        if (!isEndDated) {
+            let image = version.get('image');
+            let end_date = moment(image.end_date);
+            isEndDated = end_date && end_date.isValid();
         }
 
-        if(isEndDated) {
+        if (isEndDated) {
             return this.renderEndDated();
         } else {
             return this.renderProviders();

--- a/troposphere/static/js/components/projects/resources/instance/details/sections/details/Alias.jsx
+++ b/troposphere/static/js/components/projects/resources/instance/details/sections/details/Alias.jsx
@@ -10,11 +10,6 @@ export default React.createClass({
         instance: React.PropTypes.instanceOf(Backbone.Model).isRequired
     },
 
-    onClick(e) {
-        e.preventDefault();
-        copyElement(e.target, { acknowledge: true });
-    },
-
     render() {
         const uuid = this.props.instance.get("uuid");
         return (

--- a/troposphere/static/js/components/projects/resources/instance/details/sections/details/Alias.jsx
+++ b/troposphere/static/js/components/projects/resources/instance/details/sections/details/Alias.jsx
@@ -1,9 +1,7 @@
 import React from "react";
 import Backbone from "backbone";
 import ResourceDetail from "components/projects/common/ResourceDetail";
-
-import { copyElement } from "utilities/clipboardFunctions";
-
+import CopyButton from "components/common/ui/CopyButton";
 
 export default React.createClass({
     displayName: "Alias",
@@ -18,9 +16,11 @@ export default React.createClass({
     },
 
     render() {
+        const uuid = this.props.instance.get("uuid");
         return (
-        <ResourceDetail label="Alias" onClick={this.onClick}>
-            {this.props.instance.get("uuid")}
+        <ResourceDetail label="Alias">
+            { uuid }
+            <CopyButton text={ uuid }/>
         </ResourceDetail>
         );
     }

--- a/troposphere/static/js/components/projects/resources/instance/details/sections/details/IpAddress.jsx
+++ b/troposphere/static/js/components/projects/resources/instance/details/sections/details/IpAddress.jsx
@@ -1,20 +1,13 @@
 import React from "react";
 import Backbone from "backbone";
 import ResourceDetail from "components/projects/common/ResourceDetail";
-
-import { copyElement } from "utilities/clipboardFunctions";
-
+import CopyButton from "components/common/ui/CopyButton";
 
 export default React.createClass({
     displayName: "IpAddress",
 
     propTypes: {
         instance: React.PropTypes.instanceOf(Backbone.Model).isRequired
-    },
-
-    onClick(e) {
-        e.preventDefault();
-        copyElement(e.target, { acknowledge: true });
     },
 
     render() {
@@ -26,8 +19,9 @@ export default React.createClass({
         }
 
         return (
-        <ResourceDetail label="IP Address" onClick={this.onClick}>
+        <ResourceDetail label="IP Address">
             {address}
+            <CopyButton text={ address }/>
         </ResourceDetail>
         );
     }

--- a/troposphere/static/js/components/projects/resources/volume/details/sections/VolumeDetailsSection.jsx
+++ b/troposphere/static/js/components/projects/resources/volume/details/sections/VolumeDetailsSection.jsx
@@ -1,13 +1,11 @@
 import React from "react";
 import Backbone from "backbone";
 import ResourceDetail from "components/projects/common/ResourceDetail";
+import CopyButton from "components/common/ui/CopyButton";
 import Id from "./details/Id";
 import Status from "./details/Status";
 import Size from "./details/Size";
 import Identity from "./details/Identity";
-
-import { copyElement } from "utilities/clipboardFunctions";
-
 
 export default React.createClass({
     displayName: "VolumeDetailsSection",
@@ -16,14 +14,9 @@ export default React.createClass({
         volume: React.PropTypes.instanceOf(Backbone.Model).isRequired
     },
 
-    onClick(e) {
-        e.preventDefault();
-        copyElement(e.target, { acknowledge: true });
-    },
-
     render() {
-        let volume = this.props.volume;
-
+        const volume = this.props.volume;
+        const uuid = volume.get("uuid");
         return (
         <div className="resource-details-section section">
             <h4 className="t-title">Volume Details</h4>
@@ -32,8 +25,9 @@ export default React.createClass({
                 <Size volume={volume} />
                 <Identity volume={volume} />
                 <Id volume={volume} />
-                <ResourceDetail label="Identifier" onClick={this.onClick}>
-                    {volume.get("uuid")}
+                <ResourceDetail label="Identifier">
+                    { uuid }
+                    <CopyButton text={ uuid } />
                 </ResourceDetail>
             </ul>
         </div>

--- a/troposphere/static/js/utilities/toastrHelpers.js
+++ b/troposphere/static/js/utilities/toastrHelpers.js
@@ -1,0 +1,24 @@
+import toastr from "toastr";
+
+export function alertFail(msg, title) {
+    let toastrDefaults = {
+        "closeButton": true,
+        "debug": false,
+        "newestOnTop": false,
+        "progressBar": false,
+        "positionClass": "toast-bottom-right",
+        "preventDuplicates": true,
+        "onclick": null,
+        "showDuration": "260",
+        "hideDuration": "1000",
+        "timeOut": "6000",
+        "extendedTimeOut": "650",
+        "showEasing": "swing",
+        "hideEasing": "linear",
+        "showMethod": "fadeIn",
+        "hideMethod": "fadeOut"
+    };
+
+    toastr.warning(msg, title, toastrDefaults);
+}
+


### PR DESCRIPTION
## Description
Resolves [ATMO-1725](https://pods.iplantcollaborative.org/jira/browse/ATMO-1725)

This was a change requested by Edwin.

Watching Edwin "discover" the clipboard feature on a version id. It became apparent that the current solution is confusing. Since there is no button the user attempts to highlight the image but the copy feature is triggered on click causing the highlighted text to drop and leaves the user uncertain if all of the text was copied.

Using a button will both inform the user of the feature and not block the text from being highlighted if the user wants to do that.

I ended up using a self contained component solution that accepts the text to be copied as a string propType over the current method of selecting the text in a target DOM node. I think this is an easier interface to work with and would minimize implementation bugs with the different ways the text to be copied might be formatted for render. 

## Before
Shows that attempting to select the text trigers the notification. (gif didn't capture that a portion of the text was highlighted making the user question if only a portion was copied)
![before](https://cloud.githubusercontent.com/assets/7366338/23136928/6ea488f0-f75c-11e6-8983-9ba8a683fd2d.gif)

## After
Shows that the user can either select all of the text for manual selection or click the copy to clipboard button. Note that the gif didn't capture the animation or the cursor change to pointer. 
![after](https://cloud.githubusercontent.com/assets/7366338/23369972/5ed11dac-fcd0-11e6-82d2-232847e8e049.gif)

## Handle Failure
There seems to be no good way to optionally show the button if the copy to clipboard feature is supported other than a leaky check for `document.execCommand` [See this thread](https://github.com/Modernizr/Modernizr/pull/659). So in ( rare edge cases ) failing this initial check we catch the error and report to the user and raven. 

Since we detect for other more critical features and recommend a browser upgrade it is unlikely that many users will encounter this unless already disregarding the warning that things might be broken.
![error](https://cloud.githubusercontent.com/assets/7366338/23371559/b8095790-fcd5-11e6-9eaf-08f1cb549ac6.gif)

## Checklist before merging Pull Requests
- [x] Add button to following  areas
* Instance Detail
  * IP address field
  * Instance alias field
* Volume Detail
  * Volume alias field
- [ ] Reviewed and approved by at least one other contributor.
