### PR TITLE
Problem: Exception messages in Image Requests are distracting

### DIFF
--- a/troposphere/static/js/components/admin/ImageRequest.jsx
+++ b/troposphere/static/js/components/admin/ImageRequest.jsx
@@ -1,8 +1,100 @@
 import React from "react";
 
+import { ShowMoreEllipsis } from "cyverse-ui";
+import { marg } from "cyverse-ui/styles";
+
 import ImageRequestActions from "actions/ImageRequestActions";
 
 import subscribe from "utilities/subscribe";
+
+/**
+ * A consistently styled `<code/>` element
+ *
+ * This will likely be redefined within CyVerse-UI. When that
+ * happened, this can be replaced w/ the official version.
+ */
+const Code = (props) => {
+    // FIXME: don't hardcode these:
+    // - `style.color`
+    // -color in `style.borderLeft`
+    let lines = "",
+        text = props.text || "",
+        style = {
+            display: "block",
+            whiteSpace: "pre-wrap",
+            padding: "20px",
+            color: "rgba(0, 0, 0, 0.54)",
+            fontSize: "14px",
+            borderLeft: `solid rgba(0, 0, 0, 0.54) 5px`,
+            background: "rgba(0,0,0,0.03)",
+            ...marg(props)
+        };
+
+    text.split('\n').map((line) => {
+        lines += line;
+    });
+    return (
+        <code style={style}>
+            {lines}
+        </code>
+    );
+}
+
+/**
+ * Allow a region to be collapsed and expanded to avoid
+ * over-powering the containing context.
+ *
+ * This is a candidate for extract into a common Troposphere component,
+ * or for wider review and inclusion in CyVerse-UI. For now, it begins
+ * life as a "hopefully" useful component within Admin.
+ */
+const CollapsibleOutput = React.createClass({
+    propTypes: {
+        output: React.PropTypes.string
+    },
+
+    getInitialState() {
+        return {
+            open: false
+        };
+    },
+
+    onEllipsisClick() {
+        this.setState({
+            open: !this.state.open
+        });
+    },
+
+    render() {
+        let { open } = this.state,
+            { output } = this.props,
+            content = null,
+            partial = output
+                    ? output.substring(0, 32) : '***';
+
+        if (!open) {
+            content = (
+                <span onClick={this.onEllipsisClick}>
+                    {` ${partial} `}
+                    <ShowMoreEllipsis  />
+                </span>
+            );
+        } else {
+            content = (
+                <span onClick={this.onEllipsisClick}>
+                    <ShowMoreEllipsis  />
+                    <Code text={output} />
+                </span>
+            );
+        }
+
+        return (
+            <div style={{display: "inline-block"}}>
+                    {content}
+            </div>
+        );
+    }
+});
 
 
 const ImageRequest = React.createClass({
@@ -141,7 +233,7 @@ const ImageRequest = React.createClass({
                     { `Imaging status: ${allowImaging ? "Imaging allowed" : "Author only"}` }
                 </div>
                 <div>
-                    { `Request state: ${request.get("old_status")}` }
+                    { `Request state: ` }<CollapsibleOutput output={request.get("old_status")} />
                 </div>
                 <div>
                     { `Status: ${request.get("status").name}` }

--- a/troposphere/static/js/components/admin/ImageRequest.jsx
+++ b/troposphere/static/js/components/admin/ImageRequest.jsx
@@ -93,6 +93,7 @@ const ImageRequest = React.createClass({
         } else {
             scripts_list = "N/A";
         }
+
         if (request.get("new_version_licenses")) {
             var new_licenses_list = request.get("new_version_licenses");
             licenses_list = new_licenses_list.map(function(licenses) {
@@ -102,6 +103,7 @@ const ImageRequest = React.createClass({
         } else {
             licenses_list = "N/A";
         }
+
         if (request.get("new_version_membership")) {
             var new_membership_list = request.get("new_version_membership");
             membership_list = new_membership_list.map(function(membership) {
@@ -110,6 +112,7 @@ const ImageRequest = React.createClass({
         } else {
             membership_list = "N/A";
         }
+
         var allowImaging = false;
         var forked = false;
 

--- a/troposphere/static/js/components/admin/ImageRequest.jsx
+++ b/troposphere/static/js/components/admin/ImageRequest.jsx
@@ -1,10 +1,11 @@
 import React from "react";
 
 import ImageRequestActions from "actions/ImageRequestActions";
-import stores from "stores";
+
+import subscribe from "utilities/subscribe";
 
 
-export default React.createClass({
+const ImageRequest = React.createClass({
     displayName: "ImageRequest",
 
     propTypes: {
@@ -267,3 +268,5 @@ export default React.createClass({
         );
     }
 });
+
+export default subscribe(ImageRequest, ["ImageRequestStore", "StatusStore"]);

--- a/troposphere/static/js/components/admin/ImageRequest.jsx
+++ b/troposphere/static/js/components/admin/ImageRequest.jsx
@@ -55,7 +55,8 @@ const ImageRequest = React.createClass({
     },
 
     render: function() {
-        let request = stores.ImageRequestStore.get(this.props.params.id),
+        let { ImageRequestStore } = this.props.subscriptions,
+            request = ImageRequestStore.get(this.props.params.id),
             machine = request.get("parent_machine"),
             new_machine = request.get("new_machine"),
             new_provider = request.get("new_machine_provider"),

--- a/troposphere/static/js/components/admin/ImageRequest.jsx
+++ b/troposphere/static/js/components/admin/ImageRequest.jsx
@@ -17,8 +17,7 @@ const Code = (props) => {
     // FIXME: don't hardcode these:
     // - `style.color`
     // -color in `style.borderLeft`
-    let lines = "",
-        text = props.text || "",
+    let text = props.text || "",
         style = {
             display: "block",
             whiteSpace: "pre-wrap",
@@ -30,13 +29,10 @@ const Code = (props) => {
             ...marg(props)
         };
 
-    text.split('\n').map((line) => {
-        lines += line;
-    });
     return (
-        <code style={style}>
-            {lines}
-        </code>
+        <pre style={style}>
+            {text}
+        </pre>
     );
 }
 

--- a/troposphere/static/js/components/admin/ImageRequest.jsx
+++ b/troposphere/static/js/components/admin/ImageRequest.jsx
@@ -25,10 +25,12 @@ const ImageRequest = React.createClass({
             });
     },
 
-    approve: function() {
-        var request = stores.ImageRequestStore.get(this.props.params.id),
-            status = stores.StatusStore.findOne({
-                name: "approved"
+    submitUpdate: function(statusName) {
+        let { ImageRequestStore, StatusStore } = this.props.subscriptions;
+
+        var request = ImageRequestStore.get(this.props.params.id),
+            status = StatusStore.findOne({
+                name: statusName
             });
 
         ImageRequestActions.update({
@@ -36,32 +38,18 @@ const ImageRequest = React.createClass({
             response: this.state.response,
             status: status.id
         });
+    },
+
+    approve: function() {
+        this.submitUpdate("approved");
     },
 
     deny: function() {
-        var request = stores.ImageRequestStore.get(this.props.params.id),
-            status = stores.StatusStore.findOne({
-                name: "denied"
-            });
-
-        ImageRequestActions.update({
-            request: request,
-            response: this.state.response,
-            status: status.id
-        });
+        this.submitUpdate("denied");
     },
 
     resubmit: function() {
-        var request = stores.ImageRequestStore.get(this.props.params.id),
-            status = stores.StatusStore.findOne({
-                name: "pending"
-            });
-
-        ImageRequestActions.update({
-            request: request,
-            response: this.state.response,
-            status: status.id
-        });
+        this.submitUpdate("pending");
     },
 
     render: function() {

--- a/troposphere/static/js/components/admin/ImageRequest.jsx
+++ b/troposphere/static/js/components/admin/ImageRequest.jsx
@@ -20,9 +20,11 @@ const ImageRequest = React.createClass({
 
     handleResponseChange: function(event) {
         var response = event.target.value;
-        if (response) this.setState({
+        if (response) {
+            this.setState({
                 response: response
             });
+        }
     },
 
     submitUpdate: function(statusName) {


### PR DESCRIPTION
## Description

This work uses the `<ShowMoreEllipsis />` from `cyverse-ui` in a "clickable" context to allow for "collapsing output". 

This introduces two components within the "ImageRequest.jsx" that could be refined and extracted at a later time. 

The `<Code />` is essentially "source" copied from the CyVerse-UI Style Guide. It is not exposed as an _"import"-able_ component. 

This depends on #621 being merged first (as it extends the version of `<ImageRequest />` defined in that pull request.

<details>

## Expand and Collapse
![collapsible request status](http://g.recordit.co/9ucFue74Mo.gif)

</details>

## Checklist before merging Pull Requests
- [ ] ~New test(s) included to reproduce the bug/verify the feature~
- [ ] ~Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [x] Reviewed and approved by at least one other contributor.
