### PR TITLE
Problem: currently not using React plugin's recommended rules

### DIFF
--- a/troposphere/static/js/components/Footer.jsx
+++ b/troposphere/static/js/components/Footer.jsx
@@ -50,6 +50,7 @@ export default React.createClass({
             </div>
             );
         } else {
+            /* eslint-disable react/no-danger */
             footerContent = (<div className="container">
                 <span className="footer-content"
                     dangerouslySetInnerHTML={{ __html:footerHTML }}>
@@ -57,6 +58,7 @@ export default React.createClass({
                 {feedbackButton}
             </div>
             );
+            /* eslint-enable react/no-danger */
         }
 
         return (

--- a/troposphere/static/js/components/MaintenanceMessageBanner.jsx
+++ b/troposphere/static/js/components/MaintenanceMessageBanner.jsx
@@ -13,12 +13,14 @@ export default React.createClass({
         var provider = stores.ProviderStore.get(message.get("provider")),
             providerName = provider ? provider.get("name") : "";
 
+        /* eslint-disable react/no-danger */
         return (
         <li key={message.id} className="message">
             <strong className="provider-name">{providerName}</strong>
             <span dangerouslySetInnerHTML={{ __html: message.get("message") }} />
         </li>
         );
+        /* eslint-enable react/no-danger */
     },
 
     render: function() {

--- a/troposphere/static/js/components/Master.jsx
+++ b/troposphere/static/js/components/Master.jsx
@@ -29,9 +29,11 @@ export default React.createClass({
         return this.getState();
     },
 
+    /* eslint-disable react/no-is-mounted */
     updateState: function() {
         if (this.isMounted()) this.setState(this.getState())
     },
+    /* eslint-enable react/no-is-mounted */
 
     loadBadgeData: function() {
         stores.BadgeStore.getAll(),

--- a/troposphere/static/js/components/admin/AdminMaster.jsx
+++ b/troposphere/static/js/components/admin/AdminMaster.jsx
@@ -4,6 +4,8 @@ import SecondaryAdminNavigation from "./SecondaryAdminNavigation";
 
 
 export default React.createClass({
+    displayName: "AdminMaster",
+
     render: function() {
         return (
         <div>

--- a/troposphere/static/js/components/admin/IdentityMembership.jsx
+++ b/troposphere/static/js/components/admin/IdentityMembership.jsx
@@ -6,6 +6,7 @@ import moment from "moment";
 
 
 export default React.createClass({
+    displayName: "IdentityMembership",
 
     propTypes: {
         membership: React.PropTypes.instanceOf(Backbone.Model).isRequired

--- a/troposphere/static/js/components/admin/IdentityMembershipMaster.jsx
+++ b/troposphere/static/js/components/admin/IdentityMembershipMaster.jsx
@@ -8,7 +8,7 @@ import modals from "modals";
 
 
 export default React.createClass({
-    displayName: "IdentityMembership",
+    displayName: "IdentityMembershipMaster",
 
     mixins: [ComponentHandleInputWithDelay],
 

--- a/troposphere/static/js/components/common/AllocationSourceGraph.jsx
+++ b/troposphere/static/js/components/common/AllocationSourceGraph.jsx
@@ -6,6 +6,7 @@ import messages from "messages/allocationMessages";
 
 
 export default React.createClass({
+    displayName: "AllocationSourceGraph",
 
     propTypes: {
         allocationSource: React.PropTypes.instanceOf(Backbone.Model),

--- a/troposphere/static/js/components/common/ManyToManyList.jsx
+++ b/troposphere/static/js/components/common/ManyToManyList.jsx
@@ -41,7 +41,7 @@ export default React.createClass({
     },
     renderForm: function() {
         return (
-        <form onsubmit={this.onFormSubmit}>
+        <form onSubmit={this.onFormSubmit}>
             {this.props.renderForm()}
         </form>);
     },

--- a/troposphere/static/js/components/common/ui/Button.jsx
+++ b/troposphere/static/js/components/common/ui/Button.jsx
@@ -2,6 +2,8 @@ import React from "react";
 import Tooltip from "components/common/ui/Tooltip";
 
 export default React.createClass({
+    displayName: "Button",
+
     propTypes: {
         buttonType: React.PropTypes.string.isRequired,
         title: React.PropTypes.string.isRequired,

--- a/troposphere/static/js/components/common/ui/ProgressBar.jsx
+++ b/troposphere/static/js/components/common/ui/ProgressBar.jsx
@@ -24,9 +24,12 @@ export default React.createClass({
                 <p className="t-Caption">
                     {this.props.label}
                 </p>
-                <div className="ProgressBar-wrapper clearfix" style={{ background: "#efefef", marginBottom: "20px" }}>
-                    <div className="ProgressBar-startIndicator" style={{ transition: "all ease .3s", height: "10px", float: "left", width: startValue + "%", background: startColor }} />
-                    <div className="ProgressBar-afterIndicator" style={{ transition: "all ease .3s", height: "10px", float: "left", width: afterValue + "%", background: startColor, opacity: ".5" }} />
+                <div className="ProgressBar-wrapper clearfix"
+                     style={{ background: "#efefef", marginBottom: "20px" }}>
+                    <div className="ProgressBar-startIndicator"
+                         style={{ transition: "all ease .3s", height: "10px", float: "left", width: startValue + "%", background: startColor }} />
+                    <div className="ProgressBar-afterIndicator"
+                         style={{ transition: "all ease .3s", height: "10px", float: "left", width: afterValue + "%", background: startColor, opacity: ".5" }} />
                 </div>
             </div>
         </div>

--- a/troposphere/static/js/components/common/ui/ProgressBar.jsx
+++ b/troposphere/static/js/components/common/ui/ProgressBar.jsx
@@ -1,6 +1,8 @@
 import React from "react";
 
 export default React.createClass({
+    displayName: "ProgressBar",
+
     render: function() {
         let startValue = this.props.startValue;
         let afterValue = this.props.afterValue;

--- a/troposphere/static/js/components/common/ui/Tooltip.jsx
+++ b/troposphere/static/js/components/common/ui/Tooltip.jsx
@@ -1,6 +1,8 @@
 import React from "react";
 
 export default React.createClass({
+    displayName: "Tooltip",
+
     propTypes: {
         message: React.PropTypes.string.isRequired,
     },

--- a/troposphere/static/js/components/identities/IdentityListPage.jsx
+++ b/troposphere/static/js/components/identities/IdentityListPage.jsx
@@ -20,9 +20,11 @@ export default React.createClass({
         return getIdentityState();
     },
 
+    /* eslint-disable react/no-is-mounted */
     updateImages: function() {
         if (this.isMounted()) this.setState(getIdentityState());
     },
+    /* eslint-enable react/no-is-mounted */
 
     componentDidMount: function() {
         stores.IdentityStore.addChangeListener(this.updateImages);

--- a/troposphere/static/js/components/images/ImageTagsPage.jsx
+++ b/troposphere/static/js/components/images/ImageTagsPage.jsx
@@ -18,9 +18,11 @@ export default React.createClass({
         return state;
     },
 
+    /* eslint-disable react/no-is-mounted */
     updateState() {
         if (this.isMounted()) this.setState(this.getState());
     },
+    /* eslint-enable react/no-is-mounted */
 
     componentDidMount() {
         stores.ImageStore.addChangeListener(this.updateState);

--- a/troposphere/static/js/components/images/detail/description/DescriptionView.jsx
+++ b/troposphere/static/js/components/images/detail/description/DescriptionView.jsx
@@ -16,11 +16,14 @@ export default React.createClass({
             description = image.get("description"),
             descriptionHtml = converter.makeHtml(description);
 
+        /* eslint-disable react/no-danger */
         return (
         <div className="image-info-segment row">
             <h4 className="t-body-2 col-md-2">Description:</h4>
-            <div className="content col-md-10" dangerouslySetInnerHTML={{ __html: descriptionHtml }} />
+            <div className="content col-md-10"
+                 dangerouslySetInnerHTML={{ __html: descriptionHtml }} />
         </div>
         );
+        /* eslint-enable react/no-danger */
     }
 });

--- a/troposphere/static/js/components/images/detail/versions/Version.jsx
+++ b/troposphere/static/js/components/images/detail/versions/Version.jsx
@@ -122,13 +122,14 @@ export default React.createClass({
         let converter = new showdown.Converter();
         let changeLogHTML = converter.makeHtml(changeLog);
 
+        /* eslint-disable react/no-danger */
         return (
         <div style={ styles.description }
             dangerouslySetInnerHTML={{
                 __html: changeLogHTML
-            }}
-        />
-       );
+            }} />
+        );
+        /* eslint-enable react/no-danger */
     },
 
     renderSummary() {

--- a/troposphere/static/js/components/images/list/common/ImageListCard.jsx
+++ b/troposphere/static/js/components/images/list/common/ImageListCard.jsx
@@ -127,6 +127,7 @@ const ImageListCard = React.createClass({
             );
         }
 
+        /* eslint-disable react/no-danger */
         return (
             <MediaCard
                 avatar={ icon }
@@ -152,6 +153,7 @@ const ImageListCard = React.createClass({
                 }
             />
         );
+        /* eslint-enable react/no-danger */
     }
 });
 

--- a/troposphere/static/js/components/images/list/list/ImageCardList.jsx
+++ b/troposphere/static/js/components/images/list/list/ImageCardList.jsx
@@ -6,6 +6,7 @@ import stores from "stores";
 
 
 export default React.createClass({
+    displayName: "ImageCardList",
 
     propTypes: {
         title: React.PropTypes.string,
@@ -46,4 +47,3 @@ export default React.createClass({
         );
     }
 });
-

--- a/troposphere/static/js/components/mixins/ChosenMixinExternal.jsx
+++ b/troposphere/static/js/components/mixins/ChosenMixinExternal.jsx
@@ -8,6 +8,7 @@ import classNames from "classnames";
 
 let ENTER_KEY = 13;
 
+/* eslint-disable react/display-name */
 export default {
     getInitialState: function() {
         return {
@@ -269,3 +270,4 @@ export default {
     }
 
 };
+/* eslint-enable react/display-name */

--- a/troposphere/static/js/components/mixins/ChosenMixinExternal.jsx
+++ b/troposphere/static/js/components/mixins/ChosenMixinExternal.jsx
@@ -10,13 +10,6 @@ let ENTER_KEY = 13;
 
 /* eslint-disable react/display-name */
 export default {
-    getInitialState: function() {
-        return {
-            showOptions: false,
-            query: ""
-        }
-    },
-
     propTypes: {
         placeholderText: React.PropTypes.string,
         models: React.PropTypes.instanceOf(Backbone.Collection),
@@ -26,6 +19,13 @@ export default {
         onModelRemoved: React.PropTypes.func.isRequired,
         onEnterKeyPressed: React.PropTypes.func,
         width: React.PropTypes.string
+    },
+
+    getInitialState: function() {
+        return {
+            showOptions: false,
+            query: ""
+        }
     },
 
     getDefaultProps: function() {

--- a/troposphere/static/js/components/mixins/ChosenMixinExternal.jsx
+++ b/troposphere/static/js/components/mixins/ChosenMixinExternal.jsx
@@ -61,6 +61,7 @@ export default {
         this.closeDropdown();
     },
 
+    /* eslint-disable react/no-is-mounted */
     isOutsideClick: function(e) {
         if (!this.isMounted()) {
             return false;
@@ -77,6 +78,7 @@ export default {
         }
         return false;
     },
+    /* eslint-enable react/no-is-mounted */
 
     onEnter: function(e) {
         if (e.which !== ENTER_KEY) return;
@@ -267,4 +269,3 @@ export default {
     }
 
 };
-

--- a/troposphere/static/js/components/modals/BadgeModal.jsx
+++ b/troposphere/static/js/components/modals/BadgeModal.jsx
@@ -9,6 +9,8 @@ function getState() {
 }
 
 export default React.createClass({
+    displayName: "BadgeModal",
+
     mixins: [BootstrapModalMixin],
 
     //

--- a/troposphere/static/js/components/modals/BadgeModal.jsx
+++ b/troposphere/static/js/components/modals/BadgeModal.jsx
@@ -19,9 +19,11 @@ export default React.createClass({
         return getState();
     },
 
+    /* eslint-disable react/no-is-mounted */
     updateState: function() {
         if (this.isMounted()) this.setState(getState());
     },
+    /* eslint-enable react/no-is-mounted */
 
     //
     // Internal Modal Callbacks

--- a/troposphere/static/js/components/modals/FeedbackModal.jsx
+++ b/troposphere/static/js/components/modals/FeedbackModal.jsx
@@ -47,9 +47,11 @@ export default React.createClass({
         return getState();
     },
 
+    /* eslint-disable react/no-is-mounted */
     updateState: function() {
         if (this.isMounted()) this.setState(getState());
     },
+    /* eslint-enable react/no-is-mounted */
 
     //
     // Internal Modal Callbacks

--- a/troposphere/static/js/components/modals/InsufficientResourcesForActionBody.jsx
+++ b/troposphere/static/js/components/modals/InsufficientResourcesForActionBody.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import Glyphicon from "components/common/Glyphicon";
 
+/* eslint-disable react/display-name */
 export default {
     build: function() {
         return (
@@ -16,3 +17,4 @@ export default {
         );
     }
 }
+/* eslint-enable react/display-name */

--- a/troposphere/static/js/components/modals/MyBadgeModal.jsx
+++ b/troposphere/static/js/components/modals/MyBadgeModal.jsx
@@ -21,9 +21,11 @@ export default React.createClass({
         return getState();
     },
 
+    /* eslint-disable react/no-is-mounted */
     updateState: function() {
         if (this.isMounted()) this.setState(getState());
     },
+    /* eslint-enable react/no-is-mounted */
 
     //
     // Internal Modal Callbacks

--- a/troposphere/static/js/components/modals/VersionInformationModal.jsx
+++ b/troposphere/static/js/components/modals/VersionInformationModal.jsx
@@ -22,9 +22,11 @@ export default React.createClass({
         };
     },
 
+    /* eslint-disable react/no-is-mounted */
     updateState: function() {
         if (this.isMounted()) this.setState(this.getState.apply(this));
     },
+    /* eslint-enable react/no-is-mounted */
 
     componentDidMount: function() {
         stores.VersionStore.addChangeListener(this.updateState);

--- a/troposphere/static/js/components/modals/image_version/ImageSelect.jsx
+++ b/troposphere/static/js/components/modals/image_version/ImageSelect.jsx
@@ -44,7 +44,7 @@ export default React.createClass({
 
         return (
         <div className="form-group">
-            <h4 className="t-body-2" htmlFor="Image" className="control-label">Change Image</h4>
+            <h4 className="t-body-2 control-label" htmlFor="Image">Change Image</h4>
             <div className="alert alert-danger">
                 <strong>Warning:</strong> Changing this value will move this version to a different image you own.
             </div>

--- a/troposphere/static/js/components/modals/image_version/ImageVersionEditModal.jsx
+++ b/troposphere/static/js/components/modals/image_version/ImageVersionEditModal.jsx
@@ -51,9 +51,11 @@ export default React.createClass({
         }
     },
 
+    /* eslint-disable react/no-is-mounted */
     updateState: function() {
         if (this.isMounted()) this.setState(this.getState());
     },
+    /* eslint-enable react/no-is-mounted */
 
     getState: function() {
         return this.state;

--- a/troposphere/static/js/components/modals/image_version/requirements/EditMinimumRequirementsView.jsx
+++ b/troposphere/static/js/components/modals/image_version/requirements/EditMinimumRequirementsView.jsx
@@ -2,6 +2,8 @@ import React from "react";
 
 
 export default React.createClass({
+    displayName: "EditMinimumRequirementsView",
+
     propTypes: {
         cpu: React.PropTypes.number.isRequired,
         mem: React.PropTypes.number.isRequired,

--- a/troposphere/static/js/components/modals/instance/launch/components/AdvancedOptionsFooter.jsx
+++ b/troposphere/static/js/components/modals/instance/launch/components/AdvancedOptionsFooter.jsx
@@ -3,6 +3,8 @@ import RaisedButton from 'material-ui/RaisedButton';
 import Button from "components/common/ui/Button";
 
 export default React.createClass({
+    displayName: "AdvancedOptionsFooter",
+
     onClearAdvanced: function() {
         this.props.onClearAdvanced();
     },

--- a/troposphere/static/js/components/modals/instance/launch/components/InstanceLaunchFooter.jsx
+++ b/troposphere/static/js/components/modals/instance/launch/components/InstanceLaunchFooter.jsx
@@ -2,6 +2,8 @@ import React from "react";
 import RaisedButton from 'material-ui/RaisedButton';
 
 export default React.createClass({
+    displayName: "InstanceLaunchFooter",
+
     propTypes: {
         backIsDisabled: React.PropTypes.bool.isRequired,
         launchIsDisabled: React.PropTypes.bool.isRequired,

--- a/troposphere/static/js/components/modals/instance/launch/components/ProviderAllocationGraph.jsx
+++ b/troposphere/static/js/components/modals/instance/launch/components/ProviderAllocationGraph.jsx
@@ -2,6 +2,8 @@ import React from "react";
 import ProgressBar from "components/common/ui/ProgressBar";
 
 export default React.createClass({
+    displayName: "ProviderAllocationGraph",
+
     propTypes: {
         onRequestResources: React.PropTypes.func,
         resourcesUsed: React.PropTypes.object,

--- a/troposphere/static/js/components/modals/instance/launch/components/ResourceGraphs.jsx
+++ b/troposphere/static/js/components/modals/instance/launch/components/ResourceGraphs.jsx
@@ -3,6 +3,8 @@ import Backbone from "backbone";
 import ProgressBar from "components/common/ui/ProgressBar";
 
 export default React.createClass({
+    displayName: "ResourceGraphs",
+
     propTypes: {
         onRequestResources: React.PropTypes.func,
         resourcesUsed: React.PropTypes.object,

--- a/troposphere/static/js/components/modals/instance/launch/components/ScriptTags.jsx
+++ b/troposphere/static/js/components/modals/instance/launch/components/ScriptTags.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 export default React.createClass({
+    displayName: "ScriptTags",
 
     onRemove: function(item) {
         this.props.onRemove(item)

--- a/troposphere/static/js/components/modals/instance/launch/steps/AdvancedLaunchStep.jsx
+++ b/troposphere/static/js/components/modals/instance/launch/steps/AdvancedLaunchStep.jsx
@@ -3,6 +3,7 @@ import BootScriptOption from "../components/BootScriptOption";
 import AdvancedOptionsFooter from "../components/AdvancedOptionsFooter";
 
 export default React.createClass({
+    displayName: "AdvancedLaunchStep",
 
     getInitialState: function() {
         return {

--- a/troposphere/static/js/components/modals/instance/launch/steps/BasicLaunchStep.jsx
+++ b/troposphere/static/js/components/modals/instance/launch/steps/BasicLaunchStep.jsx
@@ -6,6 +6,8 @@ import ResourcesForm from "../components/ResourcesForm";
 import InstanceLaunchFooter from "../components/InstanceLaunchFooter";
 
 export default React.createClass({
+    displayName: "BasicLaunchStep",
+
     render: function() {
         let defaults = {
             advancedIsDisabled: false

--- a/troposphere/static/js/components/modals/migrate_resources/GroupProjectSelection.jsx
+++ b/troposphere/static/js/components/modals/migrate_resources/GroupProjectSelection.jsx
@@ -58,6 +58,7 @@ export default React.createClass({
         return state;
     },
 
+    /* eslint-disable react/no-is-mounted */
     updateState: function() {
         // TODO / FIXME: this guard using `isMounted` needs
         // to be evaluated and removed
@@ -65,6 +66,7 @@ export default React.createClass({
         // https://facebook.github.io/react/blog/2015/12/16/ismounted-antipattern.html
         if (this.isMounted()) this.setState(this.getState());
     },
+    /* eslint-enable react/no-is-mounted */
 
     componentDidMount: function() {
         stores.GroupStore.addChangeListener(this.updateState);

--- a/troposphere/static/js/components/modals/project/ProjectMoveResourceModal.jsx
+++ b/troposphere/static/js/components/modals/project/ProjectMoveResourceModal.jsx
@@ -53,9 +53,11 @@ export default React.createClass({
         return getState(this.props.currentProject, this.state || {});
     },
 
+    /* eslint-disable react/no-is-mounted */
     updateState: function() {
         if (this.isMounted()) this.setState(getState(this.props.currentProject, this.state || {}));
     },
+    /* eslint-enable react/no-is-mounted */
 
     componentDidMount: function() {
         stores.ProjectStore.addChangeListener(this.updateState);

--- a/troposphere/static/js/components/modals/project/ProjectReportResourceModal.jsx
+++ b/troposphere/static/js/components/modals/project/ProjectReportResourceModal.jsx
@@ -33,9 +33,11 @@ export default React.createClass({
         return getState();
     },
 
+    /* eslint-disable react/no-is-mounted */
     updateState: function() {
         if (this.isMounted()) this.setState(getState());
     },
+    /* eslint-enable react/no-is-mounted */
 
     //
     // Internal Modal Callbacks

--- a/troposphere/static/js/components/modals/skeleton.jsx
+++ b/troposphere/static/js/components/modals/skeleton.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import BootstrapModalMixin from "components/mixins/BootstrapModalMixin";
 
 export default React.createClass({
+    displayName: "skeleton",
 
     mixins: [BootstrapModalMixin],
 

--- a/troposphere/static/js/components/modals/tag/TagCreateModal.jsx
+++ b/troposphere/static/js/components/modals/tag/TagCreateModal.jsx
@@ -30,11 +30,13 @@ export default React.createClass({
         stores.TagStore.removeChangeListener(this.updateState);
     },
 
+    /* eslint-disable react/no-is-mounted */
     updateState: function() {
         if (this.isMounted()) {
             this.forceUpdate();
         }
     },
+    /* eslint-enable react/no-is-mounted */
 
     onCancel: function() {
         this.hide();

--- a/troposphere/static/js/components/modals/volume/VolumeAttachModal.jsx
+++ b/troposphere/static/js/components/modals/volume/VolumeAttachModal.jsx
@@ -89,9 +89,11 @@ export default React.createClass({
         return this.getState();
     },
 
+    /* eslint-disable react/no-is-mounted */
     updateState: function() {
         if (this.isMounted()) this.setState(this.getState());
     },
+    /* eslint-enable react/no-is-mounted */
 
     componentDidMount: function() {
         stores.InstanceStore.addChangeListener(this.updateState);

--- a/troposphere/static/js/components/modals/volume/VolumeCreateModal.jsx
+++ b/troposphere/static/js/components/modals/volume/VolumeCreateModal.jsx
@@ -66,9 +66,11 @@ export default React.createClass({
         };
     },
 
+    /* eslint-disable react/no-is-mounted */
     updateState: function() {
         if (this.isMounted()) this.setState(this.getState());
     },
+    /* eslint-enable react/no-is-mounted */
 
     componentDidMount: function() {
         stores.ProviderStore.addChangeListener(this.updateState);

--- a/troposphere/static/js/components/modals/volume/VolumeCreateModal.jsx
+++ b/troposphere/static/js/components/modals/volume/VolumeCreateModal.jsx
@@ -324,7 +324,7 @@ export default React.createClass({
                         {this.renderBody()}
                     </div>
                     <div className="modal-footer">
-                        <RaisedButton 
+                        <RaisedButton
                             style={{ marginRight: "10px" }}
                             onTouchTap={this.cancel}
                             label="Cancel"

--- a/troposphere/static/js/components/projects/ProjectListPage.jsx
+++ b/troposphere/static/js/components/projects/ProjectListPage.jsx
@@ -20,9 +20,11 @@ export default React.createClass({
         return getProjectState();
     },
 
+    /* eslint-disable react/no-is-mounted */
     updateImages: function() {
         if (this.isMounted()) this.setState(getProjectState());
     },
+    /* eslint-enable react/no-is-mounted */
 
     componentDidMount: function() {
         stores.ProjectStore.addChangeListener(this.updateImages);

--- a/troposphere/static/js/components/projects/detail/details/HtmlTextAreaField.jsx
+++ b/troposphere/static/js/components/projects/detail/details/HtmlTextAreaField.jsx
@@ -43,15 +43,19 @@ export default React.createClass({
 
             if (this.props.canEditTitle && this.state.isEditing) {
                 titleContent = (
-                    <EditableTextAreaField text={this.state.title} onDoneEditing={this.onDoneEditing} />
+                    <EditableTextAreaField text={this.state.title}
+                                           onDoneEditing={this.onDoneEditing} />
                 );
             } else {
+                /* eslint-disable react/no-danger */
                 titleContent = (
                     <div onClick={this.onEnterEditMode}>
-                        <span className="html-wrapper" dangerouslySetInnerHTML={{ __html: textHtml }} />
+                        <span className="html-wrapper"
+                              dangerouslySetInnerHTML={{ __html: textHtml }} />
                         <i className="glyphicon glyphicon-pencil"></i>
                     </div>
                 );
+                /* eslint-enable react/no-danger */
             }
         } else {
             titleContent = null;

--- a/troposphere/static/js/components/projects/detail/details/ViewDetails.jsx
+++ b/troposphere/static/js/components/projects/detail/details/ViewDetails.jsx
@@ -48,12 +48,14 @@ const ViewDetails = React.createClass({
             description = project.get("description"),
             descriptionHtml = converter.makeHtml(description);
 
+        /* eslint-disable react/no-danger */
         return (
         <div className="project-info-segment row">
             <h4 className="t-body-2 col-md-3">Description</h4>
             <div className="col-md-9" dangerouslySetInnerHTML={{ __html: descriptionHtml }} />
         </div>
-        )
+        );
+        /* eslint-enable react/no-danger */
     },
 
     renderUsersText: function(group_users) {

--- a/troposphere/static/js/components/projects/detail/resources/RefreshButton.jsx
+++ b/troposphere/static/js/components/projects/detail/resources/RefreshButton.jsx
@@ -81,7 +81,7 @@ export default React.createClass({
             className += " refreshing";
 
         return (
-        <RaisedButton 
+        <RaisedButton
             onTouchTap={this.handleRefresh}
             disabled={this.state.isRefreshing}
         >

--- a/troposphere/static/js/components/projects/detail/resources/RefreshButton.jsx
+++ b/troposphere/static/js/components/projects/detail/resources/RefreshButton.jsx
@@ -49,9 +49,13 @@ export default React.createClass({
             isRefreshing: true
         });
         setTimeout(function() {
-            if (this.isMounted()) this.setState({
+            /* eslint-disable react/no-is-mounted */
+            if (this.isMounted()) {
+                this.setState({
                     isRefreshing: false
                 });
+            }
+            /* eslint-enable react/no-is-mounted */
         }.bind(this), refreshTime * 1000);
 
         // now actually poll the instances and volumes

--- a/troposphere/static/js/components/projects/detail/resources/tableData/link/Name.jsx
+++ b/troposphere/static/js/components/projects/detail/resources/tableData/link/Name.jsx
@@ -4,6 +4,7 @@ import { Link } from "react-router";
 
 
 export default React.createClass({
+    displayName: "Name",
 
     contextTypes: {
         projectId: React.PropTypes.number

--- a/troposphere/static/js/components/projects/detail/resources/tableData/volume/Name.jsx
+++ b/troposphere/static/js/components/projects/detail/resources/tableData/volume/Name.jsx
@@ -3,6 +3,7 @@ import Backbone from "backbone";
 import { Link } from "react-router";
 
 export default React.createClass({
+    displayName: "Name",
 
     contextTypes: {
         projectId: React.PropTypes.number

--- a/troposphere/static/js/components/providers/ProviderListSection.jsx
+++ b/troposphere/static/js/components/providers/ProviderListSection.jsx
@@ -15,9 +15,11 @@ export default React.createClass({
         return this.getState();
     },
 
+    /* eslint-disable react/no-is-mounted */
     updateState: function() {
         if (this.isMounted()) this.setState(this.getState());
     },
+    /* eslint-enable react/no-is-mounted */
 
     componentDidMount: function() {
         stores.ProviderStore.addChangeListener(this.updateState);

--- a/troposphere/static/js/components/settings/SettingsPage.jsx
+++ b/troposphere/static/js/components/settings/SettingsPage.jsx
@@ -20,9 +20,11 @@ export default React.createClass({
         return getState();
     },
 
+    /* eslint-disable react/no-is-mounted */
     updateState: function() {
         if (this.isMounted()) this.setState(getState());
     },
+    /* eslint-enable react/no-is-mounted */
 
     componentDidMount: function() {
         stores.ProfileStore.addChangeListener(this.updateState);
@@ -89,4 +91,3 @@ export default React.createClass({
         );
     }
 });
-


### PR DESCRIPTION
## Toward a React _recommended_ lint

Depends on (built on top of) #654.

This would bring the project closer to a "react" _recommended_ linting of the source. The branch assumes that we are ignoring the ["react/prop-types"](https://github.com/yannickcr/eslint-plugin-react/blob/HEAD/docs/rules/prop-types.md) rule and focusing on the remaining violations. 

Along with moving past missing prop-types (e.g. ignoring for "now"), we have allowing the current violations related to "isMounted" and "dangerouslySetInnerHtml". The rationale is that new code would be subjected to the rules, but existing usage would be tolerated until the codebase can be evaluated & improved.

This work would still have two categories of violations. This work is captured in a central branch so that other teammates can make contributions to resolve the remaining 7 error occurrences.

Existing violation categories:
- [react/no-did-mount-set-state](https://github.com/yannickcr/eslint-plugin-react/blob/HEAD/docs/rules/no-did-mount-set-state.md)
- [react/no-direct-mutation-state](https://github.com/yannickcr/eslint-plugin-react/blob/HEAD/docs/rules/no-direct-mutation-state.md)

In other to work on this branch, you need to apply the following diff to `.eslintrc`:

```diff
diff --git a/.eslintrc b/.eslintrc
index fe84831..c1d9a21 100644
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,7 +7,8 @@
     //     "plugin:react/recommended",
     // ],
     "extends": [
-        "eslint:recommended",
+        "plugin:react/recommended",
+        "eslint:recommended"
     ],
 
     "ecmaFeatures": {
@@ -39,6 +40,7 @@
             }
         ],
         "react/jsx-uses-react": "error",
-        "react/jsx-uses-vars": "error"
+        "react/jsx-uses-vars": "error",
+        "react/prop-types": "off"
     }
 }
```

Example output of the remaining errors can be seen in the "details" section. 

<details>

```
# npm run lint 

> troposphere@0.19.0 lint /opt/dev/troposphere
> eslint -c .eslintrc --ext .jsx,.js --no-eslintrc troposphere/static/js


/opt/dev/troposphere/troposphere/static/js/components/common/AUCalculator.jsx
  46:9  error  Do not use setState in componentDidMount  react/no-did-mount-set-state

/opt/dev/troposphere/troposphere/static/js/components/common/ui/CopyButton.jsx
  109:13  error  Do not use setState in componentDidMount  react/no-did-mount-set-state
  114:13  error  Do not use setState in componentDidMount  react/no-did-mount-set-state

/opt/dev/troposphere/troposphere/static/js/components/images/detail/stats/ImageStatsView.jsx
  120:9  error  Do not use setState in componentDidMount  react/no-did-mount-set-state

/opt/dev/troposphere/troposphere/static/js/components/modals/instance/launch/steps/SizeSelectStep.jsx
  301:9  error  Do not mutate state directly. Use setState()  react/no-direct-mutation-state

/opt/dev/troposphere/troposphere/static/js/components/modals/project/ProjectAddImageModal.jsx
  196:13  error  Do not mutate state directly. Use setState()  react/no-direct-mutation-state

/opt/dev/troposphere/troposphere/static/js/components/projects/resources/instance/details/sections/metrics/InstanceMetrics.jsx
  65:9  error  Do not use setState in componentDidMount  react/no-did-mount-set-state

✖ 7 problems (7 errors, 0 warnings)
```

</details>

## Checklist before merging Pull Requests
- [ ] ~New test(s) included to reproduce the bug/verify the feature~
- [ ] ~Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Reviewed and approved by at least one other contributor.
