### PR TITLE
Problem: integer IDs can lead to selecting/unselecting collisions

### DIFF
--- a/troposphere/static/js/components/projects/detail/resources/image/ImageTable.jsx
+++ b/troposphere/static/js/components/projects/detail/resources/image/ImageTable.jsx
@@ -32,8 +32,9 @@ export default React.createClass({
             selectedResources = this.props.selectedResources;
 
         return images.map(function(image) {
-            var isPreviewed = (previewedResource === image),
-                isChecked = selectedResources.get(image) ? true : false;
+            let uuid = image.get("uuid"),
+                isPreviewed = (previewedResource === image),
+                isChecked = selectedResources.findWhere({uuid}) ? true : false;
 
             return (
             <ImageRow key={image.id || image.cid}

--- a/troposphere/static/js/components/projects/detail/resources/instance/InstanceTable.jsx
+++ b/troposphere/static/js/components/projects/detail/resources/instance/InstanceTable.jsx
@@ -19,8 +19,9 @@ export default React.createClass({
             selectedResources = this.props.selectedResources;
 
         return instances.map(function(instance) {
-            var isPreviewed = (previewedResource === instance);
-            var isChecked = selectedResources.get(instance) ? true : false;
+            let uuid = instance.get("uuid"),
+                isPreviewed = (previewedResource === instance),
+                isChecked = selectedResources.findWhere({uuid}) ? true : false;
 
             return (
             <InstanceRow key={instance.id || instance.cid}

--- a/troposphere/static/js/components/projects/detail/resources/link/ExternalLinkTable.jsx
+++ b/troposphere/static/js/components/projects/detail/resources/link/ExternalLinkTable.jsx
@@ -33,8 +33,9 @@ export default React.createClass({
             selectedResources = this.props.selectedResources;
 
         return external_links.map(function(external_link) {
-            var isPreviewed = (previewedResource === external_link),
-                isChecked = selectedResources.get(external_link) ? true : false;
+            let id = external_link.get("id"),
+                isPreviewed = (previewedResource === external_link),
+                isChecked = selectedResources.findWhere({id}) ? true : false;
 
             return (
             <ExternalLinkRow key={external_link.id || external_link.cid}

--- a/troposphere/static/js/components/projects/detail/resources/volume/VolumeTable.jsx
+++ b/troposphere/static/js/components/projects/detail/resources/volume/VolumeTable.jsx
@@ -32,8 +32,9 @@ export default React.createClass({
             selectedResources = this.props.selectedResources;
 
         return volumes.map(function(volume) {
-            var isPreviewed = (previewedResource === volume),
-                isChecked = selectedResources.get(volume) ? true : false;
+            let uuid = volume.get("uuid"),
+                isPreviewed = (previewedResource === volume),
+                isChecked = selectedResources.findWhere({uuid}) ? true : false;
 
             return (
             <VolumeRow key={volume.id || volume.cid}


### PR DESCRIPTION
## Description

When using integer identifiers from the database, you can have unintended "collisions" between identifiers for different models. Here we leverage the available "alias" identifier to avoid any "collision", and subsequent "double selection" [\[0\]](https://pods.iplantcollaborative.org/jira/browse/ATMO-1320).

Note, these aliases, "uuid" in the model attribuates, are UUIDv4 [\[1\]](https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_.28random.29) and collisions are extremely unlikely, it's "at least one collision is 2.71 quintillion" [\[2\]](https://en.wikipedia.org/wiki/Universally_unique_identifier#Collisions). We can operate as if there is a guarantee of uniqueness.

\[0\] https://pods.iplantcollaborative.org/jira/browse/ATMO-1320
\[1\] https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_.28random.29
\[2\] https://en.wikipedia.org/wiki/Universally_unique_identifier#Collisions

See [ATMO-1320](https://pods.iplantcollaborative.org/jira/browse/ATMO-1320)

## Checklist before merging Pull Requests
- ~[ ] New test(s) included to reproduce the bug/verify the feature~
- ~[ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Reviewed and approved by at least one other contributor.
