### PR TITLE
Problem: Image Detail Pages doesn't let the user know if Image is 404

### DIFF
--- a/troposphere/static/js/components/images/ImageDetailsPage.jsx
+++ b/troposphere/static/js/components/images/ImageDetailsPage.jsx
@@ -4,6 +4,7 @@ import context from "context";
 import stores from "stores";
 
 import ImageDetailsView from "./detail/ImageDetailsView";
+import NotFoundPage from "components/NotFoundPage";
 
 export default React.createClass({
     displayName: "ImageDetailsPage",
@@ -31,13 +32,15 @@ export default React.createClass({
     },
 
     renderBody: function() {
-        var image = stores.ImageStore.get(Number(this.props.params.imageId)),
+        var image = stores.ImageStore.getMaybe(Number(this.props.params.imageId)),
             tags = stores.TagStore.getAll(),
             hasLoggedInUser = context.hasLoggedInUser(),
             providers = hasLoggedInUser ? stores.ProviderStore.getAll() : null,
             identities = hasLoggedInUser ? stores.IdentityStore.getAll() : null;
 
-        if (!image || !tags) return <div className="loading"></div>;
+        if (!image || !tags) return <div className="loading"/>;
+
+        if (image.status === 404) return <NotFoundPage/>;
 
         // If the user isn't logged in, display the public view, otherwise
         // wait for providers and instances to be fetched


### PR DESCRIPTION
## Description

This resolves [ATMO-1771](https://pods.iplantcollaborative.org/jira/browse/ATMO-1771)

If a user visits an image detail directly, for example from a link provided in an email, if that image doesn't exist or is not permitted the page shows an infinite spinner. Instead we want to show a 404 page.
 
The solution here deals with the fact that are current models are null until we have a valid model returned from the server. Because of this there is no way to tell if we are still fetching or the response was 404. 

To get around this a new method was added to return a model with a status of 404 if that is the case. Since many areas are affected by the image store and we will hopefully soon have something better than the  "null pattern" this was the least invasive approach.

#### Another issue
Captured in [ATMO-1877](https://pods.iplantcollaborative.org/jira/browse/ATMO-1877)
In another PR we should rework the 404 page so that it can be used in different contexts. Like if the user is not logged in, it suggests they do, and to add a prop for what is missing, say a page or a resource like an image in this case.

Something like this: 
```
The ${ props.missingResource } you are trying to view...
```
 This way it can be used for images, or instances as well as pages.
### Screen Shot
The user is not logged in and on an image detail that returns 404, now a 404 page is shown.
<img width="1434" alt="screen shot 2017-05-18 at 9 38 26 am" src="https://cloud.githubusercontent.com/assets/7366338/26213996/be288394-3baf-11e7-83fd-1031486f7900.png">


## Checklist before merging Pull Requests
- [x] Reviewed and approved by at least one other contributor.
