### PR TITLE
Fix tropo to pull size information off instance, and not store

### DIFF
--- a/troposphere/static/js/components/projects/detail/resources/tableData/instance/Size.jsx
+++ b/troposphere/static/js/components/projects/detail/resources/tableData/instance/Size.jsx
@@ -1,6 +1,5 @@
 import React from "react";
 import Backbone from "backbone";
-import stores from "stores";
 
 export default React.createClass({
     displayName: "Size",
@@ -10,17 +9,11 @@ export default React.createClass({
     },
 
     render: function() {
-        var instance = this.props.instance,
-            size = stores.SizeStore.get(instance.get("size").id);
-
-        if (!size) {
-            return (
-            <div className="loading-tiny-inline"></div>
-            );
-        }
+        let instance = this.props.instance;
+        let size = instance.get('size');
 
         return (
-        <span style={{ textTransform: "capitalize" }}>{size.get("name")}</span>
+        <span style={{ textTransform: "capitalize" }}>{size.name}</span>
         );
     }
 });

--- a/troposphere/static/js/components/projects/resources/instance/details/sections/details/Size.jsx
+++ b/troposphere/static/js/components/projects/resources/instance/details/sections/details/Size.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import Backbone from "backbone";
 import ResourceDetail from "components/projects/common/ResourceDetail";
 import stores from "stores";
+import Size from "models/Size"
 
 
 export default React.createClass({
@@ -12,13 +13,11 @@ export default React.createClass({
     },
 
     render: function() {
-        var instance = this.props.instance,
-            size = stores.SizeStore.get(instance.get("size").id);
+        let instance = this.props.instance;
+        let size = instance.get('size');
 
-        if (!size) {
-            return (
-            <div className="loading-tiny-inline"></div>
-            );
+        if (!(size instanceof Size)) {
+            size = new Size(size);
         }
 
         return (


### PR DESCRIPTION
## Description

Prior an instance's size in details views would be looked up in the size store
which mirroed /api/v2/sizes. When an admin end-dates sizes, the sizes are no
longer at the api and correspondingly in the store resulting in a failed
lookup. Now troposphere just relies on the size information attached to the
instance.

Related jira: https://pods.iplantcollaborative.org/jira/browse/ATMO-1797

## Testing
I end dated the sizes that my instances were referring and checked the following views.

### `/application/instances/<instance>`
![screen shot 2017-04-03 at 11 19 19 am](https://cloud.githubusercontent.com/assets/3847314/24624174/d65b1dfa-185f-11e7-8e4c-9de02d690498.png)

### `/application/projects/<project>/instances/<instance>`
![screen shot 2017-04-03 at 11 22 49 am](https://cloud.githubusercontent.com/assets/3847314/24624238/fe695ab4-185f-11e7-85ad-5af4f3ec4926.png)

### `/application/projects/<project>/resources`
![screen shot 2017-04-03 at 11 25 30 am](https://cloud.githubusercontent.com/assets/3847314/24624338/6377625c-1860-11e7-9ef1-031fa6a6357e.png)


## Checklist before merging Pull Requests
- [x] New test(s) included to reproduce the bug/verify the feature
- [ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature
- [x] Reviewed and approved by at least one other contributor.
