### PR TITLE
Problem: user interface ignores instance delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## [Xylotomous-Xenops](https://github.com/cyverse/troposphere/milestone/13?closed=1) (as of 4/25/2017)
+Features:
+  - Integrated in-app, live chat to answer question & help resolve issues
+  - All actions available on an instance are now driven by the API
+
+Enhancements:
+  - Improved readability of error notifications received
+  - Started including new user interface elements (part of mini-release effort, forthcoming)
+  
+Bugfixes:
+  - Corrected the "actions" shown for instance in "Active - Networking"
+  - Corrected issue with adding tags to Images
+  - Corrected problem where "Web Desktop" link shown for suspended instances
+
 ## [Whimsical-Wyvern](https://github.com/cyverse/troposphere/milestone/12?closed=1) (as of 3/21/2017)
 Features:
   - Provided a framework that allows support for custom messages within Troposphere UI

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ cffi==1.9.1               # via cryptography
 contextlib2==0.5.4        # via raven
 cryptography==1.7.2       # via pyopenssl
 debtcollector==1.11.0     # via oslo.config, oslo.utils, python-keystoneclient
-django-cyverse-auth==1.0.9
+django-cyverse-auth==1.0.14
 django-sslserver==0.18
 django-webpack-loader==0.3.0
 django==1.9.4

--- a/troposphere/static/js/AppRoutes.jsx
+++ b/troposphere/static/js/AppRoutes.jsx
@@ -92,10 +92,10 @@ function AppRoutes(props) {
                     AdminMaster, NotFoundPage
                 )}
             >
-                <Route name="atmosphere-user-manager" path="users" component={AtmosphereUserMaster} />
-                <Route name="identity-membership-manager" path="identities" component={IdentityMembershipMaster} />
-                <Route name="image-request-manager" path="imaging-requests" component={ImageMaster}>
-                    <Route name="image-request-detail" path=":id" component={ImageRequest} />
+                <Route path="users" component={AtmosphereUserMaster} />
+                <Route path="identities" component={IdentityMembershipMaster} />
+                <Route path="imaging-requests" component={ImageMaster}>
+                    <Route path=":id" component={ImageRequest} />
                 </Route>
                 <IndexRoute component={AtmosphereUserMaster} />
             </Route>

--- a/troposphere/static/js/actions/InstanceActions.js
+++ b/troposphere/static/js/actions/InstanceActions.js
@@ -11,6 +11,10 @@ import IUpdate from "./instance/update";
 import IReport from "./instance/report";
 import IRequest from "./instance/requestImage";
 
