### PR TITLE
Problem: error message appears as title

### DIFF
--- a/troposphere/static/js/controllers/NotificationController.js
+++ b/troposphere/static/js/controllers/NotificationController.js
@@ -24,7 +24,7 @@ var noFadeDefaults = {
 export default {
     success: function(title, message, options = {}) {
         let settings = _.defaults(options, defaults);
-        toastr.success(message, settings);
+        toastr.success(message, title, settings);
     },
     info: function(title, message, options = {}) {
         let settings = _.defaults(options, defaults);

--- a/troposphere/static/js/controllers/NotificationController.js
+++ b/troposphere/static/js/controllers/NotificationController.js
@@ -24,18 +24,18 @@ var noFadeDefaults = {
 export default {
     success: function(title, message, options = {}) {
         let settings = _.defaults(options, defaults);
-        toastr.success(title, message, settings);
+        toastr.success(message, settings);
     },
     info: function(title, message, options = {}) {
         let settings = _.defaults(options, defaults);
-        toastr.info(title, message, settings);
+        toastr.info(message, title, settings);
     },
     warning: function(title, message, options = {}) {
         let settings = _.defaults(options, noFadeDefaults);
-        toastr.warning(title, message, settings);
+        toastr.warning(message, title, settings);
     },
     error: function(title, message, options = {}) {
         let settings = _.defaults(options, noFadeDefaults);
-        toastr.error(title, message, settings);
+        toastr.error(message, title, settings);
     }
 };


### PR DESCRIPTION
## Description

This work fixes the juxtaposed appears of detailed "error messages" above the _summary_ title within error notifications. 

The `toastr` libraries methods for showing "notifications", (`error`, `info`, `success`, `warning`) accept arguments in the order:  `error(message, title, optionsOverride)`. This is likely because the `title` is optional. 

## Problem

Here, message appears above title:

![atmo-1671-before](https://cloud.githubusercontent.com/assets/5923/25145544/58891260-2426-11e7-8d1b-b980c0090b67.png)

### After the fix

![atmo-1671-after](https://cloud.githubusercontent.com/assets/5923/25145562/62cde502-2426-11e7-828c-6a2b7a52edd8.png)

We may choose to alter appearance further with CSS, but this now has the _intended_ "title" appearing above the error message. _If desired, that should be done in an additional pull request._

For an example comparing the markup, please see **Details** below.

See [ATMO-1671](https://pods.iplantcollaborative.org/jira/browse/ATMO-1671)

<details>

## Markup before fix applied
![atmo-1671-markup-before-fix](https://cloud.githubusercontent.com/assets/5923/25145107/046ba0f4-2425-11e7-8927-c6a57861a635.png)

## Markup after fix applied
![atmo-1671-markup-after-fix](https://cloud.githubusercontent.com/assets/5923/25145108/04780bfa-2425-11e7-9997-90cae89a46d7.png)

</details>

## Checklist before merging Pull Requests
- [ ] ~New test(s) included to reproduce the bug/verify the feature~
- [ ] ~Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [x] Reviewed and approved by at least one other contributor.
