### PR TITLE
Problem: Admin page can be viewed by non-staff through URL

### DIFF
--- a/troposphere/static/js/AppRoutes.jsx
+++ b/troposphere/static/js/AppRoutes.jsx
@@ -7,7 +7,6 @@ import { Router,
 
 import globals from "globals";
 
-
 import Master from "./components/Master";
 import BadgeMaster from "./components/badges/BadgeMaster";
 import MyBadges from "./components/badges/MyBadges";
@@ -42,6 +41,7 @@ import AtmosphereUserMaster from "./components/admin/AtmosphereUserMaster";
 import ImageMaster from "./components/admin/ImageMaster";
 import ImageRequest from "./components/admin/ImageRequest";
 import IdentityMembershipMaster from "./components/admin/IdentityMembershipMaster";
+import NotFoundPage from "./components/NotFoundPage";
 
 const providersRoute = (
 <Route path="providers" component={ProvidersMaster}>
@@ -51,55 +51,69 @@ const providersRoute = (
 </Route>
 )
 
-const appRoutes = (
-<Route path="/" component={Master}>
-    <Route path="dashboard" component={DashboardPage} />
-    <Route path="projects" component={ProjectsMaster}>
-        <Route path=":projectId" component={ProjectDetailsMaster}>
-            <Route path="details" component={ProjectDetailsPage} />
-            <Route path="resources" component={ProjectResourcesPage} />
-            <Route path="instances/:instanceId" component={ProjectInstancePage} />
-            <Route path="volumes/:volumeId" component={ProjectVolumePage} />
-            <Route path="links/:linkId" component={ProjectLinkPage} />
-            <IndexRoute component={ProjectDetailsPage} />
-        </Route>
-        <IndexRoute component={ProjectListPage} />
-    </Route>
-    <Route path="images" component={ImagesMaster}>
-        <IndexRedirect to="search" />
-        <Route path="search" component={ImageListPage} />
-        <Route path="favorites" component={FavoritedImagesPage} />
-        <Route path="authored" component={MyImagesPage} />
-        <Route path="my-image-requests" component={MyImageRequestsPage} />
-        <Route path="tags" component={ImageTagsPage} />
-        <Route path=":imageId" component={ImageDetailsPage} />
-    </Route>
-    {globals.USE_ALLOCATION_SOURCES
-     ? null
-     : providersRoute}
-    <Route path="help" component={HelpPage} />
-    <Route path="settings" component={SettingsPage} />
-    <Route path="admin" component={AdminMaster}>
-        <Route name="atmosphere-user-manager" path="users" component={AtmosphereUserMaster} />
-        <Route name="identity-membership-manager" path="identities" component={IdentityMembershipMaster} />
-        <Route name="image-request-manager" path="imaging-requests" component={ImageMaster}>
-            <Route name="image-request-detail" path=":id" component={ImageRequest} />
-        </Route>
-        <IndexRoute component={AtmosphereUserMaster} />
-    </Route>
-    <Route path="badges" component={BadgeMaster}>
-        <Route path="my-badges" component={MyBadges} />
-        <Route path="all-badges" component={AllBadges} />
-        <Route path="unearned-badges" component={UnearnedBadges} />
-    </Route>
-    <Route path="my-requests" component={RequestMaster}>
-        <Route path="resources" component={RequestHistory} />
-        <Route path="images" component={MyImageRequestsPage} />
-    </Route>
-    <Route path="instances/:id" component={NewInstanceDetail} />
-    <IndexRoute component={DashboardPage} />
-    <IndexRedirect to="dashboard" />
-</Route>
-);
+function AppRoutes(props) {
+    const { profile } = props;
 
-export default appRoutes;
+    const staffOnly = (StaffView, PubView) => {
+        return profile.get('is_staff') ? StaffView : PubView;
+    };
+
+    return (
+        <Route path="/" component={Master}>
+            <Route path="dashboard" component={DashboardPage} />
+            <Route path="projects" component={ProjectsMaster}>
+                <Route path=":projectId" component={ProjectDetailsMaster}>
+                    <Route path="details" component={ProjectDetailsPage} />
+                    <Route path="resources" component={ProjectResourcesPage} />
+                    <Route path="instances/:instanceId" component={ProjectInstancePage} />
+                    <Route path="volumes/:volumeId" component={ProjectVolumePage} />
+                    <Route path="links/:linkId" component={ProjectLinkPage} />
+                    <IndexRoute component={ProjectDetailsPage} />
+                </Route>
+                <IndexRoute component={ProjectListPage} />
+            </Route>
+            <Route path="images" component={ImagesMaster}>
+                <IndexRedirect to="search" />
+                <Route path="search" component={ImageListPage} />
+                <Route path="favorites" component={FavoritedImagesPage} />
+                <Route path="authored" component={MyImagesPage} />
+                <Route path="my-image-requests" component={MyImageRequestsPage} />
+                <Route path="tags" component={ImageTagsPage} />
+                <Route path=":imageId" component={ImageDetailsPage} />
+            </Route>
+            {globals.USE_ALLOCATION_SOURCES
+             ? null
+             : providersRoute}
+            <Route path="help" component={HelpPage} />
+            <Route path="settings" component={SettingsPage} />
+            <Route
+                path="admin"
+                component={staffOnly(
+                    AdminMaster, NotFoundPage
+                )}
+            >
+                <Route name="atmosphere-user-manager" path="users" component={AtmosphereUserMaster} />
+                <Route name="identity-membership-manager" path="identities" component={IdentityMembershipMaster} />
+                <Route name="image-request-manager" path="imaging-requests" component={ImageMaster}>
+                    <Route name="image-request-detail" path=":id" component={ImageRequest} />
+                </Route>
+                <IndexRoute component={AtmosphereUserMaster} />
+            </Route>
+            <Route path="badges" component={BadgeMaster}>
+                <Route path="my-badges" component={MyBadges} />
+                <Route path="all-badges" component={AllBadges} />
+                <Route path="unearned-badges" component={UnearnedBadges} />
+            </Route>
+            <Route path="my-requests" component={RequestMaster}>
+                <Route path="resources" component={RequestHistory} />
+                <Route path="images" component={MyImageRequestsPage} />
+            </Route>
+            <Route path="instances/:id" component={NewInstanceDetail} />
+            <IndexRoute component={DashboardPage} />
+            <IndexRedirect to="dashboard" />
+        </Route>
+    )
+};
+
+
+export default AppRoutes;

--- a/troposphere/static/js/components/SplashScreen.jsx
+++ b/troposphere/static/js/components/SplashScreen.jsx
@@ -13,7 +13,7 @@ import { Router,
 import context from "context";
 import stores from "stores";
 
-import routes from "../AppRoutes";
+import Routes from "../AppRoutes";
 import { withAppBasename } from "utilities/historyFunctions";
 
 import Raven from "raven-js";
@@ -83,6 +83,7 @@ export default React.createClass({
     },
 
     startApplication: function() {
+        const ProfileStore = stores.ProfileStore.get();
 
         $("body").removeClass("splash-screen");
 
@@ -96,7 +97,7 @@ export default React.createClass({
                     history={withAppBasename(browserHistory)}
                     onChange={() => window.Intercom("update")}
                 >
-                    {routes}
+                    { Routes({ profile: ProfileStore }) }
                 </Router>
             </MuiThemeProvider>
         );


### PR DESCRIPTION
## Description
This resolves [ATMO-1564](https://pods.iplantcollaborative.org/jira/browse/ATMO-1564)
Non-staff shouldn't be able to see the admin page. 
However, if a non-staff user visits the admin URL path, the admin page will show. 

Instead, a "page not found" view should be shown id the user is non-staff.

## Page shown to non-staff users
`./application/admin`
<img width="1223" alt="screen shot 2017-04-07 at 2 45 43 pm" src="https://cloud.githubusercontent.com/assets/7366338/24824094/ea116f58-1bba-11e7-84a8-881128703349.png">

## Page shown to staff users
`./application/admin`
<img width="1209" alt="screen shot 2017-04-07 at 5 53 33 pm" src="https://cloud.githubusercontent.com/assets/7366338/24824114/2abde770-1bbb-11e7-966d-852a635ada3e.png">


## Checklist before merging Pull Requests
- [ ] Reviewed and approved by at least one other contributor.
