### PR TITLE
Add instructions for webpack dev server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,33 @@
 Troposphere
 ===========
-                                                        
+
 ## Development
 
-### Continuous development and quick feedback
+### Quick feedback
 
 The `webpack-dev-server` will serve new bundles to a browser when files
 change.
 
 It has the following features:
 
-- Changes result in a browser refresh (you know they are propagated)      
+- Changes result in a browser refresh (you know they are propagated)
 - The bundle is served from memory not disk
 - Small changes result in small compiles
 
-To run webpack dev server:
+Currently troposphere uses nginx to serve its assets. This makes it trivial to
+serve these assets from the dev server.
 
-Set the following variable in `variables.ini`:
-```bash
-[local.py]
-...
-BASE_URL = "https://<host name>:8080"
-...
+Update your nginx definition (at `/etc/nginx/locations/tropo.conf`)
+```nginx
+location /assets {
+    # This just needs to point to the dev server which runs on 8080
+    proxy_pass https://atmo.local.cloud:8080;
+}
 ```
 
-Finally run:
-
+Finally start the dev server:
 ```bash
-npm run server
+npm run serve -- --cert /path/to/cert --key /path/to/key
 ```
 
 ### Linting

--- a/extras/nginx/locations/tropo.conf.j2
+++ b/extras/nginx/locations/tropo.conf.j2
@@ -2,14 +2,6 @@ location /assets {
     alias {{ ASSETS_PATH }};
 }
 
-location /assets/bundles {
-    alias {{ ASSETS_PATH }}/bundles;
-}
-
-location /assets/theme {
-    alias {{ ASSETS_PATH }}/theme;
-}
-
 location ~^/(application|maintenance|login|globus_login|oauth2.0/callbackAuthorize|logout|forbidden|version|cf2|tropo-admin|tropo-api|web_shell|web_desktop|allocations) {
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## Description

This pr lays out how to setup webpack-dev-server. My previous setup was jenky, and some of the assets didn't load. This is short and much nicer.

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature
- [x] Reviewed and approved by at least one other contributor.
