### PR TITLE
Fix bad import to use .js rather than .json

### DIFF
--- a/troposphere/static/theme/appTheme.js
+++ b/troposphere/static/theme/appTheme.js
@@ -1,4 +1,4 @@
-import cyverseTheme from 'cyverse-ui/styles/cyverseTheme.json';
+import cyverseTheme from 'cyverse-ui/styles/cyverseTheme.js';
 import theme from './theme.json';
 import _ from 'lodash';
 


### PR DESCRIPTION
## Description

Webpack doesn't build because of a bad import. Should be `.js` not `.json`.

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature
- [ ] Reviewed and approved by at least one other contributor.
