### PR TITLE
Problem: project resources looks awkward at medium screen sizes

### DIFF
--- a/troposphere/static/js/components/projects/detail/resources/ButtonBar.jsx
+++ b/troposphere/static/js/components/projects/detail/resources/ButtonBar.jsx
@@ -72,13 +72,7 @@ export default React.createClass({
                     isVisible={context.profile.get("is_superuser") && this.props.isVisible} />
 
             </div>
-            <div
-                style={{
-                    display: "flex",
-                    justifyContent: "flex-end",
-                    flex: "1"
-                }}
-            >
+            <div>
                 <ResourceActionButtons onUnselect={this.props.onUnselect}
                     previewedResource={this.props.previewedResource}
                     multipleSelected={this.props.multipleSelected}

--- a/troposphere/static/js/components/projects/detail/resources/ExternalLinkActionButtons.jsx
+++ b/troposphere/static/js/components/projects/detail/resources/ExternalLinkActionButtons.jsx
@@ -33,7 +33,12 @@ export default React.createClass({
         );
 
         return (
-        <div>
+        <div style={{
+            display: "flex",
+            justifyContent: "flex-end",
+            flex: "1 1 10%",
+            flexWrap: "nowrap"
+        }}>
             {linksArray}
         </div>
         );

--- a/troposphere/static/js/components/projects/detail/resources/ImageActionButtons.jsx
+++ b/troposphere/static/js/components/projects/detail/resources/ImageActionButtons.jsx
@@ -32,7 +32,12 @@ export default React.createClass({
         );
 
         return (
-        <div>
+        <div style={{
+            display: "flex",
+            justifyContent: "flex-end",
+            flex: "1 1 10%",
+            flexWrap: "nowrap"
+        }}>
             {linksArray}
         </div>
         );

--- a/troposphere/static/js/components/projects/detail/resources/InstanceActionButtons.jsx
+++ b/troposphere/static/js/components/projects/detail/resources/InstanceActionButtons.jsx
@@ -110,7 +110,12 @@ export default React.createClass({
         }
 
         return (
-        <div className="clearfix u-md-pull-right">
+        <div style={{
+            display: "flex",
+            justifyContent: "flex-end",
+            flex: "1 1 10%",
+            flexWrap: "nowrap"
+        }}>
             {linksArray}
         </div>
         );

--- a/troposphere/static/js/components/projects/detail/resources/VolumeActionButtons.jsx
+++ b/troposphere/static/js/components/projects/detail/resources/VolumeActionButtons.jsx
@@ -66,7 +66,12 @@ export default React.createClass({
         );
 
         return (
-        <div>
+        <div style={{
+            display: "flex",
+            justifyContent: "flex-end",
+            flex: "1 1 10%",
+            flexWrap: "nowrap"
+        }}>
             {linksArray}
         </div>
         );


### PR DESCRIPTION
## Description
The group of batch action buttons on the project resource page wrap awkwardly at reasonable desktop widths. 

This is a temporary solution until we have a dedicated batch action bar that keeps all of the buttons in one wrapper. It's better but still pretty bad. :(

_Note: Since the styles are repeated several times, it would seem to be better to make this a class or component. However, since this is temporary, the styles are inline. This way, removing later will be easier because the code is bound to the component where class declarations are not and harder to delete with confidence._

### Before
Shows that buttons on the right collapse 
<img width="896" alt="screen shot 2017-05-08 at 10 36 22 am" src="https://cloud.githubusercontent.com/assets/7366338/25816880/69c35f2c-33da-11e7-8d53-4e90c73bfa00.png">

### After
Shows buttons on the right move below first group
<img width="884" alt="screen shot 2017-05-08 at 10 36 40 am" src="https://cloud.githubusercontent.com/assets/7366338/25816912/80280ccc-33da-11e7-827a-e5330d46a230.png">

This is a temporary fix 
## Checklist before merging Pull Requests
- [x] Reviewed and approved by at least one other contributor.
