### PR TITLE
Setup webpack for remote ssl

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ location /assets {
 
 Finally start the dev server:
 ```bash
-npm run serve -- --cert /path/to/cert --key /path/to/key
+npm run serve -- --env.host=server.example.com --env.port=8080 --env.https --env.sslCert=/path/to/cert --env.sslKey=/path/to/key
 ```
 
 ### Linting


### PR DESCRIPTION
## Description
This PR modifies the webpack config to support developing on a remote server with ssl support.

The default command to run the webpack server is `npm run serve`, which boots up the webpack dev server on `http://localhost:8080`. This works fine when developing on a laptop via localhost, but doesn't support the development flow of operating on a remote machine, such as `https://server.example.org`.

This PR modifies the webpack config to support overriding the variables necessary to support the remote ssl flow.

Instead of running `npm run serve`, you can now do this:

```
npm run serve --
  --env.host=server.example.org
  --env.port=8080
  --env.https
  --env.sslKey=/path/to/ssl/server.example.org.key 
  --env.sslCert=/path/to/ssl/server.example.org.crt
```

This will boot the webpack development server `http://0.0.0.0:8080` (within the VM) and expose it publicly as `https://server.example.org:8080` with the proper SSL certificates.

## Checklist before merging Pull Requests
- [x] New tests included **(not applicable)**
- [x] Documentation created/updated (new command added to README)
- [x] Reviewed and approved by at least one other contributor.
- [x] New variables supported in Clank **(not applicable)**
- [x] New variables committed to secrets repos **(not applicable)**
