### PR TITLE
Problem: memory shown in MB but labeled as GB

### DIFF
--- a/troposphere/static/js/components/projects/resources/instance/details/sections/details/Size.jsx
+++ b/troposphere/static/js/components/projects/resources/instance/details/sections/details/Size.jsx
@@ -17,7 +17,7 @@ export default React.createClass({
         let size = instance.get('size');
 
         if (!(size instanceof Size)) {
-            size = new Size(size);
+            size = new Size(size, {parse: true});
         }
 
         return (

--- a/troposphere/static/js/models/Size.js
+++ b/troposphere/static/js/models/Size.js
@@ -5,11 +5,11 @@ import moment from "moment";
 export default Backbone.Model.extend({
     urlRoot: globals.API_V2_ROOT + "/sizes",
 
-    initialize: function(attributes, option) {
-        return Object.assign({}, attributes, {
-            mem: attributes.mem / 1024,
-            start_date : moment(attributes.start_date),
-            end_date : moment(attributes.end_date)
+    parse: function (response) {
+        return Object.assign({}, response, {
+            mem: response.mem / 1024,
+            start_date: moment(response.start_date),
+            end_date: moment(response.end_date)
         });
     },
 

--- a/troposphere/static/js/models/Size.js
+++ b/troposphere/static/js/models/Size.js
@@ -5,11 +5,12 @@ import moment from "moment";
 export default Backbone.Model.extend({
     urlRoot: globals.API_V2_ROOT + "/sizes",
 
-    parse: function(response) {
-        response.mem = response.mem / 1024;
-        response.start_date = moment(response.start_date);
-        response.end_date = moment(response.end_date);
-        return response;
+    initialize: function(attributes, option) {
+        return Object.assign({}, attributes, {
+            mem: attributes.mem / 1024,
+            start_date : moment(attributes.start_date),
+            end_date : moment(attributes.end_date)
+        });
     },
 
     formattedDetails: function() {


### PR DESCRIPTION
## Description

Changes in the Whimsical-Wyvern hotfix regarding how instances of `models/Size` were fetched introduced an issue with the appearance of size data on the Instance Detail view. 

The root cause was related to the model being created as a `new` instance, not fetched via a "store". This work eliminates the "visual" inconsistency with KB shown with the label of GB. 

There still is a conflict that remains in the codebase with how instances of `models/Size` are created.

<details>

An important detail with this work is that is addresses the issue without creating any more problems. The work done in #574 fixed the issue with Instance Detail view, but introduced problems with other occurrences of `models/Size`. 

Reported as [ATMO-1798](https://pods.iplantcollaborative.org/jira/browse/ATMO-1798)

Below are screenshots to help show that all occurrences of `models/Size` are rendering correctly:

<img width="998" alt="screen shot 2017-04-12 at 11 19 28 am" src="https://cloud.githubusercontent.com/assets/5923/24972935/ed086f08-1f71-11e7-9ea0-059a018ac834.png">

<img width="999" alt="screen shot 2017-04-12 at 11 18 58 am" src="https://cloud.githubusercontent.com/assets/5923/24972934/ed0806ee-1f71-11e7-9360-36590a7d909a.png">

<img width="999" alt="screen shot 2017-04-12 at 11 18 36 am" src="https://cloud.githubusercontent.com/assets/5923/24972933/ed07eb82-1f71-11e7-988e-ba88e95ade48.png">

<img width="500" alt="screen shot 2017-04-12 at 11 18 22 am" src="https://cloud.githubusercontent.com/assets/5923/24972932/ed080dd8-1f71-11e7-920f-669a6ed877d4.png">

</details>


## Checklist before merging Pull Requests
- [ ] ~New test(s) included to reproduce the bug/verify the feature~
- [ ] ~Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [x] Reviewed and approved by at least one other contributor
