### PR TITLE
Problem: missing "status" causes a server error

### DIFF
--- a/troposphere/views/exceptions.py
+++ b/troposphere/views/exceptions.py
@@ -1,6 +1,8 @@
 import json
 import logging
 
+from rest_framework import status
+
 logger = logging.getLogger(__name__)
 
 from django.http import HttpResponse


### PR DESCRIPTION
## Description

Within this file, `status` never gets imported. This patch adds the missing lib.

## Checklist before merging Pull Requests

- [ ] Reviewed and approved by at least one other contributor.
