### PR TITLE
Problem: Instances within Project View appear "stuck" in Build

### DIFF
--- a/troposphere/static/js/actions/instance/launch.js
+++ b/troposphere/static/js/actions/instance/launch.js
@@ -101,13 +101,22 @@ function launch(params) {
             instance.set("uuid", attrs.alias);
 
             // Get the instance from the cloud, ignore our local copy
-            instance.fetch().done(function() {
+            instance.fetch().then(function() {
                 // NOTE: we have to set this here, because our instance above never gets saved
                 instance.set("projects", [project.id]);
 
                 Utils.dispatch(InstanceConstants.UPDATE_INSTANCE, {
                     instance: instance
                 });
+                Utils.dispatch(InstanceConstants.POLL_INSTANCE, {
+                    instance: instance
+                });
+            }, function() {
+                /**
+                 * this can have the same function signature as a `fail`
+                 *
+                 * the arguments would be: (jqXHR, textStatus, errorThrown)
+                 */
                 Utils.dispatch(InstanceConstants.POLL_INSTANCE, {
                     instance: instance
                 });

--- a/troposphere/static/js/actions/instance/launch.js
+++ b/troposphere/static/js/actions/instance/launch.js
@@ -98,6 +98,7 @@ function launch(params) {
     instance.createOnV1Endpoint(payload)
         .done(function(attrs, status, response) {
             instance.set("id", attrs.id);
+            instance.set("uuid", attrs.alias);
 
             // Get the instance from the cloud, ignore our local copy
             instance.fetch().done(function() {


### PR DESCRIPTION
## Description

This work increases the resilience of the _tracking_ the progress of launched instances. It does this by adding a handler for failure when looking up an instance via the Atmosphere V2 API.

### Background 

During the mock deployment of yampy-yellowlegs, running [Operation Sanity](https://github.com/cyverse/operation-sanity) produced the observation that newly launched instances appeared to be _stuck_ in the "Build" status. 

Unfortunately, the code that dispatched for status polling was not being executed. It turned out that a subsequent call to the `api/v2/instances/:new-instance` was returning a "404 Not Found" even though the call was made within a "success" handler for the instance's creation (though, the creation happen via `api/v1/...`). 

### Context

This code could be implemented using a `.fail(...)` chained onto the existing `.done(...)` handler. In surveying the existing codebase, it was not clear why we have chosen `.done(...).fail(...)` over `.then( /* done func */, /* fail func */)`. 

If anyone has more guidance on these choices, it would be great to include that in this pull request.

## Checklist before merging Pull Requests
- ~[ ] New test(s) included to reproduce the bug/verify the feature~
- ~[ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Reviewed and approved by at least one other contributor.
