### PR TITLE
Problem: some navigation code is not using "/application" basename

### DIFF
--- a/troposphere/static/js/actions/NullProjectActions.js
+++ b/troposphere/static/js/actions/NullProjectActions.js
@@ -1,5 +1,6 @@
 import Backbone from "backbone";
-import { browserHistory } from "react-router";
+
+import { appBrowserHistory } from "utilities/historyFunctions";
 
 import NotificationController from "controllers/NotificationController";
 import Utils from "./Utils";
@@ -66,7 +67,7 @@ export default {
             this._migrateResourceIntoProject(resource, project);
         }.bind(this));
 
-        browserHistory.push(`/projects/${project.id}/resources`);
+        appBrowserHistory.push(`/projects/${project.id}/resources`);
     },
 
 

--- a/troposphere/static/js/actions/ProjectActions.js
+++ b/troposphere/static/js/actions/ProjectActions.js
@@ -1,4 +1,4 @@
-import { browserHistory } from "react-router";
+import { appBrowserHistory } from "utilities/historyFunctions";
 
 import Utils from "./Utils";
 import NotificationController from "controllers/NotificationController";
@@ -103,7 +103,7 @@ export default {
             });
         });
 
-        browserHistory.push("/projects");
+        appBrowserHistory.push("/projects");
     },
 
     // ----------------------

--- a/troposphere/static/js/actions/instance/launch.js
+++ b/troposphere/static/js/actions/instance/launch.js
@@ -1,4 +1,4 @@
-import { browserHistory } from "react-router";
+import { appBrowserHistory } from "utilities/historyFunctions";
 
 import Utils from "../Utils";
 
@@ -137,7 +137,7 @@ function launch(params) {
     // Since this is triggered from the images page, navigate off
     // that page and back to the instance list so the user can see
     // their instance being created
-    browserHistory.push(`/projects/${project.id}/resources`);
+    appBrowserHistory.push(`/projects/${project.id}/resources`);
 }
 
 export default {
@@ -171,7 +171,7 @@ export default {
             // Since this is triggered from the images page, navigate off
             // that page and back to the instance list so the user can see
             // their instance being created
-            browserHistory.push(`/projects/${project.id}/resources`);
+            appBrowserHistory.push(`/projects/${project.id}/resources`);
         }).fail(function(response) {
             Utils.dispatch(ProjectConstants.REMOVE_PROJECT, {
                 project: project

--- a/troposphere/static/js/components/SplashScreen.jsx
+++ b/troposphere/static/js/components/SplashScreen.jsx
@@ -7,14 +7,13 @@ import getMuiTheme from 'material-ui/styles/getMuiTheme';
 import appTheme from 'theme/appTheme';
 import _ from 'lodash';
 
-import { Router,
-         browserHistory } from "react-router";
+import { Router } from "react-router";
 
 import context from "context";
 import stores from "stores";
 
 import Routes from "../AppRoutes";
-import { withAppBasename } from "utilities/historyFunctions";
+import { appBrowserHistory } from "utilities/historyFunctions";
 
 import Raven from "raven-js";
 
@@ -96,8 +95,8 @@ export default React.createClass({
         //     messages sent to them
         const App = (
             <MuiThemeProvider muiTheme={getMuiTheme(appTheme)}>
-                <Router 
-                    history={withAppBasename(browserHistory)}
+                <Router
+                    history={appBrowserHistory}
                     onChange={() => window.Intercom("update")}
                 >
                     { Routes({ profile: ProfileStore }) }

--- a/troposphere/static/js/modals/instance/destroy.js
+++ b/troposphere/static/js/modals/instance/destroy.js
@@ -1,4 +1,4 @@
-import { browserHistory } from "react-router";
+import { appBrowserHistory } from "utilities/historyFunctions";
 
 // TODO - this is curious `stores` is not imported here
 // and store.VolumeStore used in the exposed operation
@@ -34,7 +34,7 @@ export default {
             attachedVolumes.forEach((volume) => VolumeStore.pollUntilDetached(volume));
             actions.InstanceActions.destroy(payload, options);
             if (project) {
-                browserHistory.push(`/projects/${project.id}/resources`);
+                appBrowserHistory.push(`/projects/${project.id}/resources`);
             }
         })
     },

--- a/troposphere/static/js/modals/link/destroy.js
+++ b/troposphere/static/js/modals/link/destroy.js
@@ -1,4 +1,4 @@
-import { browserHistory } from "react-router";
+import { appBrowserHistory } from "utilities/historyFunctions";
 
 import ModalHelpers from "components/modals/ModalHelpers";
 import ExternalLinkDeleteModal from "components/modals/link/ExternalLinkDeleteModal";
@@ -25,7 +25,7 @@ export default {
                 project: project,
                 external_link: external_link
             });
-            browserHistory.push(`/projects/${project.id}/resources`);
+            appBrowserHistory.push(`/projects/${project.id}/resources`);
         })
     }
 };

--- a/troposphere/static/js/modals/volume/destroy.js
+++ b/troposphere/static/js/modals/volume/destroy.js
@@ -1,4 +1,4 @@
-import { browserHistory } from "react-router";
+import { appBrowserHistory } from "utilities/historyFunctions";
 
 import ModalHelpers from "components/modals/ModalHelpers";
 
