### PR TITLE
Problem: data for "help" page does not load on initial view or refresh

### DIFF
--- a/troposphere/static/js/components/help/HelpPage.jsx
+++ b/troposphere/static/js/components/help/HelpPage.jsx
@@ -3,11 +3,12 @@ import stores from "stores";
 import globals from "globals";
 
 
-let resources = [{
-    title: "User Manual",
-    link_key: "default",
-    description: "Complete documentation for using Atmosphere"
-},
+let resources = [
+    {
+        title: "User Manual",
+        link_key: "default",
+        description: "Complete documentation for using Atmosphere"
+    },
     {
         title: "User Forums",
         link_key: "forums",
@@ -27,6 +28,18 @@ let resources = [{
 
 export default React.createClass({
     displayName: "HelpPage",
+
+    updateState: function() {
+        this.forceUpdate();
+    },
+
+    componentDidMount: function() {
+       stores.HelpLinkStore.addChangeListener(this.updateState);
+    },
+
+    componentWillUnmount: function() {
+       stores.HelpLinkStore.removeChangeListener(this.updateState);
+    },
 
     render: function() {
         var helpLinks = stores.HelpLinkStore.getAll();


### PR DESCRIPTION
## Description

When data is finally loaded into the HelpLinkStore, the <HelpPage/> component is not receiving the call to `updateState`.

This work does a forceUpdate on the page component.

Note: this page is a candidate for being converted to the `subscribe`
connector that Connor (@cdosborn) has written in PR 561 (recently
merge into master).

See [ATMO-1844](https://pods.iplantcollaborative.org/jira/browse/ATMO-1844)

## Checklist before merging Pull Requests
- [ ] ~New test(s) included to reproduce the bug/verify the feature~
- [ ] ~Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Reviewed and approved by at least one other contributor.
