### PR TITLE
Problem: NotFoundPage isn't reusable in most cases

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "material-ui": "^0.17.1",
     "moment": "^2.10.6",
     "moment-timezone": "^0.5.1",
+    "prop-types": "^15.5.10",
     "q": "^1.4.1",
     "raven-js": "^3.13.0",
     "react": "^15.*.*",

--- a/troposphere/static/js/components/NotFoundPage.jsx
+++ b/troposphere/static/js/components/NotFoundPage.jsx
@@ -1,30 +1,41 @@
 import React from "react";
+import { hasLoggedInUser } from 'utilities/profilePredicate';
+import { capitalize } from 'utilities/str';
+
 import Glyphicon from "components/common/Glyphicon";
+import stores from "stores";
 
 
 export default React.createClass({
     displayName: "NotFoundPage",
 
     render: function() {
-        let window_location = window.location.pathname;
+        const { resource = "page" } = this.props;
+        const window_location = window.location.pathname;
+        const profile = stores.ProfileStore.get();
+        const isLoggedIn = hasLoggedInUser(profile);
 
         return (
         <div style={{ paddingTop: "50px" }} className="container">
-            <h1 className="t-display-1">Page Unavailable</h1>
+            <h1 className="t-display-1">
+                {`${capitalize(resource)} Unavailable`}
+            </h1>
             <div>
-                <p style={{ "fontSize": "133%" }}>
+                <p style={{ fontSize: "20px" }}>
                     <Glyphicon name="info-sign" />
-                    {`
-                    The requested page cannot be viewed because
+                    {` The requested ${resource} cannot be viewed because
                     it either does not exist or you do not currently
-                    have permission to view it.
-                `}
+                    have permission to view it.`}
                 </p>
-                <p style={{ "fontSize": "133%" }}>
-                    {`This page may be visible if you `}
-                    <a href={"/login?redirect_to=" + window_location}>log in</a>
-                    {`.`}
-                </p>
+                {
+                    isLoggedIn ?  null : (
+                        <p style={{ fontSize: "20px" }}>
+                            {`This ${resource} may be visible if you `}
+                            <a href={"/login?redirect_to=" + window_location}>log in</a>
+                            {`.`}
+                        </p>
+                    )
+                }
             </div>
         </div>
         );

--- a/troposphere/static/js/components/NotFoundPage.jsx
+++ b/troposphere/static/js/components/NotFoundPage.jsx
@@ -1,4 +1,6 @@
 import React from "react";
+import PropTypes from 'prop-types';
+
 import { hasLoggedInUser } from 'utilities/profilePredicate';
 import { capitalize } from 'utilities/str';
 
@@ -8,6 +10,10 @@ import stores from "stores";
 
 export default React.createClass({
     displayName: "NotFoundPage",
+
+    proptypes: {
+        resource: PropTypes.string,
+    },
 
     render: function() {
         const { resource = "page" } = this.props;
@@ -40,5 +46,4 @@ export default React.createClass({
         </div>
         );
     }
-
 })

--- a/troposphere/static/js/components/images/ImageDetailsPage.jsx
+++ b/troposphere/static/js/components/images/ImageDetailsPage.jsx
@@ -40,7 +40,9 @@ export default React.createClass({
 
         if (!image || !tags) return <div className="loading"/>;
 
-        if (image.status === 404) return <NotFoundPage/>;
+        if (image.status === 404) return (
+            <NotFoundPage resource="image"/>
+        );
 
         // If the user isn't logged in, display the public view, otherwise
         // wait for providers and instances to be fetched

--- a/troposphere/static/js/utilities/str.js
+++ b/troposphere/static/js/utilities/str.js
@@ -1,0 +1,3 @@
+export const capitalize = ([first,...rest]) => (
+    first.toUpperCase() + rest.join('').toLowerCase()
+);


### PR DESCRIPTION
## Description
Resolves [ATMO-1877](https://pods.iplantcollaborative.org/jira/browse/ATMO-1877)
We have a PageNotFound view that should be used in places that the current message isn't as appropriate as it could be. For example, PageNotFound has a prompt message to login that is inappropriate if the user is already logged in. Also, the message states that the 'page' can not be found which is ok but could be more specific. For example, trying to view an 'image' detail it could state that the 'image' is not found.

This PR only shows the login prompt if **not** logged in and allows to optionally pass a `resource` prop to change the default value `"page"`.  See screenshots. 
 
### Screenshots
Shows the default behavior of `PageNotFound` when **not** logged in and **no** `resource` prop set. 
* The login message is visible
* Says "page" 
<img width="1273" alt="screen shot 2017-05-20 at 10 54 20 pm" src="https://cloud.githubusercontent.com/assets/7366338/26287206/3c872e3e-3e2b-11e7-8466-4df4b69d4ee6.png">

Shows PageNotFound if **not** logged in and the `resource` prop is set to `"image"`.
* The login message is visible
* Says "image" 
<img width="1282" alt="screen shot 2017-05-20 at 10 53 45 pm" src="https://cloud.githubusercontent.com/assets/7366338/26287204/3a81033a-3e2b-11e7-8a59-ad55b7ab5b75.png">

Shows `PageNotFound` if logged in and the `resource` prop is set to `"image"`.
* The login message is hidden
* Says "image" 
<img width="1248" alt="screen shot 2017-05-20 at 10 52 52 pm" src="https://cloud.githubusercontent.com/assets/7366338/26287203/38b2304c-3e2b-11e7-9cdf-1cbce6a16a45.png">

   

## Checklist before merging Pull Requests
- [x] Reviewed and approved by at least one other contributor.
