### PR TITLE
Problem: Gravatar icons for Instances not consistent across views

### DIFF
--- a/troposphere/static/js/components/dashboard/InstanceHistoryList.jsx
+++ b/troposphere/static/js/components/dashboard/InstanceHistoryList.jsx
@@ -167,7 +167,7 @@ export default React.createClass({
                             <div>
                                 <Gravatar hash={instanceHistoryHash} size={iconSize} type={type} />
                                 <div className="instance-history-details">
-                                    <Link to={`instances/${instance.get("instance").id}`}>
+                                    <Link to={`instances/${instanceId}`}>
                                         <strong className="name">{name}</strong>
                                     </Link>
                                     <div>

--- a/troposphere/static/js/components/dashboard/InstanceHistoryList.jsx
+++ b/troposphere/static/js/components/dashboard/InstanceHistoryList.jsx
@@ -122,6 +122,7 @@ export default React.createClass({
 
         instanceHistoryItems = instanceHistories.map(function(instance) {
             var name = instance.get("instance").name,
+                instanceId = instance.get("instance").id,
                 image = instance.get("image"),
                 provider = instance.get("provider");
 
@@ -131,7 +132,7 @@ export default React.createClass({
                 formattedEndDate = moment(endDate).format("MMM DD, YYYY hh:mm a"),
                 now = moment(),
                 timeSpan = now.diff(startDate, "days"),
-                instanceHistoryHash = CryptoJS.MD5((instance.id || instance.cid).toString()).toString(),
+                instanceHistoryHash = CryptoJS.MD5((instanceId || instance.cid).toString()).toString(),
                 iconSize = 63,
                 type = stores.ProfileStore.get().get("icon_set"),
                 imageName = image ? image.name : "[image no longer exists]",

--- a/troposphere/static/js/components/dashboard/InstanceHistoryList.jsx
+++ b/troposphere/static/js/components/dashboard/InstanceHistoryList.jsx
@@ -120,19 +120,19 @@ export default React.createClass({
 
         if (!instanceHistories || !instances || !providers) return <div className="loading"></div>;
 
-        instanceHistoryItems = instanceHistories.map(function(instance) {
-            var name = instance.get("instance").name,
-                instanceId = instance.get("instance").id,
-                image = instance.get("image"),
-                provider = instance.get("provider");
+        instanceHistoryItems = instanceHistories.map(function(item) {
+            var name = item.get("instance").name,
+                instanceId = item.get("instance").id,
+                image = item.get("image"),
+                provider = item.get("provider");
 
-            var startDate = instance.get("instance").start_date,
-                endDate = instance.get("instance").end_date,
+            var startDate = item.get("instance").start_date,
+                endDate = item.get("instance").end_date,
                 formattedStartDate = moment(startDate).format("MMM DD, YYYY hh:mm a"),
                 formattedEndDate = moment(endDate).format("MMM DD, YYYY hh:mm a"),
                 now = moment(),
                 timeSpan = now.diff(startDate, "days"),
-                instanceHistoryHash = CryptoJS.MD5((instanceId || instance.cid).toString()).toString(),
+                instanceHistoryHash = CryptoJS.MD5((instanceId || item.cid).toString()).toString(),
                 iconSize = 63,
                 type = stores.ProfileStore.get().get("icon_set"),
                 imageName = image ? image.name : "[image no longer exists]",
@@ -160,7 +160,7 @@ export default React.createClass({
             }
 
             return (
-            <div key={instance.cid}>
+            <div key={item.cid}>
                 <div className="instance-history">
                     <ul>
                         <li>


### PR DESCRIPTION
## Description

The _identifier_ used to determine the icon for _Instances_ within the Instance History was not the valid identifier for `models/Instance`s. It was the `client ID` for the Instance History item. 

This work corrects the identifier used as input to the hash function (done in commit 2d47f74c5bddaee79c5ec6d8d05addd6e287908b, for clarity review this first).

It also does a "rename" refactor on the function that produces the rendered JSX components for `<InstanceHistoryList />`. The previous version recreates confusion by _improperly_ overloading the term "instance".

See [ATMO-1848](https://pods.iplantcollaborative.org/jira/browse/ATMO-1848)

<details>

## Interaction Demo / Consistency Between Views

![atmo-1848-fix](https://user-images.githubusercontent.com/5923/27162895-b416fcca-5138-11e7-8e1a-3c2e935ab39e.gif)

</details>

## Checklist before merging Pull Requests
- [ ] ~New test(s) included to reproduce the bug/verify the feature~
- [ ] ~Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [x] Reviewed and approved by at least one other contributor.
