### PR TITLE
Problem: Disk sizes are not validated on the client-side

### DIFF
--- a/troposphere/static/js/components/common/ui/SelectMenu.jsx
+++ b/troposphere/static/js/components/common/ui/SelectMenu.jsx
@@ -22,7 +22,8 @@ export default React.createClass({
 
     propTypes: {
         onSelect: React.PropTypes.func.isRequired,
-        optionName: React.PropTypes.func.isRequired,
+        optionName: React.PropTypes.func,
+        renderListOption: React.PropTypes.func,
         list: React.PropTypes.oneOfType([
             React.PropTypes.instanceOf(Backbone.Collection),
             React.PropTypes.array
@@ -32,6 +33,11 @@ export default React.createClass({
     },
 
     getInitialState() {
+        if(
+            (!this.props.optionName && !this.props.renderListOption) ||
+            (this.props.optionName && this.props.renderListOption) ) {
+            console.warn("SelectMenu requires optionName _or_ renderListOption")
+        }
         return this.getStateFromProps(this.props);
     },
 
@@ -113,13 +119,22 @@ export default React.createClass({
                 options.push(this.renderPlaceholderOption(placeholder || ""))
             }
 
+            let renderOptions = this.props.renderListOption;
+            let newOptions = [];
+            if(!renderOptions) {
+                /* Default Behavior:
+                * optionName(elem) -> name,
+                *        renderOption(name) -> option
+                */
+                newOptions = list.map(this.props.optionName).map(this.renderListOption);
+            } else {
+                /* Override Behavior:
+                * this.props.renderListOption(elem) -> option
+                */
+                newOptions = list.map(renderOptions);
+            }
             // Append options from the list
-            options = options.concat(
-                // optionName(elem) -> name,
-                //        renderOption(name) -> option
-                list.map(this.props.optionName)
-                    .map(this.renderListOption)
-            )
+            options = options.concat(newOptions);
 
             index = list.indexOf(current);
             if (current != null && index == -1) {

--- a/troposphere/static/js/components/modals/instance/InstanceLaunchWizardModal.jsx
+++ b/troposphere/static/js/components/modals/instance/InstanceLaunchWizardModal.jsx
@@ -631,30 +631,18 @@ export default React.createClass({
         if (providerSizeList && imageVersion) {
             let machines = imageVersion.get('machines'),
                 selectedMachine = machines.find(m => m.provider.id == provider.id),
-                limit_size = selectedMachine.size_gb;
-            providerSizeList.forEach(function(size) {
-                let disk_size = size.get('disk');
-                let is_disabled = true;
-                if (disk_size == 0 || limit_size == 0) {
-                    is_disabled = false;
-                } else {
-                    is_disabled = (limit_size > disk_size);
-                //console.log("limit_size "+limit_size+" > disk_size "+disk_size+" = " + is_disabled);
-                }
-                size.set({disabled: is_disabled});
-            });
-            let availableSizes = providerSizeList.cfilter(size=> size.get('disabled') == false),
-                is_available = availableSizes.find(size => (size.id == providerSize.id));
-            if (!is_available) {
-                let newProviderSize;
-                if(!availableSizes) {
-                    newProviderSize = null;
-                    //console.log("Size "+providerSize.get('name')+" no longer available, all other sizes are disabled!");
-                } else {
-                    newProviderSize = availableSizes.first();
-                    //console.log("Size "+providerSize.get('name')+" no longer available, auto-selecting next largest size: "+newProviderSize.get('name'));
-                }
-                providerSize = newProviderSize;
+                let limit_size = (selectedMachine) ? selectedMachine.size_gb : null;
+            if(limit_size) {
+                providerSizeList = providerSizeList.cfilter(function(size) {
+                    let disk_size = size.get('root'); // FIXME: should be 'disk'
+                    if (disk_size == 0 || limit_size == 0) {
+                        return size;
+                    } else if (disk_size >= limit_size) {
+                        return size;
+                    }
+                    console.log("limit_size "+limit_size+" > disk_size "+disk_size+" = True");
+                    return null;
+                });
             }
         }
 

--- a/troposphere/static/js/components/modals/instance/InstanceLaunchWizardModal.jsx
+++ b/troposphere/static/js/components/modals/instance/InstanceLaunchWizardModal.jsx
@@ -631,7 +631,7 @@ export default React.createClass({
         if (providerSizeList && imageVersion) {
             let machines = imageVersion.get('machines'),
                 selectedMachine = machines.find(m => m.provider.id == provider.id),
-                let limit_size = (selectedMachine) ? selectedMachine.size_gb : null;
+                limit_size = (selectedMachine) ? selectedMachine.size_gb : null;
             if(limit_size) {
                 providerSizeList = providerSizeList.cfilter(function(size) {
                     let disk_size = size.get('root'); // FIXME: should be 'disk'

--- a/troposphere/static/js/components/modals/instance/InstanceLaunchWizardModal.jsx
+++ b/troposphere/static/js/components/modals/instance/InstanceLaunchWizardModal.jsx
@@ -628,6 +628,36 @@ export default React.createClass({
             });
         }
 
+        if (providerSizeList && imageVersion) {
+            let machines = imageVersion.get('machines'),
+                selectedMachine = machines.find(m => m.provider.id == provider.id),
+                limit_size = selectedMachine.size_gb;
+            providerSizeList.forEach(function(size) {
+                let disk_size = size.get('disk');
+                let is_disabled = true;
+                if (disk_size == 0 || limit_size == 0) {
+                    is_disabled = false;
+                } else {
+                    is_disabled = (limit_size > disk_size);
+                //console.log("limit_size "+limit_size+" > disk_size "+disk_size+" = " + is_disabled);
+                }
+                size.set({disabled: is_disabled});
+            });
+            let availableSizes = providerSizeList.cfilter(size=> size.get('disabled') == false),
+                is_available = availableSizes.find(size => (size.id == providerSize.id));
+            if (!is_available) {
+                let newProviderSize;
+                if(!availableSizes) {
+                    newProviderSize = null;
+                    //console.log("Size "+providerSize.get('name')+" no longer available, all other sizes are disabled!");
+                } else {
+                    newProviderSize = availableSizes.first();
+                    //console.log("Size "+providerSize.get('name')+" no longer available, auto-selecting next largest size: "+newProviderSize.get('name'));
+                }
+                providerSize = newProviderSize;
+            }
+        }
+
         let allocationSourceList;
         if (globals.USE_ALLOCATION_SOURCES) {
             allocationSourceList = stores.AllocationSourceStore.getAll();

--- a/troposphere/static/js/components/modals/instance/launch/components/ResourcesForm.jsx
+++ b/troposphere/static/js/components/modals/instance/launch/components/ResourcesForm.jsx
@@ -23,7 +23,6 @@ export default React.createClass({
         let name = providerSize.get("name");
         let cpu = providerSize.get("cpu");
         let disk = providerSize.get("disk");
-        let disabled = providerSize.get("disabled");
         let diskStr = ""
         if (disk == 0) {
             disk = providerSize.get("root");
@@ -32,9 +31,8 @@ export default React.createClass({
             diskStr = `Disk: ${ disk } GB`
         }
         let memory = providerSize.get("mem");
-        let disabledStr = (!disabled) ? "" : " (Disabled - select a larger size)";
 
-        return `${ name } (CPU: ${ cpu }, Mem: ${ memory } GB, ${ diskStr })${disabledStr }`;
+        return `${ name } (CPU: ${ cpu }, Mem: ${ memory } GB, ${ diskStr })`;
     },
 
     renderAllocationSourceMenu() {
@@ -66,19 +64,6 @@ export default React.createClass({
         <ProviderAllocationGraph { ...this.props } />
         );
     },
-    renderProviderSizeOption(providerSize, index) {
-        let props = {
-            label: this.getProviderSizeName(providerSize),
-            key: index,
-            value: index,
-            disabled: providerSize.get('disabled')
-        }
-        return (
-                <option {...props}>
-                    {props.label}
-                </option>
-        );
-    },
 
     render: function() {
         let { provider,
@@ -108,7 +93,7 @@ export default React.createClass({
                     Instance Size
                 </label>
                 <SelectMenu current={providerSize}
-                    renderListOption={this.renderProviderSizeOption}
+                    optionName={this.getProviderSizeName}
                     list={providerSizeList}
                     onSelect={onSizeChange} />
             </div>

--- a/troposphere/static/js/components/modals/instance/launch/components/ResourcesForm.jsx
+++ b/troposphere/static/js/components/modals/instance/launch/components/ResourcesForm.jsx
@@ -23,6 +23,7 @@ export default React.createClass({
         let name = providerSize.get("name");
         let cpu = providerSize.get("cpu");
         let disk = providerSize.get("disk");
+        let disabled = providerSize.get("disabled");
         let diskStr = ""
         if (disk == 0) {
             disk = providerSize.get("root");
@@ -31,8 +32,9 @@ export default React.createClass({
             diskStr = `Disk: ${ disk } GB`
         }
         let memory = providerSize.get("mem");
+        let disabledStr = (!disabled) ? "" : " (Disabled - select a larger size)";
 
-        return `${ name } (CPU: ${ cpu }, Mem: ${ memory } GB, ${ diskStr })`;
+        return `${ name } (CPU: ${ cpu }, Mem: ${ memory } GB, ${ diskStr })${disabledStr }`;
     },
 
     renderAllocationSourceMenu() {
@@ -64,6 +66,19 @@ export default React.createClass({
         <ProviderAllocationGraph { ...this.props } />
         );
     },
+    renderProviderSizeOption(providerSize, index) {
+        let props = {
+            label: this.getProviderSizeName(providerSize),
+            key: index,
+            value: index,
+            disabled: providerSize.get('disabled')
+        }
+        return (
+                <option {...props}>
+                    {props.label}
+                </option>
+        );
+    },
 
     render: function() {
         let { provider,
@@ -93,7 +108,7 @@ export default React.createClass({
                     Instance Size
                 </label>
                 <SelectMenu current={providerSize}
-                    optionName={this.getProviderSizeName}
+                    renderListOption={this.renderProviderSizeOption}
                     list={providerSizeList}
                     onSelect={onSizeChange} />
             </div>


### PR DESCRIPTION
Solution: Disable sizes when too small to launch an instance.

## Highlight Reel:
- Use custom element-to-option rendering for providerSizeList
- Filter down available providerSizeList based on new API value, size_gb
- Select a new providerSize if the previously selected size is not
available.

## Screen-capture
![provider-sizes-disabled](https://user-images.githubusercontent.com/2889930/27445806-07059372-5730-11e7-9970-f903e95f3379.gif)


### Related PRs:
Atmosphere: https://github.com/cyverse/atmosphere/pull/397

## Checklist before merging Pull Requests
- [ ] Reviewed and approved by at least one other contributor.
