### PR TITLE
Problem: Instance name requires additional validation

### DIFF
--- a/troposphere/static/js/components/common/EditableInputField.jsx
+++ b/troposphere/static/js/components/common/EditableInputField.jsx
@@ -31,12 +31,27 @@ export default React.createClass({
         }
     },
 
+    onChange: function(e) {
+        this.props.onChange(e.target.value); 
+    },
+
     render: function() {
+        const { text, errorMessage } = this.props
+        const errStyle = errorMessage ? { borderColor: "#df0000" }: null;
         return (
-        <input type="text"
-            defaultValue={this.props.text}
-            onBlur={this.onDoneEditing}
-            onKeyPress={this.onEnterKey} />
+        <div>
+            <input 
+                style={ errStyle }
+                type="text"
+                defaultValue={ text }
+                onBlur={ this.onDoneEditing }
+                onChange={ this.onChange }
+                onKeyPress={ this.onEnterKey }
+            />
+            <div style={{ color: "#df0000" }}>
+                { errorMessage }
+            </div>
+        </div>
         );
     }
 

--- a/troposphere/static/js/components/modals/instance/InstanceLaunchWizardModal.jsx
+++ b/troposphere/static/js/components/modals/instance/InstanceLaunchWizardModal.jsx
@@ -506,8 +506,13 @@ export default React.createClass({
         return true;
     },
 
+    invalidName() {
+      let regex = /\.(\d)+$/gm;
+      return this.state.instanceName.match(regex);
+    },
+
     canLaunch: function() {
-        let requiredFields = ["project", "identityProvider", "providerSize", "imageVersion", "attachedScripts"];
+        let requiredFields = ["instanceName", "project", "identityProvider", "providerSize", "imageVersion", "attachedScripts"];
 
         // Check if we are using AllocationSource and add to requierd fields
         if (globals.USE_ALLOCATION_SOURCES) {
@@ -517,7 +522,11 @@ export default React.createClass({
         // All required fields are truthy
         let requiredExist = _.every(requiredFields, (prop) => Boolean(this.state[prop]))
 
-        return requiredExist && !this.exceedsResources();
+        return ( 
+            requiredExist 
+            && !this.exceedsResources()
+            && !this.invalidName()
+        )
     },
 
     //==================

--- a/troposphere/static/js/components/modals/instance/launch/components/BasicInfoForm.jsx
+++ b/troposphere/static/js/components/modals/instance/launch/components/BasicInfoForm.jsx
@@ -22,22 +22,53 @@ export default React.createClass({
         ReactDOM.findDOMNode(this.refs.nameInput).select();
     },
 
+    nameError() {
+        const { instanceName } = this.props;
+
+        function invalidName() {
+          let regex = /\.(\d)+$/gm;
+          return Boolean(instanceName.match(regex));
+        }
+
+        function missingName() {
+            return !Boolean(instanceName)
+        }
+
+        if (invalidName()) return "invalid";
+        if (missingName()) return "missing";
+    },
+
     render: function() {
-        let imageVersion = this.props.imageVersion;
-        let project = this.props.project;
-        let projectList = this.props.projectList;
-        let instanceName = this.props.instanceName;
-        let instanceNameClasses = "form-group";
+        const { 
+            imageVersion,
+            project,
+            projectList,
+            instanceName,
+            showValidationErr
+        } = this.props;
+        let hasErrorClass;
         let errorMessage = null;
 
-        if (this.props.showValidationErr) {
-            errorMessage = instanceName == "" ? "This field is required" : null;
-            instanceNameClasses = instanceName == "" ? "form-group has-error" : "form-group";
+        let invalidMessage = `Invalid format, names can not end in a period followed by numbers. For example: "Instance Name.2222"`;
+
+        let requiredMessage = "This field is required";
+
+        if (showValidationErr) {
+            switch (this.nameError()) {
+                case "invalid": 
+                    errorMessage = invalidMessage;
+                    hasErrorClass = "has-error";
+                    break;
+                case "missing":
+                    errorMessage = requiredMessage;
+                    hasErrorClass = "has-error";
+                    break;
+            }
         }
 
         return (
         <form>
-            <div className={instanceNameClasses}>
+            <div className={"form-group " + hasErrorClass }>
                 <label htmlFor="instanceName">
                     Instance Name
                 </label>


### PR DESCRIPTION
## Description
Add validation to instance name editing that prevents names ending
in a period followed by a series of numbers. Example: "name.2222"

In recent versions on OpenStack Nova, instance names that end with a period followed by any number of digits will cause a launch error in OpenStack Nova. A simple text validator should work on the launch dialog. If a user enters a name that matches this problematic pattern, the user should not be permitted to launch the instance and an error message should be presented to the user:

“Invalid format, names can not end in period followed by numbers. Example: “name.2222"”

This is linked to: https://iujetstream.atlassian.net/browse/JETSTREAM-139

See [ATMO-1777](https://pods.iplantcollaborative.org/jira/browse/ATMO-1777)

### Message to users:
“Invalid format, names can not end in period followed by numbers. Example: “name.2222"”

### Fields validated:
* Instance Launch Modal, Name field (can launch from Image Detail or Project Resources views)
* Instance Detail, Edit Name field (click on instance name)

### To verify: 
Change the name to anything ending in a period followed by a series of digits. Example: "name.222"
if any of the digits following the period are not digits the name should be allowed. Example: "name.22w" or "name.22w2" or "name."

### Instance Launch Modal
![instanceluanch](https://cloud.githubusercontent.com/assets/7366338/24374917/6a64199a-12eb-11e7-9dba-34b41067d51d.gif)

## Instance Detail 
![instancedetail](https://cloud.githubusercontent.com/assets/7366338/24375013/b238e9bc-12eb-11e7-8ad7-0de0d3086caa.gif)


## Checklist before merging Pull Requests
- [x] Reviewed and approved by at least one other contributor.
