### PR TITLE
Problem: "My Image Requests" table inconsistent with rest of app 

### DIFF
--- a/troposphere/static/css/app/app.scss
+++ b/troposphere/static/css/app/app.scss
@@ -87,6 +87,7 @@ $icon-font-path: "~bootstrap-sass/assets/fonts/bootstrap/";
 @import "badges";
 @import "images";
 @import "media-cards";
+@import "cy-table";
 @import "TabLinks";
 @import "tags";
 @import "toastr_mods";

--- a/troposphere/static/css/app/cy-table.scss
+++ b/troposphere/static/css/app/cy-table.scss
@@ -1,0 +1,12 @@
+.cy-Table {
+    th {
+        font-size: 16px;
+        white-space: nowrap;
+        padding: 10px;
+    }
+    td {
+        padding: 10px;
+        border: none;
+        vertical-align: center;
+    }
+}

--- a/troposphere/static/css/app/utilities.scss
+++ b/troposphere/static/css/app/utilities.scss
@@ -13,3 +13,7 @@
         float: none !important;
     }
 }
+
+.u-noWrap {
+    white-space: nowrap;
+}

--- a/troposphere/static/js/components/images/MyImageRequestsPage.jsx
+++ b/troposphere/static/js/components/images/MyImageRequestsPage.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import modals from "modals";
 import moment from "moment";
+import CopyButton from "components/common/ui/CopyButton";
 import RefreshComponent from "components/projects/resources/instance/details/sections/metrics/RefreshComponent";
 import stores from "stores";
 
@@ -70,7 +71,7 @@ export default React.createClass({
         if (stores.ProfileStore.get().get("is_staff")) {
             machineStateColumn = (
                 <th>
-                    <h3 className="t-title">Machine State</h3>
+                    Machine State
                 </th>
             );
         }
@@ -95,21 +96,25 @@ export default React.createClass({
 
         var displayRequests = requests.map(function(request) {
 
+            let requestStatus = request.get("status").name;
             // set the color of the row based on the status of the request
             var trClass,
                 endDateText = "N/A";
-            switch (request.get("status").name) {
+            switch (requestStatus) {
                 case "completed":
-                    trClass = "success";
+                    trClass = "active";
                     break;
                 case "approved":
-                    trClass = "success";
+                    trClass = "active";
+                    break;
+                case "validating":
+                    trClass = "transition";
                     break;
                 case "denied":
-                    trClass = "warning"
+                    trClass = "error"
                     break;
                 default:
-                    trClass = "active"
+                    trClass = ""
                     break;
             }
 
@@ -126,24 +131,42 @@ export default React.createClass({
             var newMachineId = !!request.get("new_machine") ? request.get("new_machine").uuid : "N/A";
             var newMachineProvider = !!request.get("new_machine_provider") ? request.get("new_machine_provider").name : "Unknown";
 
-            return <tr className={trClass}>
-                       <td>
-                           {moment(request.get("start_date")).format("MMM D, YYYY h:mm:ss a")}
-                       </td>
-                       <td>
-                           {endDateText}
-                       </td>
-                       <td>
-                           {request.get("instance").uuid + " - " + request.get("instance").name}
-                       </td>
-                       <td>
-                           {request.get("status").name}
-                       </td>
-                       {machineStateData}
-                       <td>
-                           {newMachineProvider + " - " + newMachineId}
-                       </td>
-                   </tr>
+            const { name, uuid } = request.get("instance");
+            const requestDate = moment(request.get("start_date")).format("MMM D, YYYY h:mm:ss a");
+
+            return (
+                <tr className="card">
+                    <td>
+                       { name }
+                       <div className="u-noWrap">
+                           { uuid }
+                           <CopyButton text={ uuid }/>
+                       </div>
+                    </td>
+                    <td>
+                       { requestDate }
+                    </td>
+                    <td>
+                       { endDateText }
+                    </td>
+                    <td className="u-noWrap">
+                       <span
+                           className={`instance-status-light ${trClass}`}
+                       />
+                       { requestStatus }
+                    </td>
+                    { machineStateData }
+                    <td>
+                       { newMachineProvider }
+                       <div className="u-noWrap">
+                           { newMachineId }
+                           { ( newMachineId !== "N/A" ) ?
+                               <CopyButton text={ newMachineId }/> : null
+                           }
+                       </div>
+                    </td>
+               </tr>
+            );
         }.bind(this));
 
         return (
@@ -153,24 +176,24 @@ export default React.createClass({
                 <a href={imagingDocsLink.get("href")} target="_blank">documentation on imaging</a>.
             </p>
             {this.renderRefreshButton()}
-            <table className="table table-condensed image-requests">
+            <table className="image-requests cy-Table">
                 <tbody>
-                    <tr>
+                    <tr className="card">
                         <th>
-                            <h3 className="t-title">Date requested</h3>
+                            Base Instance
                         </th>
                         <th>
-                            <h3 className="t-title">Date completed</h3>
+                            Date Requested
                         </th>
                         <th>
-                            <h3 className="t-title">Base instance</h3>
+                            Date Completed
                         </th>
                         <th>
-                            <h3 className="t-title">Status</h3>
+                            Status
                         </th>
                         {machineStateColumn}
                         <th>
-                            <h3 className="t-title">New Machine ID</h3>
+                            New Machine ID
                         </th>
                     </tr>
                     {displayRequests}
@@ -178,5 +201,6 @@ export default React.createClass({
             </table>
         </div>
         );
-    }
+    },
+
 });


### PR DESCRIPTION
## Description

This resolves [ATMO-1572](https://pods.iplantcollaborative.org/jira/browse/ATMO-1572)

The table on the My Image Request page should have a smaller headings font size and the rows should be cards. 

The status of the image request is communicated by changing the the whole row background color. While everywhere else we use "status lights"

The order of the information is very different from our other resources. 

ID's should have `CopyButton`s

#### This PR adds:
- `cy-Table` component class as a temporary solution until we create a component for this use in Cyverse-ui. The name cy-Table was used because Bootstrap occupies the name `table`

- `u-noWrap` utility class as a convenience  to make the content stay on one line
#### TODO
- This table is not responsive so this work will be done in another PR possibly as a component solution in Cyverse-ui 

### Screen Shots

#### Before
Shows the problems listed above
<img width="1308" alt="screen shot 2017-04-13 at 2 28 44 pm" src="https://cloud.githubusercontent.com/assets/7366338/25025040/87b1591e-2055-11e7-9391-99a35cc6e3f3.png">

#### After
Shows that the rows are cards, titles are correct, order is better, copy buttons are added, status lights are consistant, and overall spacing is improved
<img width="1270" alt="screen shot 2017-04-13 at 2 40 56 pm" src="https://cloud.githubusercontent.com/assets/7366338/25025501/63cd4f06-2057-11e7-8563-f93924589ff0.png">

## Checklist before merging Pull Requests
- [x] Reviewed and approved by at least one other contributor.
