### PR TITLE
Problem: instance actions are not driven by VM "status" 

### DIFF
--- a/troposphere/static/js/bootstrapper.js
+++ b/troposphere/static/js/bootstrapper.js
@@ -47,6 +47,7 @@ stores.ImageVersionScriptStore = require("stores/ImageVersionScriptStore");
 stores.IdentityStore = require("stores/IdentityStore");
 stores.ImageBookmarkStore = require("stores/ImageBookmarkStore");
 stores.InstanceHistoryStore = require("stores/InstanceHistoryStore");
+stores.InstanceActionStore = require("stores/InstanceActionStore");
 stores.ImageRequestStore = require("stores/ImageRequestStore");
 stores.InstanceStore = require("stores/InstanceStore");
 stores.InstanceTagStore = require("stores/InstanceTagStore");

--- a/troposphere/static/js/collections/InstanceActionCollection.js
+++ b/troposphere/static/js/collections/InstanceActionCollection.js
@@ -1,0 +1,18 @@
+import Backbone from "backbone";
+
+import InstanceAction from "models/InstanceAction";
+
+import globals from "globals";
+
+export default Backbone.Collection.extend({
+    model: InstanceAction,
+
+    initialize: function(models, options) {
+        if (options.alias)
+            this.alias = options.alias;
+    },
+
+    url: function() {
+        return `${globals.API_V2_ROOT}/instances/${this.alias}/actions`;
+    },
+});

