### PR TITLE
Problem: cannot shelve/unshelve instances within capable providers

### DIFF
--- a/troposphere/static/js/actions/InstanceActions.js
+++ b/troposphere/static/js/actions/InstanceActions.js
@@ -11,6 +11,10 @@ import IUpdate from "./instance/update";
 import IReport from "./instance/report";
 import IRequest from "./instance/requestImage";
 
+import { shelve } from "./instance/shelve";
+import { unshelve } from "./instance/unshelve";
+
+
 export default {
     resume: IResume.resume,
     suspend: ISuspend.suspend,
@@ -24,5 +28,7 @@ export default {
     destroy: IDestroy.destroy,
     update: IUpdate.update,
     report: IReport.report,
-    requestImage: IRequest.requestImage
+    requestImage: IRequest.requestImage,
+    shelve,
+    unshelve
 };

--- a/troposphere/static/js/actions/instance/shelve.js
+++ b/troposphere/static/js/actions/instance/shelve.js
@@ -1,0 +1,57 @@
+import InstanceConstants from "constants/InstanceConstants";
+import InstanceState from "models/InstanceState";
+import Utils from "../Utils";
+import InstanceActionRequest from "models/InstanceActionRequest";
+
+
+const shelve = (params) => {
+        if (!params.instance)
+            throw new Error("Missing instance");
+
+        var instance = params.instance,
+            instanceState = new InstanceState({
+                status_raw: "active - shelving",
+                status: "active",
+                activity: "shelving"
+            }),
+            originalState = instance.get("state"),
+            actionRequest = new InstanceActionRequest({
+                instance: instance
+            });
+
+        instance.set({
+            state: instanceState
+        });
+        Utils.dispatch(InstanceConstants.UPDATE_INSTANCE, {
+            instance: instance
+        });
+
+        actionRequest.save(null, {
+            attrs: {
+                action: "shelving"
+            }
+        }).done(function() {
+            instance.set({
+                state: instanceState
+            });
+        }).fail(function(response) {
+            instance.set({
+                state: originalState
+            });
+            Utils.displayError({
+                title: "Your instance could not be shelved",
+                response: response
+            });
+        }).always(function() {
+            Utils.dispatch(InstanceConstants.UPDATE_INSTANCE, {
+                instance: instance
+            });
+            Utils.dispatch(InstanceConstants.POLL_INSTANCE_WITH_DELAY, {
+                instance: instance,
+                delay: 15*1000,
+            });
+        });
+}
+
+
+export { shelve };

--- a/troposphere/static/js/actions/instance/shelve.js
+++ b/troposphere/static/js/actions/instance/shelve.js
@@ -28,7 +28,7 @@ const shelve = (params) => {
 
         actionRequest.save(null, {
             attrs: {
-                action: "shelving"
+                action: "shelve"
             }
         }).done(function() {
             instance.set({

--- a/troposphere/static/js/actions/instance/unshelve.js
+++ b/troposphere/static/js/actions/instance/unshelve.js
@@ -1,0 +1,55 @@
+import InstanceConstants from "constants/InstanceConstants";
+import InstanceState from "models/InstanceState";
+import Utils from "../Utils";
+import InstanceActionRequest from "models/InstanceActionRequest";
+
+const unshelve = (params) => {
+    if (!params.instance)
+        throw new Error("Missing instance");
+
+    var instance = params.instance,
+        instanceState = new InstanceState({
+            status_raw: "shelved - unshelving",
+            status: "active",
+            activity: "unshelving"
+        }),
+        originalState = instance.get("state"),
+        actionRequest = new InstanceActionRequest({
+            instance: instance
+        });
+
+    instance.set({
+        state: instanceState
+    });
+    Utils.dispatch(InstanceConstants.UPDATE_INSTANCE, {
+        instance: instance
+    });
+
+    actionRequest.save(null, {
+        attrs: {
+            action: "unshelve"
+        }
+    }).done(function() {
+        instance.set({
+            state: instanceState
+        });
+    }).fail(function(response) {
+        instance.set({
+            state: originalState
+        });
+        Utils.displayError({
+            title: "Your instance could not be unshelved",
+            response: response
+        });
+    }).always(function() {
+        Utils.dispatch(InstanceConstants.UPDATE_INSTANCE, {
+            instance: instance
+        });
+        Utils.dispatch(InstanceConstants.POLL_INSTANCE_WITH_DELAY, {
+            instance: instance,
+            delay: 25*1000,
+        });
+    });
+}
+
+export { unshelve };

--- a/troposphere/static/js/components/modals/instance/InstanceShelveModal.jsx
+++ b/troposphere/static/js/components/modals/instance/InstanceShelveModal.jsx
@@ -1,0 +1,79 @@
+import React from "react";
+import RaisedButton from "material-ui/RaisedButton";
+import BootstrapModalMixin from "components/mixins/BootstrapModalMixin";
+import Glyphicon from "components/common/Glyphicon";
+
+export default React.createClass({
+    displayName: "InstanceShelveModal",
+
+    mixins: [BootstrapModalMixin],
+
+    //
+    // Internal Modal Callbacks
+    // ------------------------
+    //
+
+    cancel: function() {
+        this.hide();
+    },
+
+    confirm: function() {
+        this.hide();
+        this.props.onConfirm();
+    },
+
+    //
+    // Render
+    // ------
+    //
+
+    renderBody: function() {
+        return (
+        <div>
+            <p className="alert alert-warning">
+                <Glyphicon name="warning-sign" />
+                {" "}
+                <strong>WARNING</strong>
+                {" Shelving an instance will freeze its state, and the IP address be removed from the instance."}
+            </p>
+            <p>
+                {'Shelving will safely preserve the state of your instance for later use. And, it frees up resources for other users . In fact, it is the best way to reduce resource usage when compared with other actions, like "suspend" and "stop".'}
+                {'Your time allocation no longer counts against you in the shelved mode.'}
+            </p>
+            <p>
+                {'Your resource usage charts will only reflect the freed resources once the instance\'s state is "shelved."'}
+            </p>
+        </div>
+        );
+    },
+
+    render: function() {
+        return (
+        <div className="modal fade">
+            <div className="modal-dialog">
+                <div className="modal-content">
+                    <div className="modal-header">
+                        {this.renderCloseButton()}
+                        <h1 className="t-title">Shelve Instance</h1>
+                    </div>
+                    <div className="modal-body">
+                        {this.renderBody()}
+                    </div>
+                    <div className="modal-footer">
+                        <RaisedButton
+                            style={{ marginRight: "10px" }}
+                            onTouchTap={this.cancel}
+                            label="Cancel"
+                        />
+                        <RaisedButton
+                            primary
+                            onTouchTap={this.confirm}
+                            label="Yes, shelve this instance"
+                        />
+                    </div>
+                </div>
+            </div>
+        </div>
+        );
+    }
+});

--- a/troposphere/static/js/components/modals/instance/InstanceUnshelveModal.jsx
+++ b/troposphere/static/js/components/modals/instance/InstanceUnshelveModal.jsx
@@ -1,0 +1,72 @@
+import React from "react";
+import RaisedButton from "material-ui/RaisedButton";
+import BootstrapModalMixin from "components/mixins/BootstrapModalMixin";
+
+export default React.createClass({
+    displayName: "InstanceUnshelveModal",
+
+    mixins: [BootstrapModalMixin],
+
+    //
+    // Internal Modal Callbacks
+    // ------------------------
+    //
+
+    cancel: function() {
+        this.hide();
+    },
+
+    confirm: function() {
+        this.hide();
+        this.props.onConfirm();
+    },
+
+    //
+    // Render
+    // ------
+    //
+
+    renderBody: function() {
+        return (
+        <div>
+            <p>
+                {"Would you like to unshelve this instance?"}
+            </p>
+            <p>
+                Your instance's IP address will have change once it is available.
+            </p>
+        </div>
+        );
+    },
+
+    render: function() {
+
+        return (
+        <div className="modal fade">
+            <div className="modal-dialog">
+                <div className="modal-content">
+                    <div className="modal-header">
+                        {this.renderCloseButton()}
+                        <h1 className="t-title">Unshelve Instance</h1>
+                    </div>
+                    <div className="modal-body">
+                        {this.renderBody()}
+                    </div>
+                    <div className="modal-footer">
+                        <RaisedButton
+                            style={{ marginRight: "10Px" }}
+                            onTouchTap={this.cancel}
+                            label="Cancel"
+                        />
+                        <RaisedButton
+                            primary
+                            onTouchTap={this.confirm}
+                            label="Yes, unshelve this instance"
+                        />
+                    </div>
+                </div>
+            </div>
+        </div>
+        );
+    }
+});

--- a/troposphere/static/js/components/projects/detail/resources/tableData/instance/Status.jsx
+++ b/troposphere/static/js/components/projects/detail/resources/tableData/instance/Status.jsx
@@ -20,8 +20,10 @@ export default React.createClass({
             lightStatus = "transition";
         } else if (status == "active") {
             lightStatus = "active";
-        } else if (status == "suspended" || status == "shutoff") {
-            lightStatus = "inactive";
+        } else if (instanceState.isInactive()) {
+            // default of <StatusLight/> is gray,
+            // so let's signal inactivity as gray
+            lightStatus = "";
         } else if (status == "deleted") {
             lightStatus = "deleted";
         } else {

--- a/troposphere/static/js/components/projects/resources/instance/details/actions/InstanceActionsAndLinks.jsx
+++ b/troposphere/static/js/components/projects/resources/instance/details/actions/InstanceActionsAndLinks.jsx
@@ -46,6 +46,12 @@ export default React.createClass({
                 onClick: this.onSuspend
             },
             {
+                key: InstanceActionNames.SHELVE,
+                label: "Shelve",
+                icon: "log-in",
+                onClick: this.onShelve
+            },
+            {
                 key: InstanceActionNames.STOP,
                 label: "Stop",
                 icon: "stop",
@@ -56,6 +62,12 @@ export default React.createClass({
                 label: "Resume",
                 icon: "play",
                 onClick: this.onResume
+            },
+            {
+                key: InstanceActionNames.UNSHELVE,
+                label: "Unshelve",
+                icon: "log-out",
+                onClick: this.onUnshelve
             },
             {
                 key: InstanceActionNames.REBOOT,
@@ -164,6 +176,13 @@ export default React.createClass({
         modals.InstanceModals.reboot(this.props.instance);
     },
 
+    onShelve: function() {
+        modals.InstanceModals.shelve(this.props.instance);
+    },
+
+    onUnshelve: function() {
+        modals.InstanceModals.unshelve(this.props.instance);
+    },
 
     onWebDesktop: function(ipAddr, instance) {
         // TODO:

--- a/troposphere/static/js/modals/InstanceModals.js
+++ b/troposphere/static/js/modals/InstanceModals.js
@@ -9,7 +9,8 @@ import IResumeModal from "./instance/resume";
 import IStartModal from "./instance/start";
 import IStopModal from "./instance/stop";
 import ISuspendModal from "./instance/suspend";
-
+import IShelveModal from "./instance/shelve";
+import IUnshelveModal from "./instance/unshelve";
 
 export default {
     createAndAddToProject: ICreateModal.createAndAddToProject,
@@ -22,5 +23,7 @@ export default {
     resume: IResumeModal.resume,
     start: IStartModal.start,
     stop: IStopModal.stop,
-    suspend: ISuspendModal.suspend
+    suspend: ISuspendModal.suspend,
+    shelve: IShelveModal.shelve,
+    unshelve: IUnshelveModal.unshelve
 };

--- a/troposphere/static/js/modals/instance/shelve.js
+++ b/troposphere/static/js/modals/instance/shelve.js
@@ -1,0 +1,15 @@
+import ModalHelpers from "components/modals/ModalHelpers";
+
+import InstanceShelveModal from "components/modals/instance/InstanceShelveModal";
+import actions from "actions";
+
+
+export default {
+    shelve: function(instance) {
+        ModalHelpers.renderModal(InstanceShelveModal, null, function() {
+            actions.InstanceActions.shelve({
+                instance: instance
+            })
+        });
+    }
+};

--- a/troposphere/static/js/modals/instance/unshelve.js
+++ b/troposphere/static/js/modals/instance/unshelve.js
@@ -1,0 +1,15 @@
+import ModalHelpers from "components/modals/ModalHelpers";
+
+import InstanceUnshelveModal from "components/modals/instance/InstanceUnshelveModal";
+import actions from "actions";
+
+
+export default {
+    unshelve: function(instance) {
+        ModalHelpers.renderModal(InstanceUnshelveModal, null, function() {
+            actions.InstanceActions.unshelve({
+                instance: instance
+            })
+        });
+    }
+};

--- a/troposphere/static/js/models/Instance.js
+++ b/troposphere/static/js/models/Instance.js
@@ -146,6 +146,9 @@ export default Backbone.Model.extend({
             "active - networking",
             "active - deploying",
             "active - initializing",
+            "active - shelving",
+            "active - shelving_image_pending_upload",
+            "active - shelving_image_uploading",
             "hard_reboot - rebooting_hard",
             "revert_resize - resize_reverting"
         ];
@@ -159,7 +162,13 @@ export default Backbone.Model.extend({
     },
 
     is_inactive: function() {
-        var states = ["suspended", "shutoff", "shutoff - powering-on"];
+        var states = [
+            "suspended",
+            "shutoff",
+            "shutoff - powering-on",
+            "shelved",
+            "shelved_offloaded"
+        ];
         return _.contains(states, this.get("status"));
     },
 

--- a/troposphere/static/js/models/InstanceState.js
+++ b/troposphere/static/js/models/InstanceState.js
@@ -31,6 +31,17 @@ var InstanceState = Backbone.Model.extend({
         return status === "active" && (activity === "deploy_error" || activity === "user_deploy_error");
     },
 
+    isInactive: function() {
+        let status = this.get("status");
+
+        return (
+            status === "suspended" ||
+            status == "shutoff" ||
+            status == "shelved" ||
+            status == "shelved_offloaded"
+        );
+    },
+
     getPercentComplete: function() {
         var status = this.get("status");
         var activity = this.get("activity");

--- a/troposphere/static/js/models/InstanceState.js
+++ b/troposphere/static/js/models/InstanceState.js
@@ -12,6 +12,7 @@ var InstanceState = Backbone.Model.extend({
             "error",
             "active - deploy_error",
             "active - user_deploy_error",
+            "shelved_offloaded",
             "suspended",
             "shutoff"
         ];
@@ -68,9 +69,12 @@ var get_percent_complete = function(state, activity) {
                 "image_uploading": 50,
                 "deleting": 50,
                 "suspending": 50,
+                "shelving": 50,
                 "initializing": 50,
                 "networking": 60,
                 "deploying": 70,
+                "shelving_image_pending_upload": 65,
+                "shelving_image_uploading": 88,
                 "running_boot_script": 90
             },
             "hard_reboot": {
@@ -84,6 +88,12 @@ var get_percent_complete = function(state, activity) {
             },
             "suspended": {
                 "resuming": 50
+            },
+            "shelved": {
+                "unshelving": 60
+            },
+            "shelved_offloaded": {
+                "spawning": 50
             },
             "error": {}
         };


### PR DESCRIPTION
## Description

This work adds the necessary components & actions for two operations (or one symmetric):
- Shelve
- Unshelve

"Shelving" instances is the best way to _free up_ resources on a provider without an outright deletion. Some operators have been shelving unused instances to reduce resource utilization. However, the owners of instances would have to contact the operators to get access to the instance. 

> Also, the changes here will indicate "inactive" instances as a "gray" dots. This is not _just_ for "Shelved_offload", but also "Shutoff" & "Suspended". We may wish to use a "calming" color to communicate a favorable decision (e.g. encourage "shelving") and an "agitating" color for operations that are less favorable.

**Note:** this used two Glyphicons to communicate _putting an instance on a shelf_ and _taking an instance off the shelf_. It is not clear that the available icon used is effective.

<details>

## Modals

### Shelve Instance

<img width="620" alt="screen shot 2017-04-27 at 3 45 44 pm" src="https://cloud.githubusercontent.com/assets/5923/25507636/166d7a54-2b62-11e7-89f5-593df2956e2a.png">

### Unshelve Instance

<img width="614" alt="screen shot 2017-04-27 at 4 01 07 pm" src="https://cloud.githubusercontent.com/assets/5923/25507716/b2748cd0-2b62-11e7-9fe8-7db42e113942.png">

## Instance Details

### Instance Actions shown to an "Active" instance

<img width="977" alt="screen shot 2017-04-27 at 3 45 28 pm" src="https://cloud.githubusercontent.com/assets/5923/25507637/166d748c-2b62-11e7-8918-eff8b87bf096.png">

### Instance Actions shown to a "Shelved_offload" instance

<img width="979" alt="screen shot 2017-04-27 at 3 50 33 pm" src="https://cloud.githubusercontent.com/assets/5923/25507635/166bd744-2b62-11e7-86ec-8ed4e741ea18.png">


</details>

## Checklist before merging Pull Requests
- [ ] ~New test(s) included to reproduce the bug/verify the feature~
- [ ] ~Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [x] Reviewed and approved by at least one other contributor.