@@ -45,7 +45,7 @@ export default {
                 volume: volume
             });
 
-            browserHistory.push(`/projects/${project.id}/resources`);
+            appBrowserHistory.push(`/projects/${project.id}/resources`);
         })
     }
 };

--- a/troposphere/static/js/public_site/bootstrapper.jsx
+++ b/troposphere/static/js/public_site/bootstrapper.jsx
@@ -10,15 +10,12 @@ import appTheme from 'theme/appTheme';
 import injectTapEvent from 'react-tap-event-plugin';
 injectTapEvent();
 
-import {
-    Router,
-    browserHistory
-} from "react-router";
+import { Router } from "react-router";
 
 import Profile from "models/Profile";
 
 import routes from "./AppRoutes";
-import { withAppBasename } from "utilities/historyFunctions";
+import { appBrowserHistory } from "utilities/historyFunctions";
 
 import browserBondo from "utilities/browserBondo";
 import modals from "modals";
@@ -68,14 +65,13 @@ function startApplication() {
 
         const App = (
             <MuiThemeProvider muiTheme={getMuiTheme(appTheme)}>
-                <Router history={withAppBasename(browserHistory)}>
+                <Router history={appBrowserHistory}>
                     {routes}
                 </Router>
             </MuiThemeProvider>
         );
 
         // Start the application router
-        
         ReactDOM.render(
             App,
             document.getElementById("application"));

--- a/troposphere/static/js/utilities/historyFunctions.js
+++ b/troposphere/static/js/utilities/historyFunctions.js
@@ -1,17 +1,36 @@
+import { browserHistory } from "react-router";
+
 import useBasename from 'history/lib/useBasename';
 
 /**
  * Helper functions for simplifying the use of the `history` module
  */
 
+
 const withBasename = (history, base) => {
     return useBasename(() => history)({basename: `/${base}`});
 }
 
 const withAppBasename = (history) => {
-    // might want to pull this from the "render context" provided
-    // in `globals` to allow for configuration transparency
+    // might want to pull the second argument, "application" from the
+    // "render context" provided in `globals` to allow for
+    // configuration transparency, and the ability to "re-root" the app
+    // to another _base_ URL using `basename`
     return withBasename(history, "application");
 }
 
-export { withBasename, withAppBasename };
+function browserHistoryWithBase() {
+    return withAppBasename(browserHistory);
+}
+
+/**
+ * Expose the history as an object/singleton to mirror the react-router
+ * `browserHistory` object.
+ *
+ * We are merely providing a 'preconfigured' version of `browserHistory`
+ * with the application basename applied so it will be prepended to
+ * routes as we navigate.
+ */
+const appBrowserHistory = browserHistoryWithBase();
+
+export { withBasename, withAppBasename, appBrowserHistory };


### PR DESCRIPTION
## Description

Originally reported by @c-mart, the "transition" navigation following a "Launch Instance" is to an invalid URL that is **not** handled by the web server. 

So, before launch, the application is at "https://<host>/application/projects/3333/resources" and after launch it transitions to "https://<host>/projects/3333/resources" and is only _noticeable_ when you refresh.

## Affected Interactions

To help understand the importance of this work being merged, here are the interactions that currently result in "transitions" to invalid URLs following the completion of the _action_:

- Launch Instance
  - from Project Resource view
- Delete Instance
- Delete Volume
- Delete Link
- Delete Project
- Migrate resources

Recorded interactions of the failures will be provided in **Details** along with fixed interaction represented by this work.

See [ATMO-1803](https://pods.iplantcollaborative.org/jira/browse/ATMO-1803)

<details>

### Launch Instance

#### from Project Resource view

Broken: http://recordit.co/v8avafuZv3

Fixed: http://recordit.co/htwphk3bsC

![atmo-1830-launch-instance-fix](https://cloud.githubusercontent.com/assets/5923/25245448/48d70a7c-25b9-11e7-9799-819ae5577517.gif)

### Delete Instance

Broken: http://recordit.co/5jCTbhH5aP

Fixed: http://recordit.co/j7J0mqoH1P

![atmo-1803-delete-instance-fix](https://cloud.githubusercontent.com/assets/5923/25245684/2687bee8-25ba-11e7-975f-71ce5e27fd2b.gif)


### Delete Volume

Broken: http://recordit.co/GhMEakiFA2

Fixed: 

### Delete Link

Broken: http://recordit.co/uDrD95zpX8

Fixed:

### Delete Project

Broken: http://recordit.co/Llzh0kj9Vi

Fixed: http://recordit.co/tqIVwmAW8W

![atmo-1803-delete-project-fix](https://cloud.githubusercontent.com/assets/5923/25245792/76cdd914-25ba-11e7-98ed-52463fc279d2.gif)


### Migrate resources

_don't have a broken interaction, trust me?_

Fixed: http://recordit.co/35oFvXg6IB

![atmo-1830-migrate-resources-fix](https://cloud.githubusercontent.com/assets/5923/25245559/ae5564f2-25b9-11e7-9ae0-1c3c11f172ad.gif)


</details>

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] ~Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [x] Reviewed and approved by at least one other contributor.