+import { shelve } from "./instance/shelve";
+import { unshelve } from "./instance/unshelve";
+
+
 export default {
     resume: IResume.resume,
     suspend: ISuspend.suspend,
@@ -24,5 +28,7 @@ export default {
     destroy: IDestroy.destroy,
     update: IUpdate.update,
     report: IReport.report,
-    requestImage: IRequest.requestImage
+    requestImage: IRequest.requestImage,
+    shelve,
+    unshelve
 };

--- a/troposphere/static/js/actions/instance/shelve.js
+++ b/troposphere/static/js/actions/instance/shelve.js
@@ -1,0 +1,57 @@
+import InstanceConstants from "constants/InstanceConstants";
+import InstanceState from "models/InstanceState";
+import Utils from "../Utils";
+import InstanceActionRequest from "models/InstanceActionRequest";
+
+
+const shelve = (params) => {
+        if (!params.instance)
+            throw new Error("Missing instance");
+
+        var instance = params.instance,
+            instanceState = new InstanceState({
+                status_raw: "active - shelving",
+                status: "active",
+                activity: "shelving"
+            }),
+            originalState = instance.get("state"),
+            actionRequest = new InstanceActionRequest({
+                instance: instance
+            });
+
+        instance.set({
+            state: instanceState
+        });
+        Utils.dispatch(InstanceConstants.UPDATE_INSTANCE, {
+            instance: instance
+        });
+
+        actionRequest.save(null, {
+            attrs: {
+                action: "shelve"
+            }
+        }).done(function() {
+            instance.set({
+                state: instanceState
+            });
+        }).fail(function(response) {
+            instance.set({
+                state: originalState
+            });
+            Utils.displayError({
+                title: "Your instance could not be shelved",
+                response: response
+            });
+        }).always(function() {
+            Utils.dispatch(InstanceConstants.UPDATE_INSTANCE, {
+                instance: instance
+            });
+            Utils.dispatch(InstanceConstants.POLL_INSTANCE_WITH_DELAY, {
+                instance: instance,
+                delay: 15*1000,
+            });
+        });
+}
+
+
+export { shelve };

--- a/troposphere/static/js/actions/instance/unshelve.js
+++ b/troposphere/static/js/actions/instance/unshelve.js
@@ -1,0 +1,55 @@
+import InstanceConstants from "constants/InstanceConstants";
+import InstanceState from "models/InstanceState";
+import Utils from "../Utils";
+import InstanceActionRequest from "models/InstanceActionRequest";
+
+const unshelve = (params) => {
+    if (!params.instance)
+        throw new Error("Missing instance");
+
+    var instance = params.instance,
+        instanceState = new InstanceState({
+            status_raw: "shelved - unshelving",
+            status: "active",
+            activity: "unshelving"
+        }),
+        originalState = instance.get("state"),
+        actionRequest = new InstanceActionRequest({
+            instance: instance
+        });
+
+    instance.set({
+        state: instanceState
+    });
+    Utils.dispatch(InstanceConstants.UPDATE_INSTANCE, {
+        instance: instance
+    });
+
+    actionRequest.save(null, {
+        attrs: {
+            action: "unshelve"
+        }
+    }).done(function() {
+        instance.set({
+            state: instanceState
+        });
+    }).fail(function(response) {
+        instance.set({
+            state: originalState
+        });
+        Utils.displayError({
+            title: "Your instance could not be unshelved",
+            response: response
+        });
+    }).always(function() {
+        Utils.dispatch(InstanceConstants.UPDATE_INSTANCE, {
+            instance: instance
+        });
+        Utils.dispatch(InstanceConstants.POLL_INSTANCE_WITH_DELAY, {
+            instance: instance,
+            delay: 25*1000,
+        });
+    });
+}
+
+export { unshelve };

--- a/troposphere/static/js/components/admin/AdminMaster.jsx
+++ b/troposphere/static/js/components/admin/AdminMaster.jsx
@@ -8,7 +8,7 @@ export default React.createClass({
         return (
         <div>
             <SecondaryAdminNavigation/>
-            <div style={{ paddingTop: "30px" }} className="container admin">
+            <div className="container admin">
                 <span className="adminHeader">
                     <h1 className="t-display-1">Admin</h1>
                     {this.props.children}

--- a/troposphere/static/js/components/admin/AtmosphereUserMaster.jsx
+++ b/troposphere/static/js/components/admin/AtmosphereUserMaster.jsx
@@ -80,7 +80,7 @@ export default React.createClass({
         }
 
         return (
-        <table className="table table-hover" style={{ marginTop: "20px" }}>
+        <table className="table table-hover">
             <tbody>
                 <tr className="admin-row">
                     <th style={{ border: "none" }}>
@@ -132,7 +132,7 @@ export default React.createClass({
     render: function() {
         return (
         <div className="resource-master">
-            <div id="user-container">
+            <div id="user-container" style={{marginBottom: "20px"}}>
                 <input type="text"
                     className="form-control search-input"
                     placeholder="Search for a specific user by username"
@@ -140,7 +140,7 @@ export default React.createClass({
                     value={this.state.query}
                     ref="textField" />
             </div>
-            <h3 className="t-body-2">Atmosphere Users</h3>
+            <h3 className="t-title">Atmosphere Users</h3>
             {this.renderTable()}
         </div>
         );

--- a/troposphere/static/js/components/admin/IdentityMembershipMaster.jsx
+++ b/troposphere/static/js/components/admin/IdentityMembershipMaster.jsx
@@ -164,16 +164,24 @@ export default React.createClass({
         }
         return false;
     },
+
     render: function() {
         return (
         <div className="resource-master">
             <div id="create-container">
-                <button className="btn btn-primary" onClick={this.launchNewProviderModal}>
-                    Create New Provider
-                </button>
-                <button className="btn btn-primary" disabled={this.newIdentityDisabled()} onClick={this.launchNewAccountModal}>
-                    Create New Account
-                </button>
+                <div className="pull-right">
+                    <button className="btn btn-primary"
+                            style={{marginBottom: "10px"}}
+                            onClick={this.launchNewProviderModal}>
+                        Create New Provider
+                    </button>
+                    <button className="btn btn-primary"
+                            style={{marginBottom: "10px", marginLeft: "10px"}}
+                            disabled={this.newIdentityDisabled()}
+                            onClick={this.launchNewAccountModal}>
+                        Create New Account
+                    </button>
+                </div>
             </div>
             <div id="membership-container">
                 <input type="text"

--- a/troposphere/static/js/components/admin/ImageMaster.jsx
+++ b/troposphere/static/js/components/admin/ImageMaster.jsx
@@ -44,11 +44,9 @@ const ImageMaster = React.createClass({
     },
 
     onResourceClick: function(request) {
-        this.props.router.transitionTo(
-            "image-request-detail", {
-                request: request,
-                id: request.id
-            });
+        let requestId = request.id;
+
+        this.props.router.push(`admin/imaging-requests/${requestId}`);
     },
 
     renderRefreshButton: function() {

--- a/troposphere/static/js/components/common/Glyphicon.jsx
+++ b/troposphere/static/js/components/common/Glyphicon.jsx
@@ -1,5 +1,10 @@
 import React from "react";
 
+/**
+ * a listing of the available icon within the existing module can be
+ * found here:
+ * - http://glyphicons.bootstrapcheatsheets.com/
+ */
 
 export default React.createClass({
     displayName: "Glyphicon",

--- a/troposphere/static/js/components/dashboard/plots/AllocationSourcePlot.jsx
+++ b/troposphere/static/js/components/dashboard/plots/AllocationSourcePlot.jsx
@@ -6,9 +6,21 @@ import stores from "stores";
 
 
 export default React.createClass({
-    displayName: "ProviderSummaryLinePlot",
+    displayName: "AllocationSourcePlot",
 
     propTypes: {
+    },
+
+    updateState: function() {
+        this.forceUpdate();
+    },
+
+    componentDidMount: function() {
+       stores.AllocationSourceStore.addChangeListener(this.updateState);
+    },
+
+    componentWillUnmount: function() {
+       stores.AllocationSourceStore.removeChangeListener(this.updateState);
     },
 
     seriesData: function(item) {

--- a/troposphere/static/js/components/help/HelpPage.jsx
+++ b/troposphere/static/js/components/help/HelpPage.jsx
@@ -18,11 +18,6 @@ let resources = [
         title: "FAQs",
         link_key: "faq",
         description: "Atmosphere's most frequently asked questions"
-    },
-    {
-        title: "VNC Viewer Tutorial",
-        link_key: "vnc-viewer",
-        description: "Instructions for downloading and using VNC Viewer"
     }
 ];
 

--- a/troposphere/static/js/components/images/common/Bookmark.jsx
+++ b/troposphere/static/js/components/images/common/Bookmark.jsx
@@ -8,6 +8,18 @@ import empty_star from "images/empty-star-icon.png";
 const Bookmark = React.createClass({
     displayName: "CommonBookmark",
 
+    updateState: function() {
+        this.forceUpdate();
+    },
+
+    componentDidMount: function() {
+       stores.ImageBookmarkStore.addChangeListener(this.updateState);
+    },
+
+    componentWillUnmount: function() {
+       stores.ImageBookmarkStore.removeChangeListener(this.updateState);
+    },
+
     toggleFavorite: function(e) {
         e.stopPropagation();
         e.preventDefault();

--- a/troposphere/static/js/components/modals/instance/InstanceLaunchWizardModal.jsx
+++ b/troposphere/static/js/components/modals/instance/InstanceLaunchWizardModal.jsx
@@ -62,6 +62,10 @@ export default React.createClass({
             }
         }
 
+        if (instanceName && instanceName.includes('.')) {
+            instanceName = instanceName.replace(/\./g, '_');
+        }
+
         return {
             // State for general operation (switching views, etc)
             view,
@@ -233,6 +237,11 @@ export default React.createClass({
 
     onSelectImage: function(image) {
         let instanceName = image.get("name");
+
+        if (instanceName && instanceName.includes('.')) {
+            instanceName = instanceName.replace(/\./g, '_');
+        }
+
         let imageVersionList = stores.ImageVersionStore.fetchWhere({
             image_id: image.id
         });
@@ -522,8 +531,8 @@ export default React.createClass({
         // All required fields are truthy
         let requiredExist = _.every(requiredFields, (prop) => Boolean(this.state[prop]))
 
-        return ( 
-            requiredExist 
+        return (
+            requiredExist
             && !this.exceedsResources()
             && !this.invalidName()
         )

--- a/troposphere/static/js/components/modals/instance/InstanceShelveModal.jsx
+++ b/troposphere/static/js/components/modals/instance/InstanceShelveModal.jsx
@@ -4,7 +4,7 @@ import BootstrapModalMixin from "components/mixins/BootstrapModalMixin";
 import Glyphicon from "components/common/Glyphicon";
 
 export default React.createClass({
-    displayName: "InstanceRedeployModal",
+    displayName: "InstanceShelveModal",
 
     mixins: [BootstrapModalMixin],
 
@@ -33,25 +33,28 @@ export default React.createClass({
             <p className="alert alert-warning">
                 <Glyphicon name="warning-sign" />
                 {" "}
-                <strong>NOTE</strong>
-                {" Redeploying an instance will allow you to fix instances that show up as 'active - deploy_error'. If after executing a 'redeploy' you find that your VM returns to the deploy_error state, please contact support."}
+                <strong>WARNING</strong>
+                {" Shelving an instance will freeze its state, and the IP address be removed from the instance."}
             </p>
             <p>
-                {"Would you like to redeploy this instance?"}
+                {'Shelving will safely preserve the state of your instance for later use. And, it frees up resources for other users . In fact, it is the best way to reduce resource usage when compared with other actions, like "suspend" and "stop".'}
+                {'Your time allocation no longer counts against you in the shelved mode.'}
+            </p>
+            <p>
+                {'Your resource usage charts will only reflect the freed resources once the instance\'s state is "shelved."'}
             </p>
         </div>
         );
     },
 
     render: function() {
-
         return (
         <div className="modal fade">
             <div className="modal-dialog">
                 <div className="modal-content">
                     <div className="modal-header">
                         {this.renderCloseButton()}
-                        <h1 className="t-title">Redeploy Instance</h1>
+                        <h1 className="t-title">Shelve Instance</h1>
                     </div>
                     <div className="modal-body">
                         {this.renderBody()}
@@ -65,7 +68,7 @@ export default React.createClass({
                         <RaisedButton
                             primary
                             onTouchTap={this.confirm}
-                            label="Yes, Redeploy Instance"
+                            label="Yes, shelve this instance"
                         />
                     </div>
                 </div>

--- a/troposphere/static/js/components/modals/instance/InstanceUnshelveModal.jsx
+++ b/troposphere/static/js/components/modals/instance/InstanceUnshelveModal.jsx
@@ -1,10 +1,9 @@
 import React from "react";
 import RaisedButton from "material-ui/RaisedButton";
 import BootstrapModalMixin from "components/mixins/BootstrapModalMixin";
-import Glyphicon from "components/common/Glyphicon";
 
 export default React.createClass({
-    displayName: "InstanceRedeployModal",
+    displayName: "InstanceUnshelveModal",
 
     mixins: [BootstrapModalMixin],
 
@@ -30,14 +29,11 @@ export default React.createClass({
     renderBody: function() {
         return (
         <div>
-            <p className="alert alert-warning">
-                <Glyphicon name="warning-sign" />
-                {" "}
-                <strong>NOTE</strong>
-                {" Redeploying an instance will allow you to fix instances that show up as 'active - deploy_error'. If after executing a 'redeploy' you find that your VM returns to the deploy_error state, please contact support."}
+            <p>
+                {"Would you like to unshelve this instance?"}
             </p>
             <p>
-                {"Would you like to redeploy this instance?"}
+                Your instance's IP address will have change once it is available.
             </p>
         </div>
         );
@@ -51,21 +47,21 @@ export default React.createClass({
                 <div className="modal-content">
                     <div className="modal-header">
                         {this.renderCloseButton()}
-                        <h1 className="t-title">Redeploy Instance</h1>
+                        <h1 className="t-title">Unshelve Instance</h1>
                     </div>
                     <div className="modal-body">
                         {this.renderBody()}
                     </div>
                     <div className="modal-footer">
                         <RaisedButton
-                            style={{ marginRight: "10px" }}
+                            style={{ marginRight: "10Px" }}
                             onTouchTap={this.cancel}
                             label="Cancel"
                         />
                         <RaisedButton
                             primary
                             onTouchTap={this.confirm}
-                            label="Yes, Redeploy Instance"
+                            label="Yes, unshelve this instance"
                         />
                     </div>
                 </div>

--- a/troposphere/static/js/components/projects/detail/resources/ProjectDetails.jsx
+++ b/troposphere/static/js/components/projects/detail/resources/ProjectDetails.jsx
@@ -27,6 +27,30 @@ export default React.createClass({
     },
 
     updateState: function() {
+        let project = this.props.project;
+        let externalLinks = stores.ProjectExternalLinkStore.getExternalLinksFor(project);
+        let instances = stores.ProjectInstanceStore.getInstancesFor(project);
+        let volumes = stores.ProjectVolumeStore.getVolumesFor(project);
+        let images = stores.ProjectImageStore.getImagesFor(project);
+        let selectedResources = this.state.selectedResources;
+
+
+        if (instances && volumes && images &&  externalLinks) {
+
+            // Take into account that selected resources may be out of date, that
+            // it may contain resources that no longer exist in the endpoints
+            let selectedThatStillExist = selectedResources.cfilter(r => {
+                return  instances.contains(r) ||
+                        volumes.contains(r) ||
+                        images.contains(r) ||
+                        externalLinks.contains(r);
+            });
+
+            this.setState({
+                selectedResources: selectedThatStillExist
+            });
+        }
+
         this.forceUpdate();
     },
 

--- a/troposphere/static/js/components/projects/detail/resources/SubMenu.jsx
+++ b/troposphere/static/js/components/projects/detail/resources/SubMenu.jsx
@@ -87,15 +87,16 @@ export default React.createClass({
         }
 
         return (
-        <div className="sub-menu" 
-            style={{ 
+        <div className="sub-menu"
+            style={{
                 display: "inline-block",
                 marginRight: "10px"
-            }}    
+            }}
         >
             <div className="dropdown">
                 <button id="res-new-menu"
                         className="btn btn-primary dropdown-toggle"
+                        style={{ height: "36px" }}
                         data-toggle="dropdown">
                     New
                 </button>

--- a/troposphere/static/js/components/projects/detail/resources/tableData/instance/Status.jsx
+++ b/troposphere/static/js/components/projects/detail/resources/tableData/instance/Status.jsx
@@ -20,8 +20,10 @@ export default React.createClass({
             lightStatus = "transition";
         } else if (status == "active") {
             lightStatus = "active";
-        } else if (status == "suspended" || status == "shutoff") {
-            lightStatus = "inactive";
+        } else if (instanceState.isInactive()) {
+            // default of <StatusLight/> is gray,
+            // so let's signal inactivity as gray
+            lightStatus = "";
         } else if (status == "deleted") {
             lightStatus = "deleted";
         } else {
@@ -34,15 +36,17 @@ export default React.createClass({
 
         if (instanceState.isDeployError()) {
             return (
-            <span><div> <StatusLight status="error"/> <span style={style}>{status}</span> </div>
+            <span>
+                <div> <StatusLight status="error"/> <span style={style}>{status}</span> </div>
             </span>
             );
         }
 
         return (
-        <span><div> <StatusLight status={lightStatus}/> <span style={style}>{status}</span> </div>
-        <StatusBar state={instanceState}
-            activity={activity} />
+        <span>
+            <div> <StatusLight status={lightStatus}/> <span style={style}>{status}</span> </div>
+            <StatusBar state={instanceState}
+                       activity={activity} />
         </span>
         );
     }

--- a/troposphere/static/js/components/projects/resources/instance/details/actions/InstanceActionsAndLinks.jsx
+++ b/troposphere/static/js/components/projects/resources/instance/details/actions/InstanceActionsAndLinks.jsx
@@ -46,6 +46,12 @@ export default React.createClass({
                 onClick: this.onSuspend
             },
             {
+                key: InstanceActionNames.SHELVE,
+                label: "Shelve",
+                icon: "log-in",
+                onClick: this.onShelve
+            },
+            {
                 key: InstanceActionNames.STOP,
                 label: "Stop",
                 icon: "stop",
@@ -58,9 +64,15 @@ export default React.createClass({
                 onClick: this.onResume
             },
             {
+                key: InstanceActionNames.UNSHELVE,
+                label: "Unshelve",
+                icon: "log-out",
+                onClick: this.onUnshelve
+            },
+            {
                 key: InstanceActionNames.REBOOT,
                 label: "Reboot",
-                icon: "repeat",
+                icon: "off",
                 onClick: this.onReboot
             },
             {
@@ -122,6 +134,13 @@ export default React.createClass({
     },
 
     onReport: function() {
+        modals.InstanceModals.report({
+            instance: this.props.instance
+        });
+
+/*
+        // This needs to be flagged to handle the case where
+        // Intercom platform is used, but Respond is *not*
         if (!featureFlags.hasIntercomActive()) {
             modals.InstanceModals.report({
                 instance: this.props.instance
@@ -133,6 +152,7 @@ export default React.createClass({
             window.Intercom('showNewMessage',
                             'I am having issues with an instance. ');
         }
+ */
     },
 
     onImageRequest: function() {
@@ -164,6 +184,13 @@ export default React.createClass({
         modals.InstanceModals.reboot(this.props.instance);
     },
 
+    onShelve: function() {
+        modals.InstanceModals.shelve(this.props.instance);
+    },
+
+    onUnshelve: function() {
+        modals.InstanceModals.unshelve(this.props.instance);
+    },
 
     onWebDesktop: function(ipAddr, instance) {
         // TODO:

--- a/troposphere/static/js/components/projects/resources/volume/details/actions/VolumeActionsAndLinks.jsx
+++ b/troposphere/static/js/components/projects/resources/volume/details/actions/VolumeActionsAndLinks.jsx
@@ -31,6 +31,13 @@ export default React.createClass({
     },
 
     handleReport: function() {
+        modals.VolumeModals.report({
+            volume: this.props.volume
+        });
+
+/*
+        // This needs to be flagged to handle the case where
+        // Intercom platform is used, but Respond is *not*
         if (!featureFlags.hasIntercomActive()) {
             modals.VolumeModals.report({
                 volume: this.props.volume
@@ -42,6 +49,7 @@ export default React.createClass({
             window.Intercom('showNewMessage',
                             'I am having issues with a volume. ');
         }
+ */
     },
 
     render: function() {

--- a/troposphere/static/js/components/projects/resources/volume/details/sections/VolumeInfoSection.jsx
+++ b/troposphere/static/js/components/projects/resources/volume/details/sections/VolumeInfoSection.jsx
@@ -69,7 +69,7 @@ export default React.createClass({
                     {nameContent}
                 </div>
                 <div className="resource-launch-date">
-                    {`Launched on `}
+                    {`Created on `}
                     <Time date={volume.get("start_date")} />
                 </div>
             </div>

--- a/troposphere/static/js/modals/InstanceModals.js
+++ b/troposphere/static/js/modals/InstanceModals.js
@@ -9,7 +9,8 @@ import IResumeModal from "./instance/resume";
 import IStartModal from "./instance/start";
 import IStopModal from "./instance/stop";
 import ISuspendModal from "./instance/suspend";
-
+import IShelveModal from "./instance/shelve";
+import IUnshelveModal from "./instance/unshelve";
 
 export default {
     createAndAddToProject: ICreateModal.createAndAddToProject,
@@ -22,5 +23,7 @@ export default {
     resume: IResumeModal.resume,
     start: IStartModal.start,
     stop: IStopModal.stop,
-    suspend: ISuspendModal.suspend
+    suspend: ISuspendModal.suspend,
+    shelve: IShelveModal.shelve,
+    unshelve: IUnshelveModal.unshelve
 };

--- a/troposphere/static/js/modals/instance/shelve.js
+++ b/troposphere/static/js/modals/instance/shelve.js
@@ -1,0 +1,15 @@
+import ModalHelpers from "components/modals/ModalHelpers";
+
+import InstanceShelveModal from "components/modals/instance/InstanceShelveModal";
+import actions from "actions";
+
+
+export default {
+    shelve: function(instance) {
+        ModalHelpers.renderModal(InstanceShelveModal, null, function() {
+            actions.InstanceActions.shelve({
+                instance: instance
+            })
+        });
+    }
+};

--- a/troposphere/static/js/modals/instance/unshelve.js
+++ b/troposphere/static/js/modals/instance/unshelve.js
@@ -1,0 +1,15 @@
+import ModalHelpers from "components/modals/ModalHelpers";
+
+import InstanceUnshelveModal from "components/modals/instance/InstanceUnshelveModal";
+import actions from "actions";
+
+
+export default {
+    unshelve: function(instance) {
+        ModalHelpers.renderModal(InstanceUnshelveModal, null, function() {
+            actions.InstanceActions.unshelve({
+                instance: instance
+            })
+        });
+    }
+};

--- a/troposphere/static/js/models/Instance.js
+++ b/troposphere/static/js/models/Instance.js
@@ -16,6 +16,9 @@ export default Backbone.Model.extend({
     },
 
     parse: function(attributes) {
+        if (attributes.name == null || attributes.name == "") {
+            attributes.name = "<Unnamed Instance>";
+        }
         attributes.start_date = new Date(attributes.start_date);
         attributes.state = new InstanceState({
             status_raw: attributes.status,
@@ -146,6 +149,9 @@ export default Backbone.Model.extend({
             "active - networking",
             "active - deploying",
             "active - initializing",
+            "active - shelving",
+            "active - shelving_image_pending_upload",
+            "active - shelving_image_uploading",
             "hard_reboot - rebooting_hard",
             "revert_resize - resize_reverting"
         ];
@@ -159,7 +165,13 @@ export default Backbone.Model.extend({
     },
 
     is_inactive: function() {
-        var states = ["suspended", "shutoff", "shutoff - powering-on"];
+        var states = [
+            "suspended",
+            "shutoff",
+            "shutoff - powering-on",
+            "shelved",
+            "shelved_offloaded"
+        ];
         return _.contains(states, this.get("status"));
     },
 

--- a/troposphere/static/js/models/InstanceState.js
+++ b/troposphere/static/js/models/InstanceState.js
@@ -12,6 +12,7 @@ var InstanceState = Backbone.Model.extend({
             "error",
             "active - deploy_error",
             "active - user_deploy_error",
+            "shelved_offloaded",
             "suspended",
             "shutoff"
         ];
@@ -28,6 +29,17 @@ var InstanceState = Backbone.Model.extend({
         var activity = this.get("activity");
 
         return status === "active" && (activity === "deploy_error" || activity === "user_deploy_error");
+    },
+
+    isInactive: function() {
+        let status = this.get("status");
+
+        return (
+            status === "suspended" ||
+            status == "shutoff" ||
+            status == "shelved" ||
+            status == "shelved_offloaded"
+        );
     },
 
     getPercentComplete: function() {
@@ -68,9 +80,12 @@ var get_percent_complete = function(state, activity) {
                 "image_uploading": 50,
                 "deleting": 50,
                 "suspending": 50,
+                "shelving": 50,
                 "initializing": 50,
                 "networking": 60,
                 "deploying": 70,
+                "shelving_image_pending_upload": 65,
+                "shelving_image_uploading": 88,
                 "running_boot_script": 90
             },
             "hard_reboot": {
@@ -84,6 +99,12 @@ var get_percent_complete = function(state, activity) {
             },
             "suspended": {
                 "resuming": 50
+            },
+            "shelved": {
+                "unshelving": 60
+            },
+            "shelved_offloaded": {
+                "spawning": 50
             },
             "error": {}
         };

--- a/troposphere/static/js/models/Size.js
+++ b/troposphere/static/js/models/Size.js
@@ -13,6 +13,16 @@ export default Backbone.Model.extend({
         });
     },
 
+    hasResources: function() {
+        let resources = [this.get("cpu"), this.get("mem")];
+
+        if (this.get("disk")) {
+            resources.push(this.get("disk"));
+        }
+
+        return resources.every((r) => r > 0);
+    },
+
     formattedDetails: function() {
         var parts = [
             this.get("cpu") + " CPUs",
@@ -24,7 +34,8 @@ export default Backbone.Model.extend({
         if (this.get("root")) {
             parts.push(this.get("root") + " GB root");
         }
+        let details = this.hasResources() ? `(${parts.join(", ")})` : "";
 
-        return this.get("name") + " (" + parts.join(", ") + ")";
+        return `${this.get("name")} ${details}`;
     }
 });

--- a/troposphere/static/js/models/Volume.js
+++ b/troposphere/static/js/models/Volume.js
@@ -20,6 +20,9 @@ export default Backbone.Model.extend({
     urlRoot: globals.API_V2_ROOT + "/volumes",
 
     parse: function(attributes) {
+        if (attributes.name == null || attributes.name == "") {
+            attributes.name = "<Unnamed Volume>";
+        }
         if (attributes.start_date) {
             attributes.start_date = new Date(attributes.start_date);
         }

--- a/troposphere/static/js/stores/InstanceStore.js
+++ b/troposphere/static/js/stores/InstanceStore.js
@@ -3,6 +3,7 @@ import BaseStore from "stores/BaseStore";
 import InstanceCollection from "collections/InstanceCollection";
 import Utils from "actions/Utils";
 import InstanceConstants from "constants/InstanceConstants";
+import ProjectInstanceConstants from "constants/ProjectInstanceConstants";
 import InstanceState from "models/InstanceState";
 import EventConstants from "constants/EventConstants";
 
@@ -77,7 +78,14 @@ var InstanceStore = BaseStore.extend({
         this.pollWhile(instance, function(model, response) {
             // If 404 then remove the model
             if (response.status == "404") {
-                this.remove(model);
+                Utils.dispatch(InstanceConstants.REMOVE_INSTANCE, {
+                    instance: model
+                });
+                // This is a hack. Some components only listen to the
+                // ProjectInstanceStore. We need them to react when an
+                // instance is deleted, so we prompt the addChangeListeners of
+                // each of those components here.
+                Utils.dispatch(ProjectInstanceConstants.EMIT_CHANGE);
 
                 return false;
             }


### PR DESCRIPTION
## Description

This pr depends on master getting the upstream changes in xx, which is a separate pr [here](https://github.com/cyverse/troposphere/pull/599).

Synopsis:
We didn't guard the case where deletion of a resource (say through nova) followed by the tropo refresh button  may cause an invalid selection in the ui.

See [ATMO-1859](https://pods.iplantcollaborative.org/jira/browse/ATMO-1859).
## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature
- [x] Reviewed and approved by at least one other contributor.
