### PR TITLE
Problem: Failure to load webpack (because webpack is compiling/failed to compile) causes 500

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "dev": "webpack -d --progress --profile --colors --bail --",
-    "serve": "webpack-dev-server -d --inline --https --host 0.0.0.0 --content-base troposphere/assets",
+    "serve": "webpack-dev-server -d --inline --https --content-base troposphere/assets",
     "build": "webpack --progress --profile --colors --bail --",
     "watch": "webpack --progress --profile --colors --bail --watch -d --",
     "jenkins": "webpack --profile --colors --",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "dev": "webpack -d --progress --profile --colors --bail --",
-    "serve": "webpack-dev-server -d --inline --https --content-base troposphere/assets",
+    "serve": "webpack-dev-server -d --inline --https --host 0.0.0.0 --content-base troposphere/assets",
     "build": "webpack --progress --profile --colors --bail --",
     "watch": "webpack --progress --profile --colors --bail --watch -d --",
     "jenkins": "webpack --profile --colors --",

--- a/troposphere/static/theme/theme.json.j2
+++ b/troposphere/static/theme/theme.json.j2
@@ -1,4 +1,11 @@
 {
+    "images": {
+        {% if USE_THEME_IMAGES -%}
+        "imagesDir": "/theme/themeImages"
+        {%- else -%}
+        "imagesDir": "/theme/themeImagesDefault"
+        {%- endif %}
+    },
     "palette": {
         {% if PRIMARY_ONE_COLOR -%}
         "primary1Color": "{{ PRIMARY_ONE_COLOR }}",

--- a/troposphere/templates/error.html
+++ b/troposphere/templates/error.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>
+    Atmosphere | {{ ORG_NAME }}
+  </title>
+  <link rel="shortcut icon" href="{{theme_images_url}}/favicon.ico" />
+  <link rel="stylesheet" href="{{BASE_URL}}/assets/theme/login.css"/>
+{% if exception %}
+  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/css/toastr.min.css"/>
+{% endif %}
+</head>
+<body>
+    <div id="wrapper" class="center">
+        <div id="imgcontainer">
+            <img src="{{theme_images_url}}/large_logo.png">
+        </div>
+        <div class="message-wrapper">
+{% if exception %}
+            <div id="toast-container" class="toast-top-full-width">
+                <div class="toast toast-error">
+                    <div class="toast-title"> Exception occurred during page load of application: </div>
+                    <div id="toast-msg-target" class="toast-message">{{ exception_message }}</div>
+                </div>
+            </div>
+{% endif %}
+
+
+
+
+            <h1>Troposphere is down for temporary maintenance.</h1>
+
+            <p>
+              If multiple attempts to refresh the page do not work, please email Support:<a href="mailto:{{SUPPORT_EMAIL}}">{{SUPPORT_EMAIL}}</a>.
+            </p>
+
+            <a class="submitButton" href="/application">
+                Reload
+            </a>
+        </div>
+    </div>
+</body>
+</html>

--- a/troposphere/views/app.py
+++ b/troposphere/views/app.py
@@ -233,9 +233,9 @@ def handle_template_error(template_params, exception=None):
             json_data = json.loads(text)
     theme_images_suffix = json_data.get('images',{}).get('imagesDir')
     if theme_images_suffix:
-        theme_images_url = "assets"+theme_images_suffix
+        theme_images_url = "/assets"+theme_images_suffix
     else:
-        theme_images_url = "assets/theme/themeImagesDefault"
+        theme_images_url = "/assets/theme/themeImagesDefault"
     template_params['theme_images_url'] = theme_images_url
 
     if 'WebpackLoaderBadStatsError' in str(template_params['exception_type']):

--- a/troposphere/views/app.py
+++ b/troposphere/views/app.py
@@ -1,4 +1,5 @@
 import json
+import os
 import logging
 
 from datetime import timedelta
@@ -204,17 +205,46 @@ def _handle_public_application_request(request, maintenance_records, disabled_lo
     """
     template_params = _populate_template_params(request, maintenance_records,
                                                 None, disabled_login, True)
-
     if 'new_relic_enabled' in template_params:
         logger.info("New Relic enabled? %s" % template_params['new_relic_enabled'])
     else:
         logger.info("New Relic key missing from `template_params`")
 
+    try:
+        response = render_to_response(
+            'index.html',
+            template_params,
+        )
+        return response
+    except Exception as exc:
+        return handle_template_error(template_params, exc)
+
+
+def handle_template_error(template_params, exception=None):
+    template_params['exception'] = exception
+    template_params['exception_message'] = str(exception)
+    template_params['exception_type'] = type(exception)
+    # Read theme by hand:
+    json_data = {}
+    theme_path = os.path.join(settings.BASE_DIR, "static/theme/theme.json")
+    if os.path.exists(theme_path):
+        with open(theme_path,'r') as the_file:
+            text = the_file.read()
+            json_data = json.loads(text)
+    theme_images_suffix = json_data.get('images',{}).get('imagesDir')
+    if theme_images_suffix:
+        theme_images_url = "assets"+theme_images_suffix
+    else:
+        theme_images_url = "assets/theme/themeImagesDefault"
+    template_params['theme_images_url'] = theme_images_url
+
+    if 'WebpackLoaderBadStatsError' in str(template_params['exception_type']):
+        template_params['exception_message'] = "Webpack bundle has not been built/completed."
+
     response = render_to_response(
-        'index.html',
+        'error.html',
         template_params,
     )
-
     return response
 
 
@@ -246,10 +276,13 @@ def _handle_authenticated_application_request(request, maintenance_records,
     else:
         logger.info("New Relic key missing from `template_params`")
 
-    response = render_to_response(
-        'index.html',
-        template_params,
-    )
+    try:
+        response = render_to_response(
+            'index.html',
+            template_params,
+        )
+    except Exception as exc:
+        return handle_template_error(template_params, exc)
 
     # Delete cookie after exchange
     if 'auth_token' in request.COOKIES:


### PR DESCRIPTION
## Solution

- Provide a new template, `error.html` that will handle resources that are not built by webpack.

## Needs improvement
- Right now, `/assets` is expected to follow the logic as set-out in `extras/nginx/locations/troposphere.conf`, this will work. But if you are using `webpack-dev-server` you will see an ugly screen.
- Possible solution to the problem above might be: Creating another location `/unbundled_assets` that will always point to the `/assets` directory, to be pointed to _only_ by `error.html` and keep separate from the `/assets`  managed by webpack-dev-server.

## Screenshots

### Rendered

![screen shot 2017-06-21 at 1 27 33 pm](https://user-images.githubusercontent.com/2889930/27405183-71b52328-5685-11e7-93b5-a023f419f37e.png)

### Unrendered

![screen shot 2017-06-21 at 1 26 15 pm](https://user-images.githubusercontent.com/2889930/27405191-76c56a9e-5685-11e7-9e05-d93a7a9b7ce3.png)

## Checklist before merging Pull Requests
- [ ] Reviewed and approved by at least one other contributor.
