### PR TITLE
Problem: Dev environments show unstyled "Loading Atmosphere"

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,19 @@ Finally start the dev server:
 npm run serve -- --host server.example.com --port 8080 --https  --cert /path/to/cert --key /path/to/key
 ```
 
+If you would like to enable CSS hot reloading, prefix the npm command like so:
+```bash
+CSS_IN_JS=true npm run serve ...
+```
+By default we extract CSS from the larger bundle into a separate asset that is
+parsed/loaded before any js, this ensures that the content of our html will be
+styled the first time it is shown. However, CSS hot reloading only works if
+the CSS is shipped in the JS. The caveat is that html content is shipped
+without initial styling.
+
+**Note:** `CSS_IN_JS` is completely ignored in a production environment.
+
+
 ### Linting
 
 See `LINT.md`

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,7 +15,7 @@ var path = require('path');
 var webpack = require('webpack');
 var ProgressBarPlugin = require('progress-bar-webpack-plugin');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
-var { getIfUtils, removeEmpty } = require('webpack-config-utils');
+var { getIfUtils, removeEmpty, propIf } = require('webpack-config-utils');
 var CopyWebpackPlugin = require('copy-webpack-plugin');
 var BundleTracker = require('webpack-bundle-tracker');
 var fs = require('fs');
@@ -25,6 +25,15 @@ var themeImagesPath = require('./themeImagesPath');
 
 module.exports = function(ENV) {
   var { ifProduction } = getIfUtils(ENV);
+
+  // Preface the webpack-dev-server command with CSS_IN_JS=true for CSS hot
+  // reloading.
+  //
+  // By default we extract CSS from the larger bundle into a separate asset
+  // that is parsed/loaded before any js, this ensures that the content of our
+  // html will be styled the first time it is shown. However, CSS hot
+  // reloading only works if the CSS is shipped in the JS.
+  var extractCSS = ifProduction(true, !process.env.CSS_IN_JS);
 
   var PATHS = {
     output: path.join(__dirname, "/troposphere/assets/bundles"),
@@ -98,7 +107,7 @@ module.exports = function(ENV) {
         },
         {
           test: /\.css/,
-          use: ifProduction(ExtractTextPlugin.extract({
+          use: propIf(extractCSS, ExtractTextPlugin.extract({
             fallback: 'style-loader',
             use: [
               {
@@ -122,7 +131,7 @@ module.exports = function(ENV) {
         },
         {
           test: /\.less$/,
-          use: ifProduction(ExtractTextPlugin.extract({
+          use: propIf(extractCSS, ExtractTextPlugin.extract({
             fallback: 'style-loader',
             use: [
               {
@@ -148,7 +157,7 @@ module.exports = function(ENV) {
         },
         {
           test: /\.scss$/,
-          use: ifProduction(ExtractTextPlugin.extract({
+          use: propIf(extractCSS, ExtractTextPlugin.extract({
             fallback: 'style-loader',
             use: [
               {


### PR DESCRIPTION
## Description

**Problem:**
Dev environments show unstyled "Loading Atmosphere"
**Solution:**
Load css before js like in prod making hot reloading css an opt-in feature

### Background
CSS hot reloading requires the css to be shipped in the js bundle. That means
that our html will show unstyled content, until the js bundle is loaded. This
results in a white page with black text:

    Loading Atmosphere

This will never happen in production, because we ship the css in a link tag
in the head of the document, forcing the css to be applied before the content.

In an effort to bring the developer experience closer to production, we are
making CSS hot reloading opt-in.

In order to enable it, prefix your npm run serve command like so:
```bash
CSS_IN_JS=true npm run serve ...
```


## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [x] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature
- [x] Reviewed and approved by at least one other contributor.
- [ ] New variables supported in Clank
- [ ] New variables committed to secrets repos