--- a/troposphere/static/js/components/common/InteractiveDateField.jsx
+++ b/troposphere/static/js/components/common/InteractiveDateField.jsx
@@ -53,7 +53,7 @@ export default React.createClass({
         var labelEl = this.props.labelText ? (<label htmlFor="interactive-date-field">
                                                   {this.props.labelText}
                                               </label>) : null;
-        var btnStyle = {
+        var btnStyle = this.props.styleOverride || {
             lineHeight: "1.31" // I know this is quite heinous ...
         };
         var lastBtnStyle = {

--- a/troposphere/static/js/components/images/detail/EditImageDetails.jsx
+++ b/troposphere/static/js/components/images/detail/EditImageDetails.jsx
@@ -89,36 +89,37 @@ export default React.createClass({
         return (
         <div className="card" style={{ maxWidth: "600px" }} >
             <div style={{ marginBottom: "20px" }} >
-                <EditNameView 
-                    image={image} 
-                    value={this.state.name} 
-                    onChange={this.handleNameChange} 
+                <EditNameView
+                    image={image}
+                    value={this.state.name}
+                    onChange={this.handleNameChange}
                 />
                 <div>
                     <h4 className="t-body-2">
                         Date to hide image from public view
                     </h4>
                     <div style={{ marginBottom: "15px" }} >
-                        <InteractiveDateField 
-                            value={this.state.endDate} 
-                            onChange={this.handleEndDateChange} 
+                        <InteractiveDateField
+                            styleOverride={{lineHeight: "1.47"}}
+                            value={this.state.endDate}
+                            onChange={this.handleEndDateChange}
                         />
                     </div>
                 </div>
-                <EditDescriptionView 
+                <EditDescriptionView
                     titleClassName="title"
                     formClassName="form-group"
                     title="Description"
                     image={image}
                     value={this.state.description}
-                    onChange={this.handleDescriptionChange} 
+                    onChange={this.handleDescriptionChange}
                 />
-                <EditTagsView 
+                <EditTagsView
                     image={image}
                     tags={allTags}
                     value={imageTags}
                     onTagAdded={this.onTagAdded}
-                    onTagRemoved={this.onTagRemoved} 
+                    onTagRemoved={this.onTagRemoved}
                 />
             </div>
             <div className="edit-link-row clearfix">

--- a/troposphere/static/js/components/projects/resources/instance/details/InstanceDetailsView.jsx
+++ b/troposphere/static/js/components/projects/resources/instance/details/InstanceDetailsView.jsx
@@ -91,7 +91,8 @@ export default React.createClass({
                      : ""}
                 </div>
                 <div className="col-md-3">
-                    <InstanceActionsAndLinks project={project} instance={instance} />
+                    <InstanceActionsAndLinks project={project}
+                                             instance={instance} />
                 </div>
             </div>
         </div>

--- a/troposphere/static/js/components/projects/resources/instance/details/actions/InstanceActionsAndLinks.jsx
+++ b/troposphere/static/js/components/projects/resources/instance/details/actions/InstanceActionsAndLinks.jsx
@@ -233,42 +233,37 @@ export default React.createClass({
         );
 
         var className = "section-link";
-        if (link.isDangerLink)
+        if (link.isDangerLink) {
             className += " danger";
+        }
 
-            let linkLabelMarkup = (
-                <span>
-                    <Glyphicon name={link.icon}/>{` ${link.label}`}
-                </span>
-            );
+        // todo: This isn't implemented well at all.  We should be disabling these
+        // buttons if there isn't a valid href for the link, or (perhaps) not even
+        // showing the buttons at all...but I think it's better communication to
+        // disable the buttons with a message explaining why on rollover.
+        //
+        if (link.openInNewWindow) {
+            let linkProps,
+                style = {};
+            if (!link.href && !link.onClick)
+                style.cursor = "not-allowed";
 
-            // todo: This isn't implemented well at all.  We should be disabling these
-            // buttons if there isn't a valid href for the link, or (perhaps) not even
-            // showing the buttons at all...but I think it's better communication to
-            // disable the buttons with a message explaining why on rollover.
-            //
-            if (link.openInNewWindow) {
-                let linkProps,
-                    style = {};
-                if (!link.href && !link.onClick)
-                    style.cursor = "not-allowed";
+            linkProps = {
+                key: link.label,
+                className: className + " link",
+                disabled: link.isDisabled
+            }
+            // conditionally include a click handler
+            if (link.onClick) {
+                linkProps.onClick = link.onClick
+            }
 
-                linkProps = {
-                    key: link.label,
-                    className: className + " link",
-                    disabled: link.isDisabled
-                }
-                // conditionally include a click handler
-                if (link.onClick) {
-                    linkProps.onClick = link.onClick
-                }
-
-                return (
-                <li {...linkProps}>
-                    <a href={link.href} target="_blank">
-                        {linkLabelMarkup}
-                    </a>
-                </li>
+            return (
+            <li {...linkProps}>
+                <a href={link.href} target="_blank">
+                    {linkLabelMarkup}
+                </a>
+            </li>
             );
         }
 

--- a/troposphere/static/js/components/projects/resources/instance/details/actions/InstanceActionsAndLinks.jsx
+++ b/troposphere/static/js/components/projects/resources/instance/details/actions/InstanceActionsAndLinks.jsx
@@ -4,15 +4,13 @@ import React from "react";
 import Backbone from "backbone";
 
 import Glyphicon from "components/common/Glyphicon";
-
-// FIXME
-import InstanceActionStore from "stores/InstanceActionStore";
 import InstanceActionNames from "constants/InstanceActionNames";
 
 import featureFlags from "utilities/featureFlags";
 import { findCookie } from "utilities/cookieHelpers";
 
 import modals from "modals";
+import stores from "stores";
 
 
 export default React.createClass({
@@ -87,7 +85,7 @@ export default React.createClass({
     },
 
     updateState: function() {
-        let actions = InstanceActionStore.getActionsFor(this.props.instance),
+        let actions = stores.InstanceActionStore.getActionsFor(this.props.instance),
             actionElements = this.state.actionElements;
 
         if (actions) {
@@ -99,12 +97,12 @@ export default React.createClass({
     },
 
     componentDidMount: function() {
-        InstanceActionStore.addChangeListener(this.updateState);
+        stores.InstanceActionStore.addChangeListener(this.updateState);
         this.updateState();
     },
 
     componentWillUnmount: function() {
-        InstanceActionStore.removeChangeListener(this.updateState);
+        stores.InstanceActionStore.removeChangeListener(this.updateState);
     },
 
     onStart: function() {
@@ -294,7 +292,7 @@ export default React.createClass({
     render: function() {
         let { actions, actionElements } = this.state;
 
-        InstanceActionStore.getActionsFor(this.props.instance);
+        stores.InstanceActionStore.getActionsFor(this.props.instance);
 
         if (!actions) {
             return (<div className="loading" />);

--- a/troposphere/static/js/components/projects/resources/instance/details/actions/InstanceActionsAndLinks.jsx
+++ b/troposphere/static/js/components/projects/resources/instance/details/actions/InstanceActionsAndLinks.jsx
@@ -105,34 +105,28 @@ export default React.createClass({
 
     componentWillUnmount: function() {
         InstanceActionStore.removeChangeListener(this.updateState);
-        InstanceActionStore.models = null;
     },
 
     onStart: function() {
         modals.InstanceModals.start(this.props.instance);
-        InstanceActionStore.models = null;
     },
 
     onSuspend: function() {
         modals.InstanceModals.suspend(this.props.instance);
-        InstanceActionStore.models = null;
     },
 
     onStop: function() {
         modals.InstanceModals.stop(this.props.instance);
-        InstanceActionStore.models = null;
     },
 
     onResume: function() {
         modals.InstanceModals.resume(this.props.instance);
-        InstanceActionStore.models = null;
     },
 
     onReport: function() {
         modals.InstanceModals.report({
             instance: this.props.instance
         });
-
     },
 
     onImageRequest: function() {

--- a/troposphere/static/js/components/projects/resources/instance/details/actions/InstanceActionsAndLinks.jsx
+++ b/troposphere/static/js/components/projects/resources/instance/details/actions/InstanceActionsAndLinks.jsx
@@ -237,6 +237,12 @@ export default React.createClass({
             className += " danger";
         }
 
+        let linkLabelMarkup = (
+            <span>
+                <Glyphicon name={link.icon}/>{` ${link.label}`}
+            </span>
+        );
+
         // todo: This isn't implemented well at all.  We should be disabling these
         // buttons if there isn't a valid href for the link, or (perhaps) not even
         // showing the buttons at all...but I think it's better communication to

--- a/troposphere/static/js/components/projects/resources/instance/details/actions/InstanceActionsAndLinks.jsx
+++ b/troposphere/static/js/components/projects/resources/instance/details/actions/InstanceActionsAndLinks.jsx
@@ -1,12 +1,18 @@
+import $ from "jquery";
+
 import React from "react";
 import Backbone from "backbone";
+
 import Glyphicon from "components/common/Glyphicon";
-import modals from "modals";
+
+// FIXME
+import InstanceActionStore from "stores/InstanceActionStore";
+import InstanceActionNames from "constants/InstanceActionNames";
 
 import featureFlags from "utilities/featureFlags";
 import { findCookie } from "utilities/cookieHelpers";
 
-import $ from "jquery";
+import modals from "modals";
 
 
 export default React.createClass({
@@ -16,26 +22,117 @@ export default React.createClass({
         instance: React.PropTypes.instanceOf(Backbone.Model).isRequired
     },
 
+    /**
+     * A manifest, of specification listing, of element data associated
+     * with a given Instance Action:
+     */
+    actionSpecs: function() {
+        // For now, order *matters*
+        let specs = [
+            {
+                key: InstanceActionNames.IMAGE,
+                label: "Image",
+                icon: "camera",
+                onClick: this.onImageRequest
+            },
+            {
+                key: InstanceActionNames.START,
+                label: "Start",
+                icon: "play",
+                onClick: this.onStart
+            },
+            {
+                key: InstanceActionNames.SUSPEND,
+                label: "Suspend",
+                icon: "pause",
+                onClick: this.onSuspend
+            },
+            {
+                key: InstanceActionNames.STOP,
+                label: "Stop",
+                icon: "stop",
+                onClick: this.onStop
+            },
+            {
+                key: InstanceActionNames.RESUME,
+                label: "Resume",
+                icon: "play",
+                onClick: this.onResume
+            },
+            {
+                key: InstanceActionNames.REBOOT,
+                label: "Reboot",
+                icon: "repeat",
+                onClick: this.onReboot
+            },
+            {
+                key: "Redeploy",
+                label: "Redeploy",
+                icon: "repeat",
+                onClick: this.onRedeploy
+            },
+            {
+                key: InstanceActionNames.DELETE,
+                label: "Delete",
+                icon: "remove",
+                onClick: this.onDelete,
+                isDangerLink: true
+            }
+        ];
+        return specs;
+    },
+
+    getInitialState: function() {
+        return { actions: null, actionElements: [] };
+    },
+
+    updateState: function() {
+        let actions = InstanceActionStore.getActionsFor(this.props.instance),
+            actionElements = this.state.actionElements;
+
+        if (actions) {
+            let keys = actions.pluck("key");
+            actionElements = this.actionSpecs().filter((a) => keys.includes(a.key));
+        }
+
+        this.setState({actions, actionElements})
+    },
+
+    componentDidMount: function() {
+        InstanceActionStore.addChangeListener(this.updateState);
+        this.updateState();
+    },
+
+    componentWillUnmount: function() {
+        InstanceActionStore.removeChangeListener(this.updateState);
+        InstanceActionStore.models = null;
+    },
+
     onStart: function() {
         modals.InstanceModals.start(this.props.instance);
+        InstanceActionStore.models = null;
     },
 
     onSuspend: function() {
         modals.InstanceModals.suspend(this.props.instance);
+        InstanceActionStore.models = null;
     },
 
     onStop: function() {
         modals.InstanceModals.stop(this.props.instance);
+        InstanceActionStore.models = null;
     },
 
     onResume: function() {
         modals.InstanceModals.resume(this.props.instance);
+        InstanceActionStore.models = null;
     },
 
     onReport: function() {
         modals.InstanceModals.report({
             instance: this.props.instance
         });
+
     },
 
     onImageRequest: function() {
@@ -67,9 +164,10 @@ export default React.createClass({
         modals.InstanceModals.reboot(this.props.instance);
     },
 
+
     onWebDesktop: function(ipAddr, instance) {
         // TODO:
-        //      move this into a utilties file
+        //      move this into a utilities file
         var CSRFToken = findCookie("tropo_csrftoken");
 
         // build a form to POST to web_desktop
@@ -93,126 +191,22 @@ export default React.createClass({
         form[0].submit();
     },
 
-    render: function() {
-        var webShellUrl = this.props.instance.shell_url(),
-            webDesktopCapable = !!(this.props.instance && this.props.instance.get("web_desktop")),
-            status = this.props.instance.get("state").get("status"),
-            activity = this.props.instance.get("state").get("activity"),
-            ip_address = this.props.instance.get("ip_address"),
-            webLinksDisabled = !ip_address || ip_address === "0.0.0.0",
-            inFinalState = this.props.instance.get("state").isInFinalState();
+    getIntegrationLinks() {
+        let { instance } = this.props,
+            webShellUrl = instance.shell_url(),
+            webDesktopCapable = !!(instance && instance.get("web_desktop")),
+            ipAddress = instance.get("ip_address"),
+            disableWebLinks = !ipAddress || ipAddress === "0.0.0.0";
 
-        // todo: Add back and implement reboot and resize once it's understood how to
-        // I'm hiding from the display for now so as not to show users functionality
-        // that doesn't exist.
-        var linksArray = [
-            {
-                label: "Actions",
-                icon: null
-            },
-            {
-                label: "Report",
-                icon: "inbox",
-                onClick: this.onReport
-            }
-        //{label: 'Reboot', icon: 'repeat', onClick: this.onReboot},
-        //{label: 'Resize', icon: 'resize-full', onClick: this.onResize},
-        ];
-
-        if (status !== "suspended") {
-            linksArray.push({
-                label: "Image",
-                icon: "camera",
-                onClick: this.onImageRequest
-            });
-        }
-
-        // Add in the conditional links based on current machine state
-        if (inFinalState) {
-            if (status === "active") {
-                linksArray.push({
-                    label: "Suspend",
-                    icon: "pause",
-                    onClick: this.onSuspend
-                });
-                linksArray.push({
-                    label: "Stop",
-                    icon: "stop",
-                    onClick: this.onStop
-                });
-                linksArray.push({
-                    label: "Reboot",
-                    icon: "off",
-                    onClick: this.onReboot
-                });
-                linksArray.push({
-                    label: "Redeploy",
-                    icon: "repeat",
-                    onClick: this.onRedeploy
-                });
-            } else if (status === "suspended") {
-                linksArray.push({
-                    label: "Resume",
-                    icon: "play",
-                    onClick: this.onResume
-                });
-                linksArray.push({
-                    label: "Reboot",
-                    icon: "off",
-                    onClick: this.onReboot
-                });
-            } else if (status === "shutoff") {
-                linksArray.push({
-                    label: "Start",
-                    icon: "play",
-                    onClick: this.onStart
-                });
-            }
-        }
-
-        if (activity === "deploying" || status === "deploying"
-            || activity === "user_deploy_error" || status === "user_deploy_error"
-            || activity === "deploy_error" || status === "deploy_error"
-            || activity === "initializing" || activity === "boot_script_error") {
-            linksArray.push({
-                label: "Redeploy",
-                icon: "repeat",
-                onClick: this.onRedeploy
-            });
-        }
-
-        if (!inFinalState && status === "active" && (activity === "networking"
-            || activity === "running_boot_script")) {
-            linksArray.push({
-                label: "Reboot",
-                icon: "off",
-                onClick: this.onReboot
-            });
-            linksArray.push({
-                label: "Redeploy",
-                icon: "repeat",
-                onClick: this.onRedeploy
-            });
-        }
-        linksArray = linksArray.concat([
-            {
-                label: "Delete",
-                icon: "remove",
-                onClick: this.onDelete,
-                isDangerLink: true
-            },
-            {
-                label: "Links",
-                icon: null
-            },
+        let links = [
             {
                 label: "Open Web Shell",
                 icon: "console",
                 href: webShellUrl,
                 openInNewWindow: true,
-                isDisabled: webLinksDisabled
+                isDisabled: disableWebLinks
             }
-        ]);
+        ];
 
         if (webDesktopCapable && featureFlags.WEB_DESKTOP) {
             linksArray.push({
@@ -227,23 +221,20 @@ export default React.createClass({
             });
         }
 
-        var links = linksArray.map(function(link) {
-            // Links without icons are generally section headings
-            if (!link.icon) return (
-                <li key={link.label} className="section-label">
-                    {link.label}
-                </li>
-                );
+        return links;
+    },
 
-            var className = "section-link";
-            if (link.isDangerLink)
-                className += " danger";
+    renderLink(link) {
+        // Links without icons are generally section headings
+        if (!link.icon) return (
+            <li key={link.label} className="section-label">
+                {link.label}
+            </li>
+        );
 
-            let linkLabelMarkup = (
-                <span>
-                    <Glyphicon name={link.icon}/>{` ${link.label}`}
-                </span>
-            );
+        var className = "section-link";
+        if (link.isDangerLink)
+            className += " danger";
 
             // todo: This isn't implemented well at all.  We should be disabling these
             // buttons if there isn't a valid href for the link, or (perhaps) not even
@@ -272,37 +263,65 @@ export default React.createClass({
                         {linkLabelMarkup}
                     </a>
                 </li>
-                );
-            }
+            );
+        }
 
-            // Some actions have hrefs, because they redirect to actual pages (and are
-            // not actions in need of confirmation).  While we *could* call
-            // Backbone.history.navigate from an onClick callback, we want all url
-            // changes to pass through our Backbone catcher in main.js that we can use
-            // to log requests to Google Analytics
-            if (link.href) {
-                return (
+        // Some actions have hrefs, because they redirect to actual pages (and are
+        // not actions in need of confirmation).  While we *could* call
+        // Backbone.history.navigate from an onClick callback, we want all url
+        // changes to pass through our Backbone catcher in main.js that we can use
+        // to log requests to Google Analytics
+        if (link.href) {
+            return (
                 <li key={link.label} className={className + " link"}>
                     <a href={link.href}>
                         {linkLabelMarkup}
                     </a>
                 </li>
-                );
-            }
+            );
+        }
 
-            // Links with onClick callbacks will typically trigger modals requiring
-            // confirmation before continuing
-            return (
+        // Links with onClick callbacks will typically trigger modals requiring
+        // confirmation before continuing
+        return (
             <li key={link.label} className={className} onClick={link.onClick}>
                 {linkLabelMarkup}
             </li>
-            );
+        );
+    },
+
+    render: function() {
+        let { actions, actionElements } = this.state;
+
+        InstanceActionStore.getActionsFor(this.props.instance);
+
+        if (!actions) {
+            return (<div className="loading" />);
+        }
+
+        let linkElements = [
+                {
+                    label: "Actions",
+                    icon: null
+                },
+                {
+                    label: "Report",
+                    icon: "inbox",
+                    onClick: this.onReport
+                }
+            ];
+
+        linkElements = linkElements.concat(actionElements);
+        linkElements.push({
+            label: "Links",
+            icon: null
         });
+        linkElements = linkElements.concat(this.getIntegrationLinks());
 
         return (
         <div className="resource-actions">
             <ul>
-                {links}
+                {linkElements.map(this.renderLink)}
             </ul>
         </div>
 

--- a/troposphere/static/js/components/projects/resources/instance/details/actions/InstanceActionsAndLinks.jsx
+++ b/troposphere/static/js/components/projects/resources/instance/details/actions/InstanceActionsAndLinks.jsx
@@ -236,6 +236,12 @@ export default React.createClass({
         if (link.isDangerLink)
             className += " danger";
 
+            let linkLabelMarkup = (
+                <span>
+                    <Glyphicon name={link.icon}/>{` ${link.label}`}
+                </span>
+            );
+
             // todo: This isn't implemented well at all.  We should be disabling these
             // buttons if there isn't a valid href for the link, or (perhaps) not even
             // showing the buttons at all...but I think it's better communication to

--- a/troposphere/static/js/constants/InstanceActionNames.js
+++ b/troposphere/static/js/constants/InstanceActionNames.js
@@ -1,0 +1,15 @@
+
+export default {
+    START: "Start",
+    STOP: "Stop",
+    RESUME: "Resume",
+    SUSPEND: "Suspend",
+    SHELVE_OFFLOAD: "Shelve Offload",
+    SHELVE: "Shelve",
+    UNSHELVE: "Unshelve",
+    REBOOT: "Reboot",
+    HARD_REBOOT: "Hard Reboot",
+    RESIZE: "Resize",
+    DELETE: "Terminate",
+    IMAGE: "Imaging"
+};

--- a/troposphere/static/js/main.js
+++ b/troposphere/static/js/main.js
@@ -4,7 +4,7 @@ import "css/app/app.scss";
 import Raven from "raven-js";
 
 
-if(!window.SENTRY_ENABLED) {
+if(window.SENTRY_ENABLED) {
     let sentryDSN = window.SENTRY_DSN;
     Raven.config(sentryDSN, {
         release: window.SENTRY_RELEASE,

--- a/troposphere/static/js/models/InstanceAction.js
+++ b/troposphere/static/js/models/InstanceAction.js
@@ -1,0 +1,7 @@
+import Backbone from "backbone";
+
+import globals from "globals";
+
+export default Backbone.Model.extend({
+    urlRoot: globals.API_V2_ROOT + "/instance_actions"
+});

--- a/troposphere/static/js/public_site/main.js
+++ b/troposphere/static/js/public_site/main.js
@@ -3,7 +3,7 @@ import bootstrapper from "public_site/bootstrapper";
 import Raven from "raven-js";
 
 
-if(!window.SENTRY_ENABLED) {
+if(window.SENTRY_ENABLED) {
     let sentryDSN = window.SENTRY_DSN;
     Raven.config(sentryDSN, {
         release: window.SENTRY_RELEASE,

--- a/troposphere/static/js/stores/InstanceActionStore.js
+++ b/troposphere/static/js/stores/InstanceActionStore.js
@@ -1,0 +1,71 @@
+import _ from "underscore";
+import Backbone from "backbone";
+
+import Store from "stores/Store";
+import Dispatcher from "dispatchers/Dispatcher";
+import InstanceAction from "models/InstanceAction";
+import InstanceActionCollection from "collections/InstanceActionCollection";
+import NotificationController from "controllers/NotificationController";
+
+import globals from "globals";
+
+
+const InstanceActionStore = function(attributes, options) {
+    this.models = null;
+
+    // isFetching: True or false depending on whether this.models is being
+    // fetch from the server. Used to prevent multiple server calls for the same data.
+    this.isFetching = false;
+}
+
+/**
+ * The (Generic) Store provides Events and `emitChange`
+ */
+_.extend(InstanceActionStore, Store, {
+    collection: InstanceActionCollection,
+
+    getActionsFor(instance) {
+        if (!this.models) {
+            return this.fetchFor(instance.get("uuid"));
+        } else {
+            return this.models;
+        }
+    },
+
+    fetchFor(alias) {
+        // alter to a "fetch every time" pattern
+        if (!this.isFetching) {
+            this.isFetching = true;
+            // pass instance alias as `options` to the collection
+            // the :alias attribute is used in fetching _context_
+            // *specific* instance actions - the status of an
+            // instance will determine the possible actions available
+            var models = new this.collection(null, { alias });
+
+            models.fetch().done(() => {
+                this.isFetching = false;
+                this.models = models;
+                this.emitChange();
+            });
+        }
+    }
+});
+
+
+Dispatcher.register(function(payload) {
+    var action = payload.action;
+
+    // Action to handle yet; However, we want to
+    // signal when a change is emitted
+    switch (action.actionType) {
+        default:
+            return true;
+    }
+
+    InstanceActionStore.emitChange();
+
+    return true;
+});
+
+
+export default InstanceActionStore;

--- a/troposphere/static/js/stores/InstanceActionStore.js
+++ b/troposphere/static/js/stores/InstanceActionStore.js
@@ -1,13 +1,9 @@
 import _ from "underscore";
-//import Backbone from "backbone";
 
 import Store from "stores/Store";
 import Dispatcher from "dispatchers/Dispatcher";
+import InstanceConstants from "constants/InstanceConstants";
 import InstanceActionCollection from "collections/InstanceActionCollection";
-//import InstanceAction from "models/InstanceAction";
-//import NotificationController from "controllers/NotificationController";
-
-//import globals from "globals";
 
 
 const InstanceActionStore = function(attributes, options) {
@@ -56,15 +52,26 @@ _.extend(InstanceActionStore, Store, {
 });
 
 
-Dispatcher.register(function(payload) {
-    var action = payload.action;
 
+Dispatcher.register(function(dispatch) {
+    let { actionType, payload } = dispatch.action;
+
+    // ---
     // right now, we want to observer Instance Status changes,
     // and dispatcher whenever that happens ...
-
-    // Action to handle yet; However, we want to
-    // signal when a change is emitted
-    switch (action.actionType) {
+    //
+    // In the case there has been an update - we want to do eager
+    // reload the actions available:
+    switch (actionType) {
+        case InstanceConstants.UPDATE_INSTANCE:
+            InstanceActionStore.updateActionsFor(payload.instance);
+            break;
+        case InstanceConstants.POLL_INSTANCE_WITH_DELAY:
+            InstanceActionStore.updateActionsFor(payload.instance);
+            break;
+        case InstanceConstants.POLL_INSTANCE:
+            InstanceActionStore.updateActionsFor(payload.instance);
+            break;
         default:
             break;
     }

--- a/troposphere/static/js/stores/InstanceActionStore.js
+++ b/troposphere/static/js/stores/InstanceActionStore.js
@@ -32,6 +32,10 @@ _.extend(InstanceActionStore, Store, {
         }
     },
 
+    updateActionsFor(instance) {
+        return this.fetchFor(instance.get("uuid"));
+    },
+
     fetchFor(alias) {
         // alter to a "fetch every time" pattern
         if (!this.isFetching) {

--- a/troposphere/static/js/stores/InstanceActionStore.js
+++ b/troposphere/static/js/stores/InstanceActionStore.js
@@ -55,11 +55,14 @@ _.extend(InstanceActionStore, Store, {
 Dispatcher.register(function(payload) {
     var action = payload.action;
 
+    // right now, we want to observer Instance Status changes,
+    // and dispatcher whenever that happens ...
+
     // Action to handle yet; However, we want to
     // signal when a change is emitted
     switch (action.actionType) {
         default:
-            return true;
+            break;
     }
 
     InstanceActionStore.emitChange();

--- a/troposphere/static/js/stores/InstanceActionStore.js
+++ b/troposphere/static/js/stores/InstanceActionStore.js
@@ -1,13 +1,13 @@
 import _ from "underscore";
-import Backbone from "backbone";
+//import Backbone from "backbone";
 
 import Store from "stores/Store";
 import Dispatcher from "dispatchers/Dispatcher";
-import InstanceAction from "models/InstanceAction";
 import InstanceActionCollection from "collections/InstanceActionCollection";
-import NotificationController from "controllers/NotificationController";
+//import InstanceAction from "models/InstanceAction";
+//import NotificationController from "controllers/NotificationController";
 
-import globals from "globals";
+//import globals from "globals";
 
 
 const InstanceActionStore = function(attributes, options) {

--- a/troposphere/static/js/stores/InstanceActionStore.js
+++ b/troposphere/static/js/stores/InstanceActionStore.js
@@ -6,25 +6,33 @@ import InstanceConstants from "constants/InstanceConstants";
 import InstanceActionCollection from "collections/InstanceActionCollection";
 
 
-const InstanceActionStore = function(attributes, options) {
-    this.models = null;
+let _modelsFor = {};
+let _isFetchingFor = {};
 
-    // isFetching: True or false depending on whether this.models is being
-    // fetch from the server. Used to prevent multiple server calls for the same data.
-    this.isFetching = false;
-}
 
-/**
- * The (Generic) Store provides Events and `emitChange`
- */
-_.extend(InstanceActionStore, Store, {
+const InstanceActionStore = {
     collection: InstanceActionCollection,
 
+    contains(instance) {
+        let alias = instance.get("uuid");
+        return _.has(_modelsFor, alias);
+    },
+
+    isFetching(alias) {
+        return _.has(_isFetchingFor, alias) && _isFetchingFor[alias];
+    },
+
+    clear(instance) {
+        let alias = instance.get("uuid");
+        _modelsFor[alias] = null;
+    },
+
     getActionsFor(instance) {
-        if (!this.models) {
-            return this.fetchFor(instance.get("uuid"));
+        let alias = instance.get("uuid");
+        if (!this.contains(instance)) {
+            return this.fetchFor(alias);
         } else {
-            return this.models;
+            return _modelsFor[alias];
         }
     },
 
@@ -34,8 +42,8 @@ _.extend(InstanceActionStore, Store, {
 
     fetchFor(alias) {
         // alter to a "fetch every time" pattern
-        if (!this.isFetching) {
-            this.isFetching = true;
+        if (!this.isFetching(alias)) {
+            _isFetchingFor[alias] = true;
             // pass instance alias as `options` to the collection
             // the :alias attribute is used in fetching _context_
             // *specific* instance actions - the status of an
@@ -43,14 +51,18 @@ _.extend(InstanceActionStore, Store, {
             var models = new this.collection(null, { alias });
 
             models.fetch().done(() => {
-                this.isFetching = false;
-                this.models = models;
+                _isFetchingFor[alias] = false;
+                _modelsFor[alias] = models;
                 this.emitChange();
             });
         }
     }
-});
+};
 
+/**
+ * Extend the (Generic) "store/Store" to listeners, `emitChange`, & Events
+ */
+_.extend(InstanceActionStore, Store);
 
 
 Dispatcher.register(function(dispatch) {

--- a/troposphere/static/js/stores/InstanceStore.js
+++ b/troposphere/static/js/stores/InstanceStore.js
@@ -55,7 +55,15 @@ var InstanceStore = BaseStore.extend({
     // Polling functions
     // -----------------
 
+    /**
+     * Poll handler, last chance to signal updates for resource
+     */
     isInFinalState: function(instance) {
+
+        Utils.dispatch(InstanceConstants.UPDATE_INSTANCE, {
+            instance: instance
+        });
+
         if (instance.get("state").get("status") == "active" &&
             instance.get("ip_address").charAt(0) == "0") {
             return false;


### PR DESCRIPTION
## Description

This work changes `<InstanceActionsAndLinks ... />` from *hard*-coded to data-driven. It adds a new store to handle fetching "actions" for an _instance_ given the *current* status. 

It leverages the API endpoint `api/v2/instances/:alias/actions` (where `:alias` is a UUID).

When the status of an instance changes, the `InstanceActionStore` will receive that _dispatched_ change and react by fetching the latest "actions" available to that instance. 

See tickets: [ATMO-1413](https://pods.iplantcollaborative.org/jira/browse/ATMO-1413), [ATMO-1268](https://pods.iplantcollaborative.org/jira/browse/ATMO-1268), & [ATMO-1735](https://pods.iplantcollaborative.org/jira/browse/ATMO-1735)

Enables action on: [ATMO-1738](https://pods.iplantcollaborative.org/jira/browse/ATMO-1738)

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] ~Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [x] Reviewed and approved by at least one other contributor.
