### PR TITLE
Fix UI ignoring instance delete

### DIFF
--- a/troposphere/static/js/stores/InstanceStore.js
+++ b/troposphere/static/js/stores/InstanceStore.js
@@ -3,6 +3,7 @@ import BaseStore from "stores/BaseStore";
 import InstanceCollection from "collections/InstanceCollection";
 import Utils from "actions/Utils";
 import InstanceConstants from "constants/InstanceConstants";
+import ProjectInstanceConstants from "constants/ProjectInstanceConstants";
 import InstanceState from "models/InstanceState";
 import EventConstants from "constants/EventConstants";
 
@@ -69,7 +70,14 @@ var InstanceStore = BaseStore.extend({
         this.pollWhile(instance, function(model, response) {
             // If 404 then remove the model
             if (response.status == "404") {
-                this.remove(model);
+                Utils.dispatch(InstanceConstants.REMOVE_INSTANCE, {
+                    instance: model
+                });
+                // This is a hack. Some components only listen to the
+                // ProjectInstanceStore. We need them to react when an
+                // instance is deleted, so we prompt the addChangeListeners of
+                // each of those components here.
+                Utils.dispatch(ProjectInstanceConstants.EMIT_CHANGE);
 
                 return false;
             }


### PR DESCRIPTION
## Description

The issue is that deleting an instance emits a change to the InstanceStore, but ProjectDetails (which displays a user's instances in a table) doesn't listen for updates to that store. Rather, it listens only to theProjectInstanceStore.

My intention is to follow this fix with a larger fix if time warrants.

Related issue, #583 
Related jira, [ATMO-1479](https://pods.iplantcollaborative.org/jira/browse/ATMO-1479)

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature
- [ ] Reviewed and approved by at least one other contributor.
