### PR TITLE
Problem: do not apply a recommended set of ESLint rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,6 +6,9 @@
     //     "eslint:recommended",
     //     "plugin:react/recommended",
     // ],
+    "extends": [
+        "eslint:recommended",
+    ],
 
     "ecmaFeatures": {
         "jsx": true

--- a/.eslintrc
+++ b/.eslintrc
@@ -38,6 +38,7 @@
                 "args": "none"
             }
         ],
+        "comma-dangle": 0,
         "react/jsx-uses-react": "error",
         "react/jsx-uses-vars": "error"
     }

--- a/.eslintrc
+++ b/.eslintrc
@@ -38,7 +38,8 @@
                 "args": "none"
             }
         ],
-        "comma-dangle": 0,
+        "no-console": 1,                      // 1=warn
+        "comma-dangle": 0,                    // 0=off
         "react/jsx-uses-react": "error",
         "react/jsx-uses-vars": "error"
     }

--- a/.eslintrc
+++ b/.eslintrc
@@ -27,6 +27,10 @@
             "error",
             "unix"
         ],
+        "no-unused-vars": [
+            "error",
+            {"args": "none"}
+        ],
         "no-console": "warn",
         "comma-dangle": "off",
         "react/jsx-uses-react": "error",

--- a/.eslintrc
+++ b/.eslintrc
@@ -38,8 +38,8 @@
                 "args": "none"
             }
         ],
-        "no-console": 1,                      // 1=warn
-        "comma-dangle": 0,                    // 0=off
+        "no-console": "warn",
+        "comma-dangle": "off",
         "react/jsx-uses-react": "error",
         "react/jsx-uses-vars": "error"
     }

--- a/.eslintrc
+++ b/.eslintrc
@@ -27,17 +27,6 @@
             "error",
             "unix"
         ],
-        "no-constant-condition": "error",     // See LINT.md for docs on these
-        "no-debugger": "error",               // rules
-        "no-mixed-spaces-and-tabs": "error",
-        "no-undef": "error",
-        "no-unreachable": "error",
-        "no-unused-vars": [
-            "error",
-            {
-                "args": "none"
-            }
-        ],
         "no-console": "warn",
         "comma-dangle": "off",
         "react/jsx-uses-react": "error",

--- a/LINT.md
+++ b/LINT.md
@@ -14,6 +14,18 @@ npm run lint
 
 The configuration for eslint is to use the "recommended" set. You can review the recommended rules here: http://eslint.org/docs/rules/
 
+This section notes the variation(s) from the "eslint:recommended" rules.
+
+### General Rules
+
+#### no-unused-vars
+
+Its an error to have unused variables, but okay to have unused paramaters, so functions can demonstrate their interface even if its not currently used.
+
+```
+"no-unused-vars": ["error", {"args": "none"}]
+```
+
 ### React-specific Rules
 
 We do currently define two rules that are enforced via the React plugin for ESLint, `eslint-plugin-react`.

--- a/LINT.md
+++ b/LINT.md
@@ -11,16 +11,14 @@ npm run lint
 ```
 
 ## Rules
-Here are some of the less clear rules that we use.
 
-### no-unused-vars
-Its an error to have unused variables, but okay to have unused paramaters, so
-functions can demonstrate their interface even if its not currently used.
-```
-"no-unused-vars": [2, {"args": "none"}]
-```
+The configuration for eslint is to use the "recommended" set. You can review the recommended rules here: http://eslint.org/docs/rules/
 
-### react/jsx-uses-vars
+### React-specific Rules
+
+We do currently define two rules that are enforced via the React plugin for ESLint, `eslint-plugin-react`.
+
+#### react/jsx-uses-vars
 This rule is necessary to allow variables in jsx.
 ```
 import ReactComponent from '...'
