### PR TITLE
Problem: Layout on Create Tag Step is broken and semantics are wrong

### DIFF
--- a/troposphere/static/js/components/modals/instance/image/components/Tags.jsx
+++ b/troposphere/static/js/components/modals/instance/image/components/Tags.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import Backbone from "backbone";
 import stores from "stores";
 import actions from "actions";
+import RaisedButton from "material-ui/RaisedButton";
 import TagMultiSelect from "components/common/tags/TagMultiSelect";
 
 
@@ -117,26 +118,44 @@ export default React.createClass({
 
     renderTagCreateForm() {
         return (
-        <div className="form-group">
-            <label htmlFor="tag-create" className="control-label">
+        <div className="form-group clearfix">
+            <h3
+                className="t-title"
+                style={{
+                    marginBottom: "20px"
+                }}
+            >
                 Create new tag
-            </label>
-            <form>
-                <span>Name:</span>
-                <input className="form-control"
-                    type="text"
-                    onChange={this.onNewTagNameChange}
-                    value={this.state.newTagName} />
-                <br />
-                <span>Description:</span>
-                <textarea className="form-control"
-                    type="text"
-                    onChange={this.onNewTagDescriptionChange}
-                    value={this.state.newTagDescription} />
+            </h3>
+            <form className="clearfix">
+                <div className="form-group">
+                    <label htmlFor="newTagName">Name</label>
+                    <input
+                        id="newTagName"
+                        className="form-control"
+                        type="text"
+                        onChange={this.onNewTagNameChange}
+                        value={this.state.newTagName}
+                    />
+                </div>
+                <div className="form-group">
+                    <label htmlFor="newTagDescription">Description</label>
+                    <textarea
+                        id="newTagDescription"
+                        className="form-control"
+                        type="text"
+                        onChange={this.onNewTagDescriptionChange}
+                        value={this.state.newTagDescription}
+                    />
+                </div>
             </form>
-            <button disabled={!this.isSubmittable()} onClick={this.createTagAndAddToImage} className="btn btn-primary btn-sm pull-right">
-                Create and add
-            </button>
+            <RaisedButton
+                primary
+                disabled={!this.isSubmittable()}
+                onTouchTap={this.createTagAndAddToImage}
+                className="pull-right"
+                label="Create and add"
+            />
         </div>
         );
     },


### PR DESCRIPTION
## Description
This PR resolves [ATMO-1702](https://pods.iplantcollaborative.org/jira/browse/ATMO-1702)
When a user tries to create a new tag from the Create Image Modal the layout is broken as the "create and add" button overlaps the modal footer.

### Bonus
* The labels for the input fields were `span` tags. These were swapped for `label` tags and given the `htmlFor` attributes connecting them to the added input `id`s. This helps screen readers know what the input is for, since blind people can't see the relationship between the label and input. 
* The Bootstrap button was replaced with a MUI RaisedButton.

### To Do
The `AddTag` select field is still focused when the `CreateTag` form is exposed. This keeps the user's attention in the wrong place. Better would be to move the focus the the description field. 
This is will be resolved by [ATMO-1804](https://pods.iplantcollaborative.org/jira/browse/ATMO-1804)
 
### Before Change
<img width="606" alt="screen shot 2017-04-09 at 12 17 19 pm" src="https://cloud.githubusercontent.com/assets/7366338/24840250/956dfe3e-1d1e-11e7-8e46-6b69d64b7ca3.png">

### After Change
<img width="670" alt="screen shot 2017-04-09 at 12 16 13 pm" src="https://cloud.githubusercontent.com/assets/7366338/24840253/a04c240c-1d1e-11e7-9b47-07127d72dfa8.png">

## Checklist before merging Pull Requests
- [x] Reviewed and approved by at least one other contributor.
