### PR TITLE
Problem: footer override is not position correctly on mobile

### DIFF
--- a/troposphere/static/css/app/footer.scss
+++ b/troposphere/static/css/app/footer.scss
@@ -6,6 +6,9 @@
   border-top: 1px solid #dddddd;
   text-align: center;
   line-height: 48px;
+  @media (max-width: 990px) {
+    position: relative;
+  }
 
   button {
     margin-left: 20px;

--- a/troposphere/static/css/app/layout.scss
+++ b/troposphere/static/css/app/layout.scss
@@ -1,6 +1,7 @@
 #main {
   padding-top: 52px;
   padding-bottom: 80px;
+  min-height: 100vh;
 
   @media (min-width:768px) and (max-width:1200px) {
     padding-top:103px;


### PR DESCRIPTION
Footer should have `position = relative` on smaller screens.

If the footer is *not* relative, then it appears in a fixed width and is always visible (potentially occluding other components).

## Footer on smaller screens, _without_ relative positioning
<img width="338" alt="screen shot 2017-04-04 at 12 04 07 pm" src="https://cloud.githubusercontent.com/assets/7366338/24675280/62f0ed70-1933-11e7-9e6e-48a4f499441e.png">
Note the presence of the footer element at the bottom.

## Footer, with relative positioning
The end result of merging is this view:
<img width="328" alt="screen shot 2017-04-04 at 12 36 29 pm" src="https://cloud.githubusercontent.com/assets/7366338/24675271/5b3fb624-1933-11e7-8da6-461f26d09386.png">
This reclaims the viewport to show as much of the content as possible.
