### PR TITLE
Problem: Image Requests not updated as status changes

### DIFF
--- a/troposphere/static/js/components/admin/ImageRequest.jsx
+++ b/troposphere/static/js/components/admin/ImageRequest.jsx
@@ -93,6 +93,7 @@ const ImageRequest = React.createClass({
         } else {
             scripts_list = "N/A";
         }
+
         if (request.get("new_version_licenses")) {
             var new_licenses_list = request.get("new_version_licenses");
             licenses_list = new_licenses_list.map(function(licenses) {
@@ -102,6 +103,7 @@ const ImageRequest = React.createClass({
         } else {
             licenses_list = "N/A";
         }
+
         if (request.get("new_version_membership")) {
             var new_membership_list = request.get("new_version_membership");
             membership_list = new_membership_list.map(function(membership) {
@@ -110,6 +112,7 @@ const ImageRequest = React.createClass({
         } else {
             membership_list = "N/A";
         }
+
         var allowImaging = false;
         var forked = false;
 

--- a/troposphere/static/js/components/admin/ImageRequest.jsx
+++ b/troposphere/static/js/components/admin/ImageRequest.jsx
@@ -1,10 +1,11 @@
 import React from "react";
 
 import ImageRequestActions from "actions/ImageRequestActions";
-import stores from "stores";
+
+import subscribe from "utilities/subscribe";
 
 
-export default React.createClass({
+const ImageRequest = React.createClass({
     displayName: "ImageRequest",
 
     propTypes: {
@@ -267,3 +268,5 @@ export default React.createClass({
         );
     }
 });
+
+export default subscribe(ImageRequest, ["ImageRequestStore", "StatusStore"]);

--- a/troposphere/static/js/components/admin/ImageRequest.jsx
+++ b/troposphere/static/js/components/admin/ImageRequest.jsx
@@ -55,7 +55,8 @@ const ImageRequest = React.createClass({
     },
 
     render: function() {
-        let request = stores.ImageRequestStore.get(this.props.params.id),
+        let { ImageRequestStore } = this.props.subscriptions,
+            request = ImageRequestStore.get(this.props.params.id),
             machine = request.get("parent_machine"),
             new_machine = request.get("new_machine"),
             new_provider = request.get("new_machine_provider"),

--- a/troposphere/static/js/components/admin/ImageRequest.jsx
+++ b/troposphere/static/js/components/admin/ImageRequest.jsx
@@ -25,10 +25,12 @@ const ImageRequest = React.createClass({
             });
     },
 
-    approve: function() {
-        var request = stores.ImageRequestStore.get(this.props.params.id),
-            status = stores.StatusStore.findOne({
-                name: "approved"
+    submitUpdate: function(statusName) {
+        let { ImageRequestStore, StatusStore } = this.props.subscriptions;
+
+        var request = ImageRequestStore.get(this.props.params.id),
+            status = StatusStore.findOne({
+                name: statusName
             });
 
         ImageRequestActions.update({
@@ -36,32 +38,18 @@ const ImageRequest = React.createClass({
             response: this.state.response,
             status: status.id
         });
+    },
+
+    approve: function() {
+        this.submitUpdate("approved");
     },
 
     deny: function() {
-        var request = stores.ImageRequestStore.get(this.props.params.id),
-            status = stores.StatusStore.findOne({
-                name: "denied"
-            });
-
-        ImageRequestActions.update({
-            request: request,
-            response: this.state.response,
-            status: status.id
-        });
+        this.submitUpdate("denied");
     },
 
     resubmit: function() {
-        var request = stores.ImageRequestStore.get(this.props.params.id),
-            status = stores.StatusStore.findOne({
-                name: "pending"
-            });
-
-        ImageRequestActions.update({
-            request: request,
-            response: this.state.response,
-            status: status.id
-        });
+        this.submitUpdate("pending");
     },
 
     render: function() {

--- a/troposphere/static/js/components/admin/ImageRequest.jsx
+++ b/troposphere/static/js/components/admin/ImageRequest.jsx
@@ -20,9 +20,11 @@ const ImageRequest = React.createClass({
 
     handleResponseChange: function(event) {
         var response = event.target.value;
-        if (response) this.setState({
+        if (response) {
+            this.setState({
                 response: response
             });
+        }
     },
 
     submitUpdate: function(statusName) {


### PR DESCRIPTION
## Description

This work uses the `subscribe` Higher-order Function to gain the default "forceUpdate" on emit change behavior. 

The issue appears to be related/created by the changes made during `react-router` upgrade. The `<Master />` component as the parent to all components was receiving "emit change" and causing components to re-`render`. With the upgrade, that (potential) _accidential_ behavior was no longer present.

_Note: this is targeting Yampy-Yellowlegs so that it will be included in the forthcoming release to Jetstream._

## Checklist before merging Pull Requests
- [ ] ~New test(s) included to reproduce the bug/verify the feature~
- [ ] ~Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Reviewed and approved by at least one other contributor.
