### PR TITLE
Problem: typos exist on html attributes (className used when classNames intended)

### DIFF
--- a/troposphere/static/js/components/modals/volume/VolumeCreateModal.jsx
+++ b/troposphere/static/js/components/modals/volume/VolumeCreateModal.jsx
@@ -265,7 +265,7 @@ export default React.createClass({
         return (
         <div role="form">
             <div className="modal-section form-horizontal">
-                <h4 classNames="t-body-2">Volume Details</h4>
+                <h4 className="t-body-2">Volume Details</h4>
                 <div className="form-group">
                     <label htmlFor="volumeName" className="col-sm-3 control-label">
                         Volume Name
@@ -301,7 +301,7 @@ export default React.createClass({
                 </div>
             </div>
             <div className="modal-section">
-                <h4 classNames="t-body-2"><span>Projected Resource Usage</span> <a className="modal-link" href="#" onClick={this.handleResourceRequest}>{"Need more resources?"}</a></h4>
+                <h4 className="t-body-2"><span>Projected Resource Usage</span> <a className="modal-link" href="#" onClick={this.handleResourceRequest}>{"Need more resources?"}</a></h4>
                 {this.renderStorageConsumption(identity, size, volumes)}
                 {this.renderStorageCountConsumption(identity, size, volumes)}
             </div>


### PR DESCRIPTION
## Description

I might be wrong. But from my perceptive, the intention here is trying to use a CSS class called `classNames`. We do have a 'classNames' than can be imported but I think that's probably not something fits here? 



## Checklist before merging Pull Requests

- [x] Reviewed and approved by at least one other contributor.
