### PR TITLE
Add special case for provider size of 0

### DIFF
--- a/troposphere/static/js/components/modals/instance/InstanceLaunchWizardModal.jsx
+++ b/troposphere/static/js/components/modals/instance/InstanceLaunchWizardModal.jsx
@@ -438,8 +438,14 @@ export default React.createClass({
             imageVersion.get('machines')
                         .find(m => m.provider.id == provider.id);
 
+        let largeEnough = size =>
+            // Disk size of 0 specially treated in Openstack, the size will be
+            // the size of the image
+            size.get('disk') === 0 ||
+            size.get('disk') >= selectedMachine.size_gb;
+
         // Return provider sizes that have enough disk space
-        return sizes.cfilter(size => size.get('disk') >= selectedMachine.size_gb);
+        return sizes.cfilter(largeEnough);
     },
 
     //============================


### PR DESCRIPTION
## Description

A provider size of 0 means that Openstack will match the disk size of the image, being launched for that size. 

Please describe your pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. When linking to an issue, please use `refs #...` in the description of the pull request.

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature
- [ ] Reviewed and approved by at least one other contributor.
