### PR TITLE
Problem: Identity dropdown appears when Project Sharing disabled

### DIFF
--- a/troposphere/static/js/components/modals/instance/launch/components/ResourcesForm.jsx
+++ b/troposphere/static/js/components/modals/instance/launch/components/ResourcesForm.jsx
@@ -135,13 +135,10 @@ const ResourcesForm = React.createClass({
         </label>
         );
     },
-    render: function() {
-        let { identity, identityList, onIdentityChange, providerSize, providerSizeList, onSizeChange, } = this.props;
+    renderIdentity() {
+        let { identity, identityList, onIdentityChange } = this.props;
+
         return (
-        <form>
-            {globals.USE_ALLOCATION_SOURCES
-             ? this.renderAllocationSourceMenu()
-             : null}
             <div className="form-group">
                 {this.renderIdentityLabel()}
                 <SelectMenu id="identity"
@@ -150,6 +147,17 @@ const ResourcesForm = React.createClass({
                             list={ identityList }
                             onSelect={ onIdentityChange } />
             </div>
+        );
+    },
+    render: function() {
+        let { providerSize, providerSizeList, onSizeChange } = this.props;
+
+        return (
+        <form>
+            {globals.USE_ALLOCATION_SOURCES
+             ? this.renderAllocationSourceMenu()
+             : null}
+            {featureFlags.hasProjectSharing() ? this.renderIdentity() : null}
             <div className="form-group">
                 <label htmlFor="instanceSize">
                     Instance Size


### PR DESCRIPTION
## Description

This uses `featureFlags.hasProjectSharing()` to determine if the "form-group" for identity needs to be included in the <ResourcesForm/>.

We have merged Project Sharing (aka User/Group Mapping) into the mainline to avoid "drift". We know this feature will take multiple releases before it can be enabled within a production deployment.

Our intend is to make Project Sharing something that can be "toggled" on, or enabled - then development can enhance the feature without it falling behind the master branch (e.g. trunk). This concept has been discussed in a way places [0,1] (usually ThoughtWorks folks [2])

This work is part of what needs to be fixed in master before a release branch for the A-A (2017) can be cut.

[0] https://trunkbaseddevelopment.com/
[1] https://www.youtube.com/watch?v=lqRQYEHAtpk
[2] like [Neal Ford](http://www.se-radio.net/2017/04/se-radio-episode-287-success-skills-for-architects-with-neil-ford/), for example

<details>

## 💥 
<img width="720" alt="pr-662-broke" src="https://user-images.githubusercontent.com/5923/28395066-346886a4-6ca6-11e7-8cf0-3e1aee48a6ee.png">

## Fixed

<img width="720" alt="pr-662-fixed" src="https://user-images.githubusercontent.com/5923/28395068-3be9ed0a-6ca6-11e7-8da1-9acf6e361800.png">

</details>

## Checklist before merging Pull Requests
- [ ] ~New test(s) included to reproduce the bug/verify the feature~
- [ ] ~Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [x] Reviewed and approved by at least one other contributor.
- [ ] ~New variables supported in Clank~
- [ ] ~New variables committed to secrets repos~
