### PR TITLE
Problem: memory for an instance detail is shown in KB for labeled in GB

### DIFF
--- a/troposphere/static/js/models/Size.js
+++ b/troposphere/static/js/models/Size.js
@@ -5,11 +5,12 @@ import moment from "moment";
 export default Backbone.Model.extend({
     urlRoot: globals.API_V2_ROOT + "/sizes",
 
-    parse: function(response) {
-        response.mem = response.mem / 1024;
-        response.start_date = moment(response.start_date);
-        response.end_date = moment(response.end_date);
-        return response;
+    initialize: function(attributes, option) {
+        return Object.assign({}, attributes, {
+            mem: attributes.mem / 1024,
+            start_date : moment(attributes.start_date),
+            end_date : moment(attributes.end_date)
+        });
     },
 
     formattedDetails: function() {


### PR DESCRIPTION
## Description

In #568, we fixed how the instance's size model was being fetched. But we ran into the fact that `models/Size` returned from `SizeStore` are done use following a call to `Backbone#parse` and new instances of `models/Size` are *not*. 

Here, the work in the pull request makes it so that getting an instance from `SizeStore` or `new models/Size(...)` are consistent and the right normalization of `mem` is applied appropriated.

The root issue is discussed further in 	8a34cde. 

See also [ATMO-1798](https://pods.iplantcollaborative.org/jira/browse/ATMO-1798)

## Checklist before merging Pull Requests
- [ ] ~New test(s) included to reproduce the bug/verify the feature~
- [ ]  ~No Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Reviewed and approved by at least one other contributor.
