### PR TITLE
Included actions to track when activated (2)

### DIFF
--- a/troposphere/static/js/components/projects/resources/instance/details/actions/InstanceActionsAndLinks.jsx
+++ b/troposphere/static/js/components/projects/resources/instance/details/actions/InstanceActionsAndLinks.jsx
@@ -221,6 +221,10 @@ export default React.createClass({
         form[0].submit();
     },
 
+    onWebShell: function() {
+        trackAction('activated-web_shell-ssh');
+    },
+
     getIntegrationLinks() {
         let { instance } = this.props,
             webShellUrl = instance.shell_url(),
@@ -233,6 +237,7 @@ export default React.createClass({
                 label: "Open Web Shell",
                 icon: "console",
                 href: webShellUrl,
+                onClick: this.onWebShell,
                 openInNewWindow: true,
                 isDisabled: disableWebLinks
             }


### PR DESCRIPTION
## Description

This includes any activations of the "Web Shell" remote access action.
The approach for including and activating the Gate One remote access
technology so we can properly evaluate the community adoption of this
when compared with the new/beta technology: Apache Guacamole.

This is a transplant of @lenards https://github.com/cdosborn/troposphere/pull/6. It was based against a branch that was rewritten an brought into zesty-zapdos, so I reproduced it here.

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature
- [ ] Reviewed and approved by at least one other contributor.
