### PR TITLE
Problem: form elements difficult to target with testing tools

### DIFF
--- a/troposphere/static/js/components/common/ProjectCreateView.jsx
+++ b/troposphere/static/js/components/common/ProjectCreateView.jsx
@@ -119,6 +119,8 @@ export default React.createClass({
                     Project Name
                 </label>
                 <input type="text"
+                    name="project-name"
+                    id="project-name"
                     className="form-control"
                     value={projectName}
                     onChange={this.onNameChange}
@@ -130,6 +132,8 @@ export default React.createClass({
                     Description
                 </label>
                 <textarea type="text"
+                    name="project-description"
+                    id="project-description"
                     className="form-control"
                     rows="7"
                     value={this.state.projectDescription}


### PR DESCRIPTION
## Add name & id attributes to form elements

For the "Create New Project" modal, we have two elements that do not
have "name" attributes [0,1]. Having names on the form elements allows
them to be _targeted_ easily using `splinter` [2]:

```python
for key in context.browser.type('el-name', '..text..', slowly=True):
    assert key
```

I also added `id` attributes to the elements because there are
`<label/>` that indicate they're "for" [3] the inputs, but without the
`id` I do not believe the associated is made.

Note, `htmlFor` is used by `<label/>` because *for* is a keyword in
JavaScript [4].

[0] https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes
[1] https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#Attributes
[2] http://splinter.readthedocs.io/en/latest/api/driver-and-element-api.html?highlight=screenshot#splinter.driver.DriverAPI.type
[3] https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label
[4] https://facebook.github.io/react/docs/dom-elements.html#htmlfor

## Checklist before merging Pull Requests
- ~[ ] New test(s) included to reproduce the bug/verify the feature~
- ~[ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Reviewed and approved by at least one other contributor.
