### PR TITLE
Problem: Maintenance messages do not persist in new lines (\n) in render

### DIFF
--- a/troposphere/templates/login.html
+++ b/troposphere/templates/login.html
@@ -38,11 +38,8 @@
                     <div class='maintenance-message'
                          id='maintenance-record-{{ record.id }}'>
                         <i class="glyphicon glyphicon-info-sign icon-white"></i>
-                    {% if record.provider %}
-                        {{ record.provider }} {{ record.message }}
-                    {% else %}
-                        {{ record.message }}
-                    {% endif %}</div>
+                        {{ record.message |safe }}
+                    </div>
                 {% endfor %}
             </div>
         </div>

--- a/troposphere/views/maintenance.py
+++ b/troposphere/views/maintenance.py
@@ -4,8 +4,15 @@ from django.shortcuts import render, redirect, render_to_response
 from django.template import RequestContext
 
 from api.models import MaintenanceRecord, MaintenanceNotice
+def replace_with_br(x):
+    return x.replace("\n", "<br/>")
 
-
+def replace_html(x):
+    message = replace_with_br(x.message)
+    return { 
+        'message': message,
+    }
+    
 def get_maintenance(request):
     """
     Returns a list of maintenance records along with a boolean to indicate
@@ -14,7 +21,8 @@ def get_maintenance(request):
     records = MaintenanceRecord.active()
     disable_login = MaintenanceRecord.disable_login_access(request)
     in_maintenance = records.count() > 0
-    return (records, disable_login, in_maintenance)
+    clean_records = list(map(replace_html, records))
+    return (clean_records, disable_login, in_maintenance)
 
 
 def get_notice(request):


### PR DESCRIPTION
## Description
Sometimes a maintenance record wants to have new lines. It is more useful to use `\n` for this. Because HTML doesn't respect `\n` we need to replace this with `<br/>` before rendering in our template.  

_Note: that I removed the check for `record.provider` because it seems like dead code. With my best efforts I can't see that it exists in the model. If we want to account for `record.provider` and I am missing something then [this branch](https://github.com/Tharon-C/troposphere/tree/ATMO-1863-if-provider) can be used instead._

### After Change
Shows that the middle message containing `\n` has spaces where desired. 
<img width="929" alt="screen shot 2017-05-05 at 5 15 01 pm" src="https://cloud.githubusercontent.com/assets/7366338/25768381/eaf898de-31b7-11e7-86f6-5e874bdc8937.png">
shows the `<br/>` added to the markup
<img width="565" alt="screen shot 2017-05-05 at 5 26 56 pm" src="https://cloud.githubusercontent.com/assets/7366338/25768392/13513246-31b8-11e7-819a-e7ba6bed1582.png">

## Checklist before merging Pull Requests
- [x] Reviewed and approved by at least one other contributor.
