### PR TITLE
Implement an explicit way to tie data to a component.

### DIFF
--- a/troposphere/static/js/bootstrapper.js
+++ b/troposphere/static/js/bootstrapper.js
@@ -40,6 +40,8 @@ browserBondo.conditionalFill();
 // Register which stores the image should use
 import stores from "stores";
 
+// NOTE: Any store added needs to be added to subscribe.js. This is temporary
+// and required so that the subscribe function will work for that store.
 stores.AllocationStore = require("stores/AllocationStore");
 stores.BadgeStore = require("stores/BadgeStore");
 stores.ClientCredentialStore = require("stores/ClientCredentialStore");

--- a/troposphere/static/js/components/requests/ResourceHistoryMaster.jsx
+++ b/troposphere/static/js/components/requests/ResourceHistoryMaster.jsx
@@ -1,29 +1,15 @@
 import React from "react";
+
 import ResourceActions from "actions/ResourceActions";
-import stores from "stores";
+import subscribe from "utilities/subscribe";
 import RaisedButton from "material-ui/RaisedButton";
 
-export default React.createClass({
+const MyResourceRequestsPage = React.createClass({
     displayName: "MyResourceRequestsPage",
 
-    componentDidMount: function() {
-        stores.StatusStore.addChangeListener(this.updateState);
-        stores.ProfileStore.addChangeListener(this.updateState);
-        stores.ResourceRequestStore.addChangeListener(this.updateState);
-    },
-
-    componentWillUnmount: function() {
-        stores.StatusStore.removeChangeListener(this.updateState);
-        stores.ProfileStore.removeChangeListener(this.updateState);
-        stores.ResourceRequestStore.removeChangeListener(this.updateState);
-    },
-
-    updateState: function() {
-        this.forceUpdate();
-    },
-
     closeRequest: function(request) {
-        var closedStatus = stores.StatusStore.findWhere({
+        let { StatusStore } = this.props.subscriptions;
+        var closedStatus = StatusStore.findWhere({
             "name": "closed"
         }).models[0].id;
         ResourceActions.close({
@@ -33,14 +19,15 @@ export default React.createClass({
     },
 
     render: function() {
-        var username = stores.ProfileStore.get().id,
-            statusTypes = stores.StatusStore.getAll();
+        let { IdentityStore, ProfileStore, StatusStore, ResourceRequestStore } = this.props.subscriptions;
+        var username = ProfileStore.get().id,
+            statusTypes = StatusStore.getAll();
 
         if (username == null || !statusTypes) {
             return <div className="loading"></div>
         }
 
-        var requests = stores.ResourceRequestStore.findWhere({
+        var requests = ResourceRequestStore.findWhere({
             "created_by.username": username
         });
 
@@ -126,3 +113,5 @@ export default React.createClass({
         );
     }
 });
+
+export default subscribe(MyResourceRequestsPage, ["ProfileStore", "StatusStore", "ResourceRequestStore"]);

--- a/troposphere/static/js/utilities/subscribe.js
+++ b/troposphere/static/js/utilities/subscribe.js
@@ -1,0 +1,97 @@
+import React from "react";
+
+import AllocationStore from "stores/AllocationStore";
+import BadgeStore from "stores/BadgeStore";
+import ClientCredentialStore from "stores/ClientCredentialStore";
+import ExternalLinkStore from "stores/ExternalLinkStore";
+import HelpLinkStore from "stores/HelpLinkStore";
+import ImageStore from "stores/ImageStore";
+import ImageVersionStore from "stores/ImageVersionStore";
+import ImageVersionMembershipStore from "stores/ImageVersionMembershipStore";
+import ImageVersionLicenseStore from "stores/ImageVersionLicenseStore";
+import ImageVersionScriptStore from "stores/ImageVersionScriptStore";
+import IdentityStore from "stores/IdentityStore";
+import ImageBookmarkStore from "stores/ImageBookmarkStore";
+import InstanceHistoryStore from "stores/InstanceHistoryStore";
+import ImageRequestStore from "stores/ImageRequestStore";
+import InstanceStore from "stores/InstanceStore";
+import InstanceTagStore from "stores/InstanceTagStore";
+import LicenseStore from "stores/LicenseStore";
+import ScriptStore from "stores/ScriptStore";
+import MaintenanceMessageStore from "stores/MaintenanceMessageStore";
+import MyBadgeStore from "stores/MyBadgeStore";
+import MembershipStore from "stores/MembershipStore";
+import ProfileStore from "stores/ProfileStore";
+import ProjectStore from "stores/ProjectStore";
+import ProjectExternalLinkStore from "stores/ProjectExternalLinkStore";
+import ProjectImageStore from "stores/ProjectImageStore";
+import ProjectInstanceStore from "stores/ProjectInstanceStore";
+import ProjectVolumeStore from "stores/ProjectVolumeStore";
+import ProviderMachineStore from "stores/ProviderMachineStore";
+import ProviderStore from "stores/ProviderStore";
+import ResourceRequestStore from "stores/ResourceRequestStore";
+import IdentityMembershipStore from "stores/IdentityMembershipStore";
+import StatusStore from "stores/StatusStore";
+import SSHKeyStore from "stores/SSHKeyStore";
+import QuotaStore from "stores/QuotaStore";
+import SizeStore from "stores/SizeStore";
+import TagStore from "stores/TagStore";
+import UserStore from "stores/UserStore";
+import VersionStore from "stores/VersionStore";
+import VolumeStore from "stores/VolumeStore";
+import AllocationSourceStore from "stores/AllocationSourceStore";
+
+// Create a dictionary of all stores
+//
+// We cannot rely on `import stores from 'stores'`, since it is populated too
+// late. This wrapper component wraps the module when it is defined and
+// stores.<STORE_NAME> isn't available then.
+let stores = {
+    AllocationStore, BadgeStore, ClientCredentialStore, ExternalLinkStore, HelpLinkStore, ImageStore, ImageVersionStore, ImageVersionMembershipStore, ImageVersionLicenseStore, ImageVersionScriptStore, IdentityStore, ImageBookmarkStore, InstanceHistoryStore, ImageRequestStore, InstanceStore, InstanceTagStore, LicenseStore, ScriptStore, MaintenanceMessageStore, MyBadgeStore, MembershipStore, ProfileStore, ProjectStore, ProjectExternalLinkStore, ProjectImageStore, ProjectInstanceStore, ProjectVolumeStore, ProviderMachineStore, ProviderStore, ResourceRequestStore, IdentityMembershipStore, StatusStore, SSHKeyStore, QuotaStore, SizeStore, TagStore, UserStore, VersionStore, VolumeStore, AllocationSourceStore,
+}
+
+// Add change listeners to the component for the following stores. The stores
+// will be added to the props of the instance via a prop called subscriptions.
+// Inside the wrapped component:
+//
+//     let { ProfileStore } = this.props.subscriptions;
+//
+// Only stores included in storeNames will be visible to the component
+export default function(component, storeNames) {
+    let subscriptions = {};
+    storeNames.forEach(name => {
+        if (stores[name]) {
+            subscriptions[name] = stores[name];
+        }
+    });
+
+    return React.createClass({
+        componentDidMount: function() {
+            Object.values(subscriptions)
+                  .forEach(store => {
+                      store.addChangeListener(this.updateState)
+                  });
+        },
+
+        componentWillUnmount: function() {
+            Object.values(subscriptions)
+                  .forEach(store => {
+                      store.removeChangeListener(this.updateState)
+                  });
+        },
+
+        updateState: function() {
+            this.forceUpdate();
+        },
+
+        render: function() {
+            // Define the props so that we extend props, with a new prop:
+            // 'subscriptions'
+            let newProps = Object.assign(
+                    {},
+                    this.props,
+                    { subscriptions });
+            return React.createElement(component, newProps);
+        }
+    });
+};

--- a/troposphere/static/js/utilities/subscribe.js
+++ b/troposphere/static/js/utilities/subscribe.js
@@ -62,6 +62,11 @@ export default function(component, storeNames) {
     storeNames.forEach(name => {
         if (stores[name]) {
             subscriptions[name] = stores[name];
+        } else {
+            // If this is thrown either:
+            //    The store needs to be added to the above stores object /OR/
+            //    The store name was a typo and needs to be fixed in the component
+            throw new Error(`The store: ${name} does not exist. It cannot be subscribed to.`);
         }
     });
 


### PR DESCRIPTION
**TLDR:** This is a proposal for new way of adding listeners to stores, should just make it safer and easier to ensure a component doesn't encounter loading issues

**Example:** https://github.com/cyverse/troposphere/pull/561/files#diff-3df49258f0990fc6037016911f22d5bcR4

Whenever a component depends on data (makes calls to stores to fetch data), we
require the good habit of listening to stores, but nothing enforces that.

Many pages didn't listen to the stores on which they depend. They assume a
populated store. A full page refresh on the dependent page will reveal that
its not subscribed to the data. So the data comes back empty on first blush,
and they don't listen to the store for when the real data does arrive.

See [troposphere/static/js/utilities/subscribe.js](https://github.com/cdosborn/troposphere/blob/fbc2a72c831cd3d41c5cec4e1646712f10ba7df7/troposphere/static/js/utilities/subscribe.js#L53-L59) for some brief docs on the
new way to subscribe to stores in a component.

See [components/requests/ResourceHistoryMaster.jsx](https://github.com/cdosborn/troposphere/blob/fbc2a72c831cd3d41c5cec4e1646712f10ba7df7/troposphere/static/js/components/requests/ResourceHistoryMaster.jsx#L117) for an example

## Checklist before merging Pull Requests
- [ ] ~New test(s) included to reproduce the bug/verify the feature~
- [x] Documentation created at [troposphere/static/js/utilities/subscribe.js](https://github.com/cdosborn/troposphere/blob/fbc2a72c831cd3d41c5cec4e1646712f10ba7df7/troposphere/static/js/utilities/subscribe.js#L53-L59) to give context to the feature
- [x] Reviewed and approved by at least one other contributor.
