### PR TITLE
Problem: newline translation to breaks adds code / breaks assumption

### DIFF
--- a/troposphere/templates/login.html
+++ b/troposphere/templates/login.html
@@ -38,7 +38,7 @@
                     <div class='maintenance-message'
                          id='maintenance-record-{{ record.id }}'>
                         <i class="glyphicon glyphicon-info-sign icon-white"></i>
-                        {{ record.message |safe }}
+                        {{ record.message | linebreaksbr | safe }}
                     </div>
                 {% endfor %}
             </div>

--- a/troposphere/views/maintenance.py
+++ b/troposphere/views/maintenance.py
@@ -4,15 +4,8 @@ from django.shortcuts import render, redirect, render_to_response
 from django.template import RequestContext
 
 from api.models import MaintenanceRecord, MaintenanceNotice
-def replace_with_br(x):
-    return x.replace("\n", "<br/>")
 
-def replace_html(x):
-    message = replace_with_br(x.message)
-    return { 
-        'message': message,
-    }
-    
+
 def get_maintenance(request):
     """
     Returns a list of maintenance records along with a boolean to indicate
@@ -21,9 +14,8 @@ def get_maintenance(request):
     records = MaintenanceRecord.active()
     disable_login = MaintenanceRecord.disable_login_access(request)
     in_maintenance = records.count() >= 1
-    # FIXME: Avoid moving QuerySet -> list
-    clean_records = list(map(replace_html, records))
-    return (clean_records, disable_login, in_maintenance)
+
+    return (records, disable_login, in_maintenance)
 
 
 def get_notice(request):


### PR DESCRIPTION
## Description

This work removes the "replace_*" methods added in #603 and leverages already available template filters provided by Django (see [linebreaksbr](https://docs.djangoproject.com/en/1.10/ref/templates/builtins/#linebreaksbr)).

### Change Outline

- commit 1eaebec - restores the assumption that `records` is a [`QuerySet`](https://docs.djangoproject.com/en/1.10/ref/models/querysets/)
- commit 7d6bf56 - favors the usage of [builtin template filters](https://docs.djangoproject.com/en/1.10/ref/templates/builtins) provided in Django

Note: `linebreaksbr` is used over [`linebreaks`](https://docs.djangoproject.com/en/1.10/ref/templates/builtins/#linebreaks) because `linebreaksbr` does not surround the result in _another_ block-level element (in this case, `<p/>`).

## Reasoning

We are choosing this options for three reasons:

1. the object interface of `records` remains a [`QuerySet`](https://docs.djangoproject.com/en/1.10/ref/models/querysets/) data structure
2. translation from newlines to breaks is a presentation concern
3. there is no added Python code (use what's provided)

### Regarding (1)

By altering the interface of "records" (to "clean_records"), a Python `list` is used over [`QuerySet`](https://docs.djangoproject.com/en/1.10/ref/models/querysets/). This caused a failure in a portion of the application not exercised during testing nor during review prior to the Yampy-Yellowlegs on Tuesday (2017-05-30). 

Within the Troposphere Django backend, we endeavor not to limit functionality _too_ early. 

### Regarding (2)

Converting from `\n` characters to `<br/>` elements is a presentation level concern that is best dealt with at the _template_ level. By doing so, we allow `records` to remain an expected, robust data structured _*and*_ we can rendering the data in the *desired*, requested manner.

### Regarding (3)

Adopting a framework like Django means that common solutions to problems are available. The provided solution may not meet the needs of our project. However, when it does (and no rationale is offered in pull request messages nor commits, #603), then selecting the "Django approach" means _less_ code to maintain. 

<details>

<img width="1163" alt="screen shot 2017-05-30 at 8 42 28 pm" src="https://cloud.githubusercontent.com/assets/5923/26662875/dd3ed59e-463b-11e7-9af5-f16e1a3bcaee.png">

</details>

## Checklist before merging Pull Requests
- ~[ ] New test(s) included to reproduce the bug/verify the feature~
- ~[ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Reviewed and approved by at least one other contributor.
