### PR TITLE
Problem: When creating a new tag focus stays on search field 

### DIFF
--- a/troposphere/static/js/components/mixins/ChosenMixinExternal.jsx
+++ b/troposphere/static/js/components/mixins/ChosenMixinExternal.jsx
@@ -81,6 +81,12 @@ export default {
     onEnter: function(e) {
         if (e.which !== ENTER_KEY) return;
 
+        // Stops the enter event from bubbling out to other elements.
+        // If we want to say move focus to the another field on enter, a line break (\n)
+        // would be passed to that field causing the line break to be added before the cursor.
+        e.preventDefault();
+        e.stopPropagation();
+
         var value = e.target.value;
 
         if (this.onEnterKeyPressed) {

--- a/troposphere/static/js/components/modals/instance/image/components/TagCreateForm.jsx
+++ b/troposphere/static/js/components/modals/instance/image/components/TagCreateForm.jsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import RaisedButton from "material-ui/RaisedButton";
+
+export default React.createClass({
+    componentDidMount() {
+        this.tagDescription.focus();
+    },
+
+    render() {
+        const {
+            isSubmittable,
+            createTagAndAddToImage,
+            newTagDescription,
+            newTagName,
+            onNewTagDescriptionChange,
+            onNewTagName,
+            onNewTagNameChange,
+
+        } = this.props;
+
+        return (
+        <div className="form-group clearfix">
+            <h3
+                style={{
+                    marginBottom: "20px"
+                }}
+                className="t-title"
+            >
+                Create new tag
+            </h3>
+            <form>
+                <div className="form-group">
+                    <label htmlFor="newTagName">Name</label>
+                    <input
+                        id="newTagName"
+                        className="form-control"
+                        type="text"
+                        onChange={ onNewTagNameChange }
+                        value={ newTagName }
+                    />
+                </div>
+                <div className="form-group">
+                    <label htmlFor="newTagDescription">Description</label>
+                    <textarea
+                        ref={(input) => { this.tagDescription = input; }}
+                        id="newTagDescription"
+                        className="form-control"
+                        type="text"
+                        onChange={ onNewTagDescriptionChange }
+                        value={ newTagDescription }
+                    />
+                </div>
+            </form>
+            <RaisedButton
+                primary
+                disabled={ !isSubmittable() }
+                onTouchTap={ createTagAndAddToImage }
+                className="pull-right"
+                label="Create and add"
+            />
+        </div>
+        );
+    },
+});

--- a/troposphere/static/js/components/modals/instance/image/components/Tags.jsx
+++ b/troposphere/static/js/components/modals/instance/image/components/Tags.jsx
@@ -2,8 +2,8 @@ import React from "react";
 import Backbone from "backbone";
 import stores from "stores";
 import actions from "actions";
-import RaisedButton from "material-ui/RaisedButton";
 import TagMultiSelect from "components/common/tags/TagMultiSelect";
+import TagCreateForm from "./TagCreateForm";
 
 
 export default React.createClass({
@@ -104,59 +104,31 @@ export default React.createClass({
         }
 
         return (
-        <TagMultiSelect models={filteredTags}
-            activeModels={filteredImageTags}
-            onCreateNewTag={this.onCreateNewTag}
-            onModelAdded={this.props.onTagAdded}
-            onModelRemoved={this.props.onTagRemoved}
-            onModelCreated={this.props.onTagCreated}
-            onQueryChange={this.onQueryChange}
-            width={"100%"}
-            placeholderText="Search by tag name..." />
+            <TagMultiSelect
+                models={filteredTags}
+                activeModels={filteredImageTags}
+                onCreateNewTag={this.onCreateNewTag}
+                onModelAdded={this.props.onTagAdded}
+                onModelRemoved={this.props.onTagRemoved}
+                onModelCreated={this.props.onTagCreated}
+                onQueryChange={this.onQueryChange}
+                width={"100%"}
+                placeholderText="Search by tag name..."
+            />
         );
     },
 
     renderTagCreateForm() {
         return (
-        <div className="form-group clearfix">
-            <h3
-                className="t-title"
-                style={{
-                    marginBottom: "20px"
-                }}
-            >
-                Create new tag
-            </h3>
-            <form className="clearfix">
-                <div className="form-group">
-                    <label htmlFor="newTagName">Name</label>
-                    <input
-                        id="newTagName"
-                        className="form-control"
-                        type="text"
-                        onChange={this.onNewTagNameChange}
-                        value={this.state.newTagName}
-                    />
-                </div>
-                <div className="form-group">
-                    <label htmlFor="newTagDescription">Description</label>
-                    <textarea
-                        id="newTagDescription"
-                        className="form-control"
-                        type="text"
-                        onChange={this.onNewTagDescriptionChange}
-                        value={this.state.newTagDescription}
-                    />
-                </div>
-            </form>
-            <RaisedButton
-                primary
-                disabled={!this.isSubmittable()}
-                onTouchTap={this.createTagAndAddToImage}
-                className="pull-right"
-                label="Create and add"
+            <TagCreateForm
+                isSubmittable={ this.isSubmittable }
+                createTagAndAddToImage={ this.createTagAndAddToImage }
+                newTagDescription={ this.state.newTagDescription }
+                newTagName={ this.state.newTagName }
+                onNewTagDescriptionChange={ this.onNewTagDescriptionChange }
+                onNewTagName={ this.onNewTagName }
+                onNewTagNameChange={ this.onNewTagNameChange }
             />
-        </div>
         );
     },
 


### PR DESCRIPTION
## Description
Resolves [ATMO-1804](https://pods.iplantcollaborative.org/jira/browse/ATMO-1804)
When creating a new tag on the Create Image Request Modal. The focus stays on the search field rather than moving to the description field (the next field a user would want to fill). Because this field is a bit further down and there is no animation it would be easy for a user to not realize that a new form section was added, or at the least it is inconvenient. 

This PR moves the focus to the next empty field (the description field) so that the attention is in the right place, the screen scrolls down and the user doesn't have to grab the mouse. 

### TODO
Testing this I became aware that the tags are not being added to the image after they are created like the button "Create and Add" suggests. This will be fixed in [ATMO-1701](https://pods.iplantcollaborative.org/jira/browse/ATMO-1701)

### Before
Shows that the search field is still focused after hitting enter, causing the new form section to be hidded and the user to have to scroll.

![before](https://cloud.githubusercontent.com/assets/7366338/24874981/58190872-1ddb-11e7-88f9-1e45fd5757f5.gif)

### After
Shows that the focus moves to the next appropriate field after hitting enter, revealing  the newly added section. 

![after](https://cloud.githubusercontent.com/assets/7366338/24875112/ca95a63a-1ddb-11e7-927f-cb65570302e5.gif)


## Checklist before merging Pull Requests
- [x] Reviewed and approved by at least one other contributor.
