### PR TITLE
Problem: Atmosphere was showing Jetstream wording in the request more…

### DIFF
--- a/troposphere/static/js/modals/help/requestMoreResources.js
+++ b/troposphere/static/js/modals/help/requestMoreResources.js
@@ -5,11 +5,8 @@ import ModalHelpers from "components/modals/ModalHelpers";
 import RequestMoreResourcesModal from "components/modals/RequestMoreResourcesModal";
 import RequestMoreQuotaOrAllocationModal from "components/modals/RequestMoreQuotaOrAllocationModal";
 
-// Based on the allocation strategy being used, we want to select
-// the matching request-more-requests modal to be rendered
-let RequestModal = globals.USE_ALLOCATION_SOURCES ?
-                   RequestMoreQuotaOrAllocationModal :
-                   RequestMoreResourcesModal;
+// HOTFIX: show the NON-Jetstream modal ;__;
+let RequestModal = RequestMoreResourcesModal;
 
 export default {
 


### PR DESCRIPTION
Problem: Atmosphere was showing Jetstream wording in the request more resources modal
Solution: Always show the original request modal in Atmosphere

