### PR TITLE
Fix broken upgrade to django 1.11

### DIFF
--- a/dev_requirements.in
+++ b/dev_requirements.in
@@ -3,7 +3,7 @@ behaving
 colorama
 coverage
 django-jenkins
-django==1.10
+django==1.11
 emoji
 ipython
 ipdb

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -6,29 +6,30 @@
 #
 backports.shutil-get-terminal-size==1.0.0  # via ipython
 behave==1.2.5
-behaving==1.5.5
-colorama==0.3.3
-coverage==3.7.1
+behaving==1.5.6
+colorama==0.3.9
+coverage==4.4.1
 decorator==4.0.11         # via ipython, traitlets
-django-jenkins==0.19
-django==1.10
-emoji==0.3.6
+django-jenkins==0.110.0
+django==1.11
+emoji==0.4.5
 enum34==1.1.6             # via parse-type, traitlets
-ipdb==0.10.2
-ipython-genutils==0.1.0   # via traitlets
-ipython==5.3.0
+ipdb==0.10.3
+ipython-genutils==0.2.0   # via traitlets
+ipython==5.4.1
 parse-type==0.3.4         # via behave
-parse==1.8.0              # via behave, behaving, parse-type
-pathlib2==2.2.1           # via ipython, pickleshare
+parse==1.8.2              # via behave, behaving, parse-type
+pathlib2==2.3.0           # via ipython, pickleshare
 pexpect==4.2.1            # via ipython
 pickleshare==0.7.4        # via ipython
 prompt-toolkit==1.0.14    # via ipython
 ptyprocess==0.5.1         # via pexpect
 pygments==2.2.0           # via ipython
-scandir==1.4              # via pathlib2
-selenium==3.3.3           # via splinter
+pytz==2016.10             # via django
+scandir==1.5              # via pathlib2
+selenium==3.4.3           # via splinter
 simplegeneric==0.8.1      # via ipython
 six==1.10.0               # via behave, parse-type, pathlib2, prompt-toolkit, traitlets
 splinter==0.7.5           # via behaving
-traitlets==4.3.1          # via ipython
+traitlets==4.3.2          # via ipython
 wcwidth==0.1.7            # via prompt-toolkit

--- a/requirements.in
+++ b/requirements.in
@@ -1,15 +1,18 @@
 # External/Third Party
 pycparser==2.14 # TEMPORARY
-django==1.10
+django==1.11
 django-sslserver==0.18
-djangorestframework==3.6
+
+djangorestframework
+markdown
+
 django-webpack-loader==0.3.0
 itsdangerous==0.24
 Jinja2==2.8
 pycrypto==2.6.1
 PyJWT==1.4.0
 python-dateutil==2.4
-psycopg2==2.5.2
+psycopg2==2.5.4
 requests[security]==2.11.1
 uWSGI==2.0.13
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,8 +15,8 @@ debtcollector==1.11.0     # via oslo.config, oslo.utils, python-keystoneclient
 django-cyverse-auth==1.0.14
 django-sslserver==0.18
 django-webpack-loader==0.3.0
-django==1.11.2
-djangorestframework==3.6.3
+django==1.11
+djangorestframework==3.6
 enum34==1.1.6             # via cryptography
 funcsigs==1.0.2           # via debtcollector, oslo.utils
 httplib2==0.9.2           # via oauth2client
@@ -27,6 +27,7 @@ itsdangerous==0.24
 jinja2==2.8
 jwt.py==0.1.0             # via django-cyverse-auth
 keystoneauth1==2.18.0     # via django-cyverse-auth, python-keystoneclient
+markdown==2.6.8
 markupsafe==0.23          # via jinja2
 monotonic==1.2            # via oslo.utils
 msgpack-python==0.4.8     # via oslo.serialization
@@ -41,7 +42,7 @@ oslo.serialization==2.16.0  # via python-keystoneclient
 oslo.utils==3.22.0        # via oslo.serialization, python-keystoneclient
 pbr==1.10.0               # via debtcollector, keystoneauth1, oslo.i18n, oslo.serialization, oslo.utils, positional, python-keystoneclient, stevedore
 positional==1.1.1         # via keystoneauth1, python-keystoneclient
-psycopg2==2.7.1
+psycopg2==2.5.4
 pyasn1-modules==0.0.8     # via oauth2client
 pyasn1==0.1.9             # via cryptography, oauth2client, pyasn1-modules, requests, rsa
 pycparser==2.14
@@ -52,7 +53,7 @@ pyparsing==2.1.10         # via oslo.utils
 python-dateutil==2.4
 python-keystoneclient==3.10.0  # via django-cyverse-auth
 python-ldap==2.4.29       # via django-cyverse-auth
-pytz==2016.10             # via babel, oslo.serialization, oslo.utils
+pytz==2016.10             # via babel, django, oslo.serialization, oslo.utils
 raven==6.0.0
 requests[security]==2.11.1
 rfc3986==0.4.1            # via oslo.config


### PR DESCRIPTION
## Description
Correct *requirements.in specifications
Add unlisted markdown dependency (django-rest-framework)

In a larger feature, I'm going to implement the improved solution for *.in files and add docs to make it crystal clear :crystal_ball:.

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature
- [ ] Reviewed and approved by at least one other contributor.