@@ -33,7 +31,7 @@ It's not so much a rule as a feature.
 "react/jsx-uses-vars": "error"
 ```
 
-### react/jsx-uses-react
+#### react/jsx-uses-react
 This rule is more nuanced, and caters to a specific instance: A file contains
 only jsx and a necessary React import. The file does not otherwise mention
 React, eslint thinks React is an unused var. This option stifles the unused var
@@ -41,6 +39,11 @@ error. Note: "jsx-uses-react" is only effective with "no-unused-vars"
 ```
 "react/jsx-uses-react": "error"
 ```
+
+#### Toward a "React" recommended
+
+We are currently working to adopt a recommended set of rules for the React plugin, as well.
+
 
 ## Documentation
 - [eslint](http://eslint.org/docs/rules/)
@@ -66,7 +69,7 @@ eslint $FILES
 
 Run a subset of rules over the codebase
 ```
-RULES='{ "no-undef": 2 }'
+RULES='{ "no-undef": "error" }'
 eslint --env es6 --ext .js,.jsx --env browser --env commonjs --parser "babel-eslint" --rule "$RULES" --no-eslintrc troposphere/static/js
 ```
 

--- a/troposphere/static/js/AppRoutes.jsx
+++ b/troposphere/static/js/AppRoutes.jsx
@@ -136,7 +136,7 @@ function AppRoutes(props) {
             <IndexRedirect to="dashboard" />
         </Route>
     )
-};
+}
 
 
 export default AppRoutes;

--- a/troposphere/static/js/components/common/ui/Button.jsx
+++ b/troposphere/static/js/components/common/ui/Button.jsx
@@ -50,7 +50,6 @@ export default React.createClass({
         if (!tooltip || !this.state.showTooltip) {
             return
         }
-        ;
 
         return (
         <Tooltip message={tooltip} />

--- a/troposphere/static/js/components/common/ui/CopyButton.jsx
+++ b/troposphere/static/js/components/common/ui/CopyButton.jsx
@@ -85,10 +85,10 @@ function copyTextToClipboard(text) {
         document.execCommand('copy');
     } catch (err) {
         reportException(err);
-    };
+    }
 
     document.body.removeChild(textArea);
-};
+}
 
 export default React.createClass({
     getInitialState() {
@@ -114,7 +114,7 @@ export default React.createClass({
             this.setState({
                 canCopy: false,
             });
-        };
+        }
     },
 
     onClick() {

--- a/troposphere/static/js/components/help/HelpPage.jsx
+++ b/troposphere/static/js/components/help/HelpPage.jsx
@@ -44,7 +44,7 @@ export default React.createClass({
             return <div className="loading"></div>;
         }
 
-        var resourceElements = resources.map(function(resource) {
+        resourceElements = resources.map(function(resource) {
             var hyperlink = helpLinks.get(resource.link_key).get("href");
             return (
             <li key={resource.title}>

--- a/troposphere/static/js/components/images/MyImageRequestsPage.jsx
+++ b/troposphere/static/js/components/images/MyImageRequestsPage.jsx
@@ -128,8 +128,8 @@ export default React.createClass({
                 endDateText = moment(request.get("end_date")).format("MMM D, YYYY h:mm:ss a");
             }
 
-            var newMachineId = !!request.get("new_machine") ? request.get("new_machine").uuid : "N/A";
-            var newMachineProvider = !!request.get("new_machine_provider") ? request.get("new_machine_provider").name : "Unknown";
+            var newMachineId = request.get("new_machine") ? request.get("new_machine").uuid : "N/A";
+            var newMachineProvider = request.get("new_machine_provider") ? request.get("new_machine_provider").name : "Unknown";
 
             const { name, uuid } = request.get("instance");
             const requestDate = moment(request.get("start_date")).format("MMM D, YYYY h:mm:ss a");

--- a/troposphere/static/js/components/images/detail/versions/VersionList.jsx
+++ b/troposphere/static/js/components/images/detail/versions/VersionList.jsx
@@ -61,8 +61,10 @@ export default React.createClass({
         );
     },
     getVersions: function(versions) {
-        var versions = [],
-            partialLoad = false;
+        versions = versions || [];
+
+        var partialLoad = false;
+
         //Wait for it...
         if (!versions) {
             return null;

--- a/troposphere/static/js/components/modals/instance/InstanceImageWizardModal.jsx
+++ b/troposphere/static/js/components/modals/instance/InstanceImageWizardModal.jsx
@@ -117,11 +117,13 @@ export default React.createClass({
     },
 
     onReviewImage: function(data) {
+        data = data || {};
+
         var step = REVIEW_STEP,
-            data = data || {},
             state = _.extend({
                 step: step
             }, data);
+
         this.setState(state);
     },
 
@@ -167,25 +169,29 @@ export default React.createClass({
     },
 
     onPrevious: function(data) {
+        data = data || {};
+
         // Breadcrumbs still starts at 0 even though steps starts at 1.
         // this.state.step - 2 == current breadcrumb - 1
         var previousStep = this.state.breadcrumbs[this.state.step - 2],
-            data = data || {},
             state = _.extend({
                 step: previousStep.step,
                 title: previousStep.name
             }, data);
+
         this.setState(state);
     },
 
     onNext: function(data) {
+        data = data || {};
+
         // Similar logic to onPrevious. this.state.step == breadcrumbs + 1
         var nextStep = this.state.breadcrumbs[this.state.step],
-            data = data || {},
             state = _.extend({
                 step: nextStep.step,
                 title: nextStep.name
             }, data);
+
         this.setState(state);
     },
 

--- a/troposphere/static/js/components/modals/instance/launch/components/BasicInfoForm.jsx
+++ b/troposphere/static/js/components/modals/instance/launch/components/BasicInfoForm.jsx
@@ -28,8 +28,7 @@ export default React.createClass({
         const { instanceName } = this.props;
 
         function invalidName() {
-          let regex = /\.(\d)+$/gm;
-          return Boolean(instanceName.match(regex));
+            return /\.(\d)+$/gm.test(instanceName);
         }
 
         function missingName() {

--- a/troposphere/static/js/components/modals/instance/launch/components/BasicInfoForm.jsx
+++ b/troposphere/static/js/components/modals/instance/launch/components/BasicInfoForm.jsx
@@ -32,7 +32,7 @@ export default React.createClass({
         }
 
         function missingName() {
-            return !Boolean(instanceName)
+            return !instanceName;
         }
 
         if (invalidName()) return "invalid";

--- a/troposphere/static/js/components/modals/instance/launch/components/BasicInfoForm.jsx
+++ b/troposphere/static/js/components/modals/instance/launch/components/BasicInfoForm.jsx
@@ -28,7 +28,7 @@ export default React.createClass({
         const { instanceName } = this.props;
 
         function invalidName() {
-            return /\.(\d)+$/gm.test(instanceName);
+            return /\.\d+$/gm.test(instanceName);
         }
 
         function missingName() {

--- a/troposphere/static/js/components/modals/instance/launch/components/BasicInfoForm.jsx
+++ b/troposphere/static/js/components/modals/instance/launch/components/BasicInfoForm.jsx
@@ -50,7 +50,7 @@ export default React.createClass({
     },
 
     render: function() {
-        const { 
+        const {
             imageVersion,
             project,
             projectList,

--- a/troposphere/static/js/components/modals/instance/launch/steps/LicenseStep.jsx
+++ b/troposphere/static/js/components/modals/instance/launch/steps/LicenseStep.jsx
@@ -85,7 +85,6 @@ export default React.createClass({
         if (this.props.licenseList.length <= 1) {
             return
         }
-        ;
 
         let licenses = this.props.licenseList.map(this.renderLicense);
         return (

--- a/troposphere/static/js/components/modals/instance/launch/steps/SizeSelectStep.jsx
+++ b/troposphere/static/js/components/modals/instance/launch/steps/SizeSelectStep.jsx
@@ -221,7 +221,7 @@ export default React.createClass({
         return this.renderProgressBar(message, currentlyUsedPercent, projectedPercent, overQuotaMessage);
     },
 
-    renderNoSizesAvailable: function(minRequirements) {
+    renderNoSizesAvailable: function() {
         var minRequirements = (
         <div className="col-sm-9 control-label pull -left">
             Minimum requirements:

--- a/troposphere/static/js/components/projects/resources/instance/details/sections/AllocationSourceSection.jsx
+++ b/troposphere/static/js/components/projects/resources/instance/details/sections/AllocationSourceSection.jsx
@@ -36,7 +36,6 @@ export default React.createClass({
             let allocSrc = instance.get("allocation_source");
             if (!allocSrc) {
                 // Do nothing if null
-                ;
             } else if (!(allocSrc instanceof Backbone.Model)) {
                 current = allocationSources.findWhere({
                     name: allocSrc.name

--- a/troposphere/static/js/components/projects/resources/instance/details/sections/InstanceInfoSection.jsx
+++ b/troposphere/static/js/components/projects/resources/instance/details/sections/InstanceInfoSection.jsx
@@ -33,11 +33,7 @@ export default React.createClass({
     },
 
     isValid: function(text) {
-        if(!text) {
-            return false;
-        }
-        let regex = /\.(\d)+$/gm;
-        return !Boolean(text.match(regex));
+        return !/\.(\d)+$/gm.test(text);
     },
 
     onDoneEditing: function(text) {

--- a/troposphere/static/js/components/projects/resources/instance/details/sections/metrics/GraphController.js
+++ b/troposphere/static/js/components/projects/resources/instance/details/sections/metrics/GraphController.js
@@ -27,9 +27,9 @@ GraphController.prototype.switch = function(settings, onSuccess, onError) {
 
     // Fetch data/build graphs for a timeframe
     if (graphs == undefined) {
-
-        var graphs = [["cpu", CPUGraph], ["mem", MemoryGraph], ["net", NetworkGraph]];
-        graphs = graphs.map((data) => {
+        graphs = [["cpu", CPUGraph],
+                  ["mem", MemoryGraph],
+                  ["net", NetworkGraph]].map((data) => {
             return new data[1]({
                 type: data[0],
                 from: settings.from,

--- a/troposphere/static/js/stores/BaseStore.js
+++ b/troposphere/static/js/stores/BaseStore.js
@@ -209,8 +209,8 @@ _.extend(Store.prototype, Backbone.Events, {
     // same as fetchFirstPage, but with URL query params
     fetchFirstPageWhere: function(queryParams, options, cb) {
         if (options && options.clearQueryCache) {
-            var queryString = this.buildQueryStringFromQueryParams(queryParams);
-            delete this.queryModels[queryString];
+            let clearQS = this.buildQueryStringFromQueryParams(queryParams);
+            delete this.queryModels[clearQS];
         }
 
         if (!this.isFetching) {
@@ -428,13 +428,14 @@ _.extend(Store.prototype, Backbone.Events, {
         var queryString = this.buildQueryStringFromQueryParams(queryParams);
         var queryKey = modelId + queryString;
         var model = null;
+
         if (this.queryModels[queryKey]) {
             model = this.queryModels[queryKey];
             return model;
         } else if (!this.isFetchingQuery[queryKey]) {
             this.isFetchingQuery[queryKey] = true;
             this.isFetching = true;
-            var model = new this.collection.prototype.model({
+            model = new this.collection.prototype.model({
                 id: modelId
             });
             model.fetch({

--- a/troposphere/static/js/stores/ProjectInstanceStore.js
+++ b/troposphere/static/js/stores/ProjectInstanceStore.js
@@ -69,10 +69,10 @@ let ProjectInstanceStore = BaseStore.extend({
 
     getInstancesForProjectOnProvider: function(project, provider) {
         // get instances in project
-        var instances = this.getInstancesFor(project);
+        let projectInstances = this.getInstancesFor(project);
 
         // filter out instances not on provider
-        var instances = instances.filter(function(i) {
+        let instances = projectInstances.filter(function(i) {
             return i.get("provider").id === provider.id;
         });
 


### PR DESCRIPTION
## Description

This work resolves a number of `eslint:recommended` violations:
- no-extra-semi
- no-unused-vars
- no-extra-boolean-cast
- no-redeclare

This would allow:
- comma-dangle

And, it treats `console` statements as warnings.

The results of merging this would be enabling `"eslint:recommended"` rules, plus our existing `.eslintrc` definition.

Note: I have "disable" a violation for one issue related to removing licenses from an imaging request. This has been captured within [the product's internal issue tracking](https://pods.iplantcollaborative.org/jira/browse/ATMO-1962) (noted within commit 7d39a6c).

## Checklist before merging Pull Requests
- [ ] ~New test(s) included to reproduce the bug/verify the feature~
- [ ] ~Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Reviewed and approved by at least one other contributor.
