### PR TITLE
Problem: Regression, MUI Button style broken by footer line-height property

### DIFF
--- a/troposphere/static/css/app/footer.scss
+++ b/troposphere/static/css/app/footer.scss
@@ -7,7 +7,6 @@
   background-color: #eeeeee;
   border-top: 1px solid #dddddd;
   text-align: center;
-  line-height: 48px;
 
   @media (max-width: 990px) {
     position: relative;


### PR DESCRIPTION
## Description
This fixes a regression on master undoing work in [this commit](https://github.com/Tharon-C/troposphere/commit/cff8c06943e11efd77ca504cc54f4b8dc3601801)

The Support Button style in the footer was broken by a `line-height` property set on the footer.  

Typographic styles affect everything below the element they are applied to. Because of this it is best practice to set typography styles on the element you want to change using a class name.

In the case of the footer using `line-height` to manage the height of an element is not the way. Better to use padding or min-height as these only affect the element they are applied to and are flexible to the content within. In other words, zooming in or out the portal or changing font-size won't break the layout.  

### Support Button before change
<img width="639" alt="screen shot 2017-04-06 at 11 45 47 am" src="https://cloud.githubusercontent.com/assets/7366338/24771585/0791ebbe-1ac3-11e7-9a9c-b3327028ccf1.png">

### Support Button after change
<img width="553" alt="screen shot 2017-04-06 at 11 46 26 am" src="https://cloud.githubusercontent.com/assets/7366338/24771602/1619da84-1ac3-11e7-9518-660fe1eae629.png">


## Checklist before merging Pull Requests
- [x] Reviewed and approved by at least one other contributor.
