### PR TITLE
Problem: typos exist in HTML attribute name for CSS class

### DIFF
--- a/troposphere/static/js/components/modals/instance/launch/steps/SizeSelectStep.jsx
+++ b/troposphere/static/js/components/modals/instance/launch/steps/SizeSelectStep.jsx
@@ -321,7 +321,7 @@ export default React.createClass({
                         {minRequirements}
                     </div>
                     <div className="modal-section">
-                        <h4 classNames="t-body-2">Projected Resource Usage</h4>
+                        <h4 className="t-body-2">Projected Resource Usage</h4>
                         <div className="form-group">
                             {this.renderCpuConsumption(selectedIdentity, size, sizes, instances)}
                             {this.renderMemoryConsumption(selectedIdentity, size, sizes, instances)}

--- a/troposphere/static/js/components/modals/project/CantMoveAttachedModal.jsx
+++ b/troposphere/static/js/components/modals/project/CantMoveAttachedModal.jsx
@@ -15,7 +15,7 @@ export default React.createClass({
     render: function() {
         var content = (
         <div>
-            <h4 classNames="t-body-2">You are trying to move attached resources</h4>
+            <h4 className="t-body-2">You are trying to move attached resources</h4>
             <p>
                 An instance or volume cannot be moved while attached. To move these resources, please detach them by first selecting the attached volume and then selecting the detach
                 option on the top right.

--- a/troposphere/static/js/modals/UnsupportedModal.jsx
+++ b/troposphere/static/js/modals/UnsupportedModal.jsx
@@ -21,7 +21,7 @@ const UnsupportedModal = React.createClass({
     render: function() {
         var content = (
         <div>
-            <h4 classNames="t-body-2">This application uses features your browser does not support</h4>
+            <h4 className="t-body-2">This application uses features your browser does not support</h4>
             <p>
                 For the best user experience please update your browser. We recomend using a desktop or laptop with one of the following browsers.
             </p>
@@ -43,7 +43,7 @@ const UnsupportedModal = React.createClass({
                 </div>
             </div>
             <hr />
-            <h4 classNames="t-body-2">Features that may cause problems with your browser</h4>
+            <h4 className="t-body-2">Features that may cause problems with your browser</h4>
             <BreakingFeatureList />
         </div>
         );
@@ -53,7 +53,7 @@ const UnsupportedModal = React.createClass({
             <div className="modal-dialog">
                 <div className="modal-content">
                     <div className="modal-header">
-                        <h3 classNames="t-body-2">Unsupported Features</h3>
+                        <h3 className="t-body-2">Unsupported Features</h3>
                     </div>
                     <div className="modal-body">
                         {content}


### PR DESCRIPTION
## Description

As noted in #625 by @xuhang57, we had a couple of typos for the attribute name used to JSX syntax for including CSS classes. 

This work corrects the remaining occurrences of this typo _pattern_ within the codebase.

It appears these incidents might have been caused by a "replace string" operation gone awry. All of the occurrences found were for the `t-body-2` class.

```
 <h4 className="t-body-2">
```

## Checklist before merging Pull Requests
- ~[ ] New test(s) included to reproduce the bug/verify the feature~
- ~[ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Reviewed and approved by at least one other contributor.
