### PR TITLE
Problem: dev requirements pinned and do not state ipdb latest

### DIFF
--- a/dev_requirements.in
+++ b/dev_requirements.in
@@ -1,8 +1,8 @@
 behave
 behaving
-colorama==0.3.3
-coverage==3.7.1
-django-jenkins==0.18.1
-emoji==0.3.6
-ipython==5.3.0
+colorama
+coverage
+django-jenkins
+emoji
+ipython
 ipdb

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -15,7 +15,7 @@ django-jenkins==0.18.1
 django==1.9.4             # via django-jenkins
 emoji==0.3.6
 enum34==1.1.6             # via parse-type, traitlets
-ipdb==0.10.1
+ipdb==0.10.2
 ipython-genutils==0.1.0   # via traitlets
 ipython==5.3.0
 packaging==16.8           # via setuptools


### PR DESCRIPTION
## Description

This updated `ipdb` to `0.10.2` in _dev_requirements.txt_.

Also, it removes the _"pinning"_ present in `dev_requirements.in` (which seems to be an anti-pattern for projects managed by pip-tools). 

## Background

When authoring `behave` tests, I was attempting to set a breakpoint for `ipdb` and caught hitting the following error:
```
 AttributeError: 'TerminalInteractiveShell' object has no attribute '_eventloop'
```

Digging around, it appeared that `ipdb==0.10.2` did not have this issue (see [ipdb issue 105](https://github.com/gotcha/ipdb/issues/105)). 

Thank you to @julianpistorius for the assignment.

## Checklist before merging Pull Requests
- [ ] ~New test(s) included to reproduce the bug/verify the feature~
- [ ] ~Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Reviewed and approved by at least one other contributor.
