### PR TITLE
Problem: no easy way to emulate a community member

### DIFF
--- a/troposphere/static/js/components/admin/AtmosphereUser.jsx
+++ b/troposphere/static/js/components/admin/AtmosphereUser.jsx
@@ -3,6 +3,7 @@ import Backbone from "backbone";
 import moment from "moment";
 import actions from "actions";
 import ToggleButton from "components/common/ToggleButton";
+import Emulate from "./Emulate";
 
 
 export default React.createClass({
@@ -60,7 +61,7 @@ export default React.createClass({
             <td style={{ border: "none" }} 
                 className="user-name"
             >
-                {user.get("username")}
+                {user.get("username")} <Emulate username={user.get("username")} />
             </td>
             <td style={{ border: "none" }}
                 className="email"

--- a/troposphere/static/js/components/admin/AtmosphereUser.jsx
+++ b/troposphere/static/js/components/admin/AtmosphereUser.jsx
@@ -61,7 +61,7 @@ export default React.createClass({
             <td style={{ border: "none" }} 
                 className="user-name"
             >
-                {user.get("username")} <Emulate username={user.get("username")} />
+                 <Emulate username={user.get("username")} /> {user.get("username")}
             </td>
             <td style={{ border: "none" }}
                 className="email"

--- a/troposphere/static/js/components/admin/Emulate.jsx
+++ b/troposphere/static/js/components/admin/Emulate.jsx
@@ -1,9 +1,9 @@
 import $ from "jquery";
 import React from "react";
 import ReactDOM from "react-dom";
+import Tooltip from "react-tooltip";
 
 import Glyphicon from 'components/common/Glyphicon';
-import Tooltip from "components/common/ui/Tooltip";
 
 
 export default React.createClass({
@@ -13,27 +13,18 @@ export default React.createClass({
         username: React.PropTypes.string.isRequired
     },
 
-    componentDidMount() {
-        this.generateTooltip();
-    },
-
-    componentDidUpdate() {
-        this.generateTooltip();
-    },
-
-    generateTooltip() {
-        let $el = $(ReactDOM.findDOMNode(this));
-        $el.tooltip({
-            title: "Emulate"
-        });
-    },
-
     render() {
         let { username } = this.props;
 
         return (
         <a href={`emulate/${username}`}>
-            <Glyphicon name="sunglasses" />
+            <i className={"glyphicon glyphicon-sunglasses"}
+               data-for={username}
+               data-tip="Emulate"
+               aria-hidden="true" />
+            <Tooltip id={username}
+                     place="top"
+                     effect="solid" />
         </a>
         );
     }

--- a/troposphere/static/js/components/admin/Emulate.jsx
+++ b/troposphere/static/js/components/admin/Emulate.jsx
@@ -28,16 +28,11 @@ export default React.createClass({
         });
     },
 
-    onClick() {
-        let $el = $(ReactDOM.findDOMNode(this));
-        $el.tooltip("hide");
-    },
-
     render() {
         let { username } = this.props;
 
         return (
-        <a href={`emulate/${username}`} onClick={this.onClick()}>
+        <a href={`emulate/${username}`}>
             <Glyphicon name="sunglasses" />
         </a>
         );

--- a/troposphere/static/js/components/admin/Emulate.jsx
+++ b/troposphere/static/js/components/admin/Emulate.jsx
@@ -18,7 +18,7 @@ export default React.createClass({
 
         return (
         <a href={`emulate/${username}`}>
-            <i className={"glyphicon glyphicon-sunglasses"}
+            <i className={"glyphicon glyphicon-user"}
                data-for={username}
                data-tip="Emulate"
                aria-hidden="true" />

--- a/troposphere/static/js/components/admin/Emulate.jsx
+++ b/troposphere/static/js/components/admin/Emulate.jsx
@@ -1,0 +1,46 @@
+import $ from "jquery";
+import React from "react";
+import ReactDOM from "react-dom";
+
+import Glyphicon from 'components/common/Glyphicon';
+import Tooltip from "components/common/ui/Tooltip";
+
+
+export default React.createClass({
+    displayName: "Emulate",
+
+    propTypes: {
+        username: React.PropTypes.string.isRequired
+    },
+
+    componentDidMount() {
+        this.generateTooltip();
+    },
+
+    componentDidUpdate() {
+        this.generateTooltip();
+    },
+
+    generateTooltip() {
+        let $el = $(ReactDOM.findDOMNode(this));
+        $el.tooltip({
+            title: "Emulate"
+        });
+    },
+
+    onClick() {
+        let $el = $(ReactDOM.findDOMNode(this));
+        $el.tooltip("hide");
+    },
+
+    render() {
+        let { username } = this.props;
+
+        return (
+        <a href={`emulate/${username}`} onClick={this.onClick()}>
+            <Glyphicon name="sunglasses" />
+        </a>
+        );
+    }
+
+});


### PR DESCRIPTION
## Description

The _emulation_ feature has been obscure from view - but known amongst the team. This work would define a compact, clickable component to perform the `emulate` action for a community member within the "Admin > Atmosphere Users" section of the administrative user interface.

See also [ATMO-1602](https://pods.iplantcollaborative.org/jira/browse/ATMO-1602)

<details>

### "user" icon, click to emulate

<img width="325" alt="screen shot 2017-06-20 at 12 57 03 pm" src="https://user-images.githubusercontent.com/5923/27347931-fa5126f6-55b7-11e7-9e69-74083e9b62f0.png">


### wider view of each occurrence 

<img width="1259" alt="screen shot 2017-06-20 at 12 53 40 pm" src="https://user-images.githubusercontent.com/5923/27347956-0dbcd208-55b8-11e7-80e9-e8182358c118.png">


</details>

## Checklist before merging Pull Requests
- [ ] ~New test(s) included to reproduce the bug/verify the feature~
- [x] Documentation updated relating to [Account Emulation](https://github.com/cyverse/atmosphere-guides/pull/19).
- [x] Reviewed and approved by at least one other contributor.
