### PR TITLE
Problem: "Create and Add" creates only, doesn't add

### DIFF
--- a/troposphere/static/js/components/modals/instance/image/components/Tags.jsx
+++ b/troposphere/static/js/components/modals/instance/image/components/Tags.jsx
@@ -84,14 +84,16 @@ export default React.createClass({
     },
 
     allowAccessFilter(tag) {
-        return tag.get("allow_access");
+        // The 'allow_access' field determines if a user can see/use the tag.
+        // If the tag has not been persisted yet, but the user was allowed to
+        // make it, we assume they can see/use it.
+        return tag.isNew() || tag.get("allow_access");
     },
 
     renderTagSelect() {
         let imageTags = this.props.imageTags;
         let tags = this.state.tags;
         let query = this.state.query;
-
         let filteredImageTags = imageTags.cfilter(this.allowAccessFilter);
         let filteredTags = tags.cfilter(this.allowAccessFilter);
 

--- a/troposphere/static/js/components/modals/instance/image/steps/ImageInfoStep.jsx
+++ b/troposphere/static/js/components/modals/instance/image/steps/ImageInfoStep.jsx
@@ -24,6 +24,7 @@ export default React.createClass({
     componentDidMount: function() {
         stores.ImageStore.addChangeListener(this.updateState);
         stores.TagStore.addChangeListener(this.updateState);
+
         this.updateState();
     },
 
@@ -40,27 +41,19 @@ export default React.createClass({
             defaultName = instance.get("image").name;
             defaultDescription = instance.get("image").description;
         }
+        let imageTags = new TagCollection(instance.get("image").tags);
 
         return {
             name: defaultName,
             nameError: this.setNameError(defaultName),
             description: defaultDescription,
             newImage: true,
-            imageTags: null,
+            imageTags,
         }
     },
 
     updateState: function() {
-        let instance = this.props.instance;
-        let parent_image_tags = instance.get("image").tags;
-        let toTagList = parent_image_tags.map(function (api_tag) {
-            return new Tag(api_tag, {parse: true});
-        });
-        let imageTags = new TagCollection(toTagList);
-
-        this.setState({
-            imageTags
-        });
+        this.forceUpdate();
     },
 
     isValidName: function(input) {


### PR DESCRIPTION
## Description
This PR resolves [ATMO-1701](https://pods.iplantcollaborative.org/jira/browse/ATMO-1701)
From the Image Request Modal, when creating a new tag it is expected after filling out the new tag form and clicking "Create and Add" that the new tag will be added to the list of tags for the image. Instead the tag is created but is not added to the list. 

The issues are that we are filtering the list for tags with "allow_access = true" yet this is handled on the server and the tag is optimistically added to the tag list so "allow_access" would be falsy. And the updateState method is blowing away our modified tag list when the store updates.   

This PR adds black list validation to the client so that optimistic updates to tags map more closely to the modals created on the server. (currently just stubbed out).

### Shows feature is now working
Note newly created tag is added to the list. 


![after](https://cloud.githubusercontent.com/assets/7366338/24924370/6357b868-1ea9-11e7-989e-7b87da6270cd.gif)


## Checklist before merging Pull Requests
- [ ] Reviewed and approved by at least one other contributor.
