### PR TITLE
Problem: Request more resources modal doesn't default to a provider when expected

### DIFF
--- a/troposphere/static/js/components/modals/RequestMoreResourcesModal.jsx
+++ b/troposphere/static/js/components/modals/RequestMoreResourcesModal.jsx
@@ -12,6 +12,7 @@ export default React.createClass({
 
     propTypes: {
         identity: React.PropTypes.number,
+        onConfirm: React.PropTypes.func.isRequired
     },
 
     getInitialState: function() {
@@ -55,11 +56,6 @@ export default React.createClass({
         return hasResources && hasReason;
     },
 
-    //
-    // Internal Modal Callbacks
-    // ------------------------
-    //
-
     cancel: function() {
         this.hide();
     },
@@ -69,14 +65,6 @@ export default React.createClass({
         this.props.onConfirm(this.state.identity, this.state.resources, this.state.reason);
     },
 
-    //
-    // Custom Modal Callbacks
-    // ----------------------
-    //
-
-    // todo: I don't think there's a reason to update state unless
-    // there's a risk of the component being re-rendered by the parent.
-    // Should probably verify this behavior, but for now, we play it safe.
     handleIdentityChange: function(e) {
         this.setState({
             identity: Number(e.target.value)
@@ -95,10 +83,6 @@ export default React.createClass({
         });
     },
 
-    //
-    // Render
-    // ------
-    //
     renderAllocationSourceText: function() {
         return (
         <div>
@@ -135,6 +119,12 @@ export default React.createClass({
     renderBody: function() {
         var identities = stores.IdentityStore.getAll(),
             selectedIdentity = this.state.identity,
+
+            // Hack: We have to call this method to populate the request
+            // store. When this modal is submitted (see the call to onConfirm
+            // above), a single resource request gets posted. When the
+            // callback succeeds, the new request is added to the store. If
+            // the store is not populated (models is null), then adding fails.
             requests = stores.ResourceRequestStore.getAll();
 
         let isLoading =

--- a/troposphere/static/js/components/modals/instance/InstanceLaunchWizardModal.jsx
+++ b/troposphere/static/js/components/modals/instance/InstanceLaunchWizardModal.jsx
@@ -380,7 +380,9 @@ export default React.createClass({
 
     onRequestResources: function() {
         this.hide();
-        modals.HelpModals.requestMoreResources(this);
+        modals.HelpModals.requestMoreResources({
+            identity: this.state.identityProvider.id
+        });
     },
 
     onAddAttachedScript: function(value) {

--- a/troposphere/static/js/modals/help/requestMoreResources.js
+++ b/troposphere/static/js/modals/help/requestMoreResources.js
@@ -13,8 +13,8 @@ let RequestModal = globals.USE_ALLOCATION_SOURCES ?
 
 export default {
 
-    requestMoreResources: function() {
-        ModalHelpers.renderModal(RequestModal, null, function(identity, quota, reason) {
+    requestMoreResources: function(props) {
+        ModalHelpers.renderModal(RequestModal, props, function(identity, quota, reason) {
             actions.HelpActions.requestMoreResources({
                 identity,
                 quota,


### PR DESCRIPTION
## Description

Resolves [ATMO-1784](https://pods.iplantcollaborative.org/jira/browse/ATMO-1784)
In some circumstances, like when a user is trying to launch an instance, if the user is over resource limit or will be for a particular Provider, the user is given the chance to request more resources. It is a reasonable expectation that in the Request Modal presented to the user, the provider they are requesting for is already populated. Instead the provider is set to the first in the collection. This is awkward and could lead to requests being made to the wrong provider. 

Now when the user is requesting in the case described, the expected provider is set as default.

### Screen Shots
Shows that whatever provider selected on Instance Launch Modal is default on RequestResource modal
![after-atmo-1784](https://cloud.githubusercontent.com/assets/7366338/25969552/2de17a9e-364a-11e7-9922-5d8e9486181d.gif)

Shows that the default provider otherwise is the first in the collection
![after-atmo-1784-without-passing-prop](https://cloud.githubusercontent.com/assets/7366338/25969577/48539e8e-364a-11e7-975e-1c186b9fc143.gif)

## Checklist before merging Pull Requests
- [ ] Reviewed and approved by at least one other contributor.
