### PR TITLE
Problem: Not enough information is visible to users/staff when a VM reaches error/deploy_error/user_deploy_error

### DIFF
--- a/troposphere/static/js/components/admin/ImageRequest.jsx
+++ b/troposphere/static/js/components/admin/ImageRequest.jsx
@@ -1,7 +1,5 @@
 import React from "react";
-
-import { ShowMoreEllipsis } from "cyverse-ui";
-import { marg } from "cyverse-ui/styles";
+import CollapsibleOutput from "components/common/ui/CollapsibleOutput";
 
 import ImageRequestActions from "actions/ImageRequestActions";
 
@@ -18,92 +16,6 @@ const buildInstanceSizeLabel = (size) => {
         return `${name}(${alias}) : ${cpu} CPU, ${mem} MB Memory, ${disk} Disk`;
     }
 };
-
-/**
- * A consistently styled `<code/>` element
- *
- * This will likely be redefined within CyVerse-UI. When that
- * happened, this can be replaced w/ the official version.
- */
-const Code = (props) => {
-    // FIXME: don't hardcode these:
-    // - `style.color`
-    // -color in `style.borderLeft`
-    let text = props.text || "",
-        style = {
-            display: "block",
-            whiteSpace: "pre-wrap",
-            padding: "20px",
-            color: "rgba(0, 0, 0, 0.54)",
-            fontSize: "14px",
-            borderLeft: `solid rgba(0, 0, 0, 0.54) 5px`,
-            background: "rgba(0,0,0,0.03)",
-            ...marg(props)
-        };
-
-    return (
-        <pre style={style}>
-            {text}
-        </pre>
-    );
-}
-
-/**
- * Allow a region to be collapsed and expanded to avoid
- * over-powering the containing context.
- *
- * This is a candidate for extract into a common Troposphere component,
- * or for wider review and inclusion in CyVerse-UI. For now, it begins
- * life as a "hopefully" useful component within Admin.
- */
-const CollapsibleOutput = React.createClass({
-    propTypes: {
-        output: React.PropTypes.string
-    },
-
-    getInitialState() {
-        return {
-            open: false
-        };
-    },
-
-    onEllipsisClick() {
-        this.setState({
-            open: !this.state.open
-        });
-    },
-
-    render() {
-        let { open } = this.state,
-            { output } = this.props,
-            content = null,
-            partial = output
-                    ? output.substring(0, 32) : '***';
-
-        if (!open) {
-            content = (
-                <span onClick={this.onEllipsisClick}>
-                    {` ${partial} `}
-                    <ShowMoreEllipsis  />
-                </span>
-            );
-        } else {
-            content = (
-                <span onClick={this.onEllipsisClick}>
-                    <ShowMoreEllipsis  />
-                    <Code text={output} />
-                </span>
-            );
-        }
-
-        return (
-            <div style={{display: "inline-block"}}>
-                    {content}
-            </div>
-        );
-    }
-});
-
 
 const ImageRequest = React.createClass({
     displayName: "ImageRequest",

--- a/troposphere/static/js/components/common/InstanceHistorySection.jsx
+++ b/troposphere/static/js/components/common/InstanceHistorySection.jsx
@@ -3,7 +3,7 @@ import Backbone from "backbone";
 import stores from "stores";
 import context from "context";
 import moment from "moment";
-
+import CollapsibleOutput from "components/common/ui/CollapsibleOutput";
 
 var InstanceHistorySection = React.createClass({
     displayName: "InstanceHistorySection",
@@ -79,23 +79,21 @@ var InstanceHistorySection = React.createClass({
         if (historyItem.get("end_date") && historyItem.get("end_date").isValid()) {
             formattedEndDate = moment(historyItem.get("end_date")).format("MMMM Do YYYY, h:mm a");
         }
-        let formattedExtra = "";
+        let formattedExtra;
         let formattedExtraLines = [];
         let show_traceback = (is_staff_user || context.hasEmulatedSession() );
         if(extra && 'display_error' in extra) {
-            formattedExtra = extra['display_error'];
+            formattedExtra = (<p>{extra['display_error']}</p>);
             if('traceback' in extra && show_traceback) {
-                formattedExtra = formattedExtra + "\\n" + extra['traceback']
-                formattedExtraLines = formattedExtra.split('\\n');
+                let formattedText = extra['display_error'] + "\n" + extra['traceback'];
+                formattedExtra = (<CollapsibleOutput output={formattedText} />);
             }
         }
         return (<tr key={historyItem.cid}>
                     <td>{historyItem.get("status")}</td>
                     <td>{formattedStartDate}</td>
                     <td>{formattedEndDate}</td>
-                    <td>{formattedExtraLines.map(
-                        (strng, idx) => (<p key={idx}>{strng}</p>)) }
-                    </td>
+                    <td>{formattedExtra}</td>
                 </tr>);
     },
     onRefresh() {
@@ -110,10 +108,9 @@ var InstanceHistorySection = React.createClass({
 
     },
     render: function() {
-        var instance = this.props.instance;
         var content;
-
-        if (!this.state.instanceHistory) {
+        let { instanceHistory } = this.state;
+        if (!instanceHistory) {
             if (stores.InstanceHistoryStore.isFetching) {
                 content = (
                     <div className="loading" />
@@ -137,7 +134,7 @@ var InstanceHistorySection = React.createClass({
                         </tr>
                     </thead>
                     <tbody>
-                        {this.state.instanceHistory.map(this.renderHistoryRow) }
+                        {instanceHistory.map(this.renderHistoryRow) }
                     </tbody>
                 </table>
             );

--- a/troposphere/static/js/components/common/InstanceHistorySection.jsx
+++ b/troposphere/static/js/components/common/InstanceHistorySection.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import Backbone from "backbone";
 import stores from "stores";
+import context from "context";
 import moment from "moment";
 
 
@@ -15,16 +16,26 @@ var InstanceHistorySection = React.createClass({
         return {
             instanceHistory: stores.InstanceHistoryStore.fetchWhere({
                 "instance": this.props.instance.id
-            })
+            }),
+            refreshing: false
         }
     },
 
     componentDidMount: function() {
         stores.InstanceHistoryStore.addChangeListener(this.onNewData);
+        stores.InstanceStore.addChangeListener(this.onNewData);
+        stores.InstanceHistoryStore.addChangeListener(this.requestListener);
     },
 
     componentWillUnmount: function() {
         stores.InstanceHistoryStore.removeChangeListener(this.onNewData);
+        stores.InstanceStore.removeChangeListener(this.onNewData);
+        stores.InstanceHistoryStore.removeChangeListener(this.requestListener);
+    },
+    requestListener() {
+        this.setState({
+            refreshing: false
+        });
     },
 
     onNewData: function() {
@@ -35,19 +46,73 @@ var InstanceHistorySection = React.createClass({
         });
     },
 
+    style() {
+        return {
+            refreshIcon: {
+                float: "right",
+                color: "lightgrey"
+            },
+        }
+    },
+
+    renderRefreshButton() {
+        let { refreshing } = this.state;
+        let { refreshIcon } = this.style();
+        let controlsClass = "glyphicon glyphicon-refresh";
+
+        if (refreshing) {
+            controlsClass += " refreshing"
+            refreshIcon.color = "inherit";
+        }
+
+        return (
+        <span className={controlsClass} style={refreshIcon} onClick={this.onRefresh} />
+        );
+    },
+
+    renderHistoryRow: function(historyItem) {
+        let profile = stores.ProfileStore.get();
+        let is_staff_user = (profile) ? profile.get("is_staff") : false;
+        let extra = historyItem.get('extra'),
+            formattedStartDate = moment(historyItem.get("start_date")).format("MMMM Do YYYY, h:mm a"),
+            formattedEndDate = "Present";
+        if (historyItem.get("end_date") && historyItem.get("end_date").isValid()) {
+            formattedEndDate = moment(historyItem.get("end_date")).format("MMMM Do YYYY, h:mm a");
+        }
+        let formattedExtra = "";
+        let formattedExtraLines = [];
+        let show_traceback = (is_staff_user || context.hasEmulatedSession() );
+        if(extra && 'display_error' in extra) {
+            formattedExtra = extra['display_error'];
+            if('traceback' in extra && show_traceback) {
+                formattedExtra = formattedExtra + "\\n" + extra['traceback']
+                formattedExtraLines = formattedExtra.split('\\n');
+            }
+        }
+        return (<tr key={historyItem.cid}>
+                    <td>{historyItem.get("status")}</td>
+                    <td>{formattedStartDate}</td>
+                    <td>{formattedEndDate}</td>
+                    <td>{formattedExtraLines.map(
+                        (strng, idx) => (<p key={idx}>{strng}</p>)) }
+                    </td>
+                </tr>);
+    },
+    onRefresh() {
+        stores.InstanceHistoryStore.clearCache();
+        let instanceHistory = stores.InstanceHistoryStore.fetchWhere({
+            "instance": this.props.instance.id
+        })
+        this.setState({
+            refreshing: true,
+            instanceHistory
+        });
+
+    },
     render: function() {
         var instance = this.props.instance;
-        var content,
-            items,
-            deletedInfo;
+        var content;
 
-        if (instance.get("end_date")) {
-            deletedInfo = (
-                <lh>
-                    <strong>{"Deleted on " + moment(instance.get("end_date")).format("MMMM Do YYYY, h:mm a")}</strong>
-                </lh>
-            );
-        }
         if (!this.state.instanceHistory) {
             if (stores.InstanceHistoryStore.isFetching) {
                 content = (
@@ -61,30 +126,25 @@ var InstanceHistorySection = React.createClass({
                 );
             }
         } else {
-            items = this.state.instanceHistory.map(function(historyItem) {
-                let formattedAUTotal = historyItem.get("total_hours"),
-                    formattedStartDate = moment(historyItem.get("start_date")).format("MMMM Do YYYY, h:mm a"),
-                    formattedEndDate = "Present";
-                if (historyItem.get("end_date") && historyItem.get("end_date").isValid()) {
-                    formattedEndDate = moment(historyItem.get("end_date")).format("MMMM Do YYYY, h:mm a");
-                }
-                return (<div key={historyItem.cid}>
-                            {historyItem.get("status")}:
-                            {formattedStartDate} -
-                            {formattedEndDate} -
-                            {formattedAUTotal}
-                        </div>);
-            });
             content = (
-                <ul>
-                    {deletedInfo}
-                    {items}
-                </ul>
+                <table className="clearfix table" style={{ tableLayout: "fixed" }}>
+                    <thead>
+                        <tr>
+                            <th style={{ width: "100px"}}>Status</th>
+                            <th>Start Date</th>
+                            <th>End Date</th>
+                            <th>Message</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {this.state.instanceHistory.map(this.renderHistoryRow) }
+                    </tbody>
+                </table>
             );
         }
         return (
         <div className="resource-details-section section">
-            <h4 className="t-title">Instance Status History</h4>
+            <h4 className="t-headline">Instance Status History {this.renderRefreshButton()}</h4>
             {content}
         </div>
         );

--- a/troposphere/static/js/components/common/InstanceHistorySection.jsx
+++ b/troposphere/static/js/components/common/InstanceHistorySection.jsx
@@ -14,7 +14,6 @@ const HistoryRow = React.createClass({
 
     renderFormattedExtra(isStaffUser, extra) {
         let formattedExtra = "";
-        let formattedExtraLines = [];
         let show_traceback = (isStaffUser || context.hasEmulatedSession());
 
         if(extra && 'display_error' in extra) {

--- a/troposphere/static/js/components/common/image_request/ImageMembership.jsx
+++ b/troposphere/static/js/components/common/image_request/ImageMembership.jsx
@@ -17,7 +17,6 @@ export default React.createClass({
         });
     },
     removeMemberFromList: function(user) {
-        console.log("Remove", user);
         var rem_list = this.props.membership_list;
         rem_list.remove(user);
         this.setState({

--- a/troposphere/static/js/components/common/ui/CollapsibleOutput.jsx
+++ b/troposphere/static/js/components/common/ui/CollapsibleOutput.jsx
@@ -1,0 +1,92 @@
+import { ShowMoreEllipsis } from "cyverse-ui";
+import { marg } from "cyverse-ui/styles";
+import React from "react";
+
+/**
+ * A consistently styled `<code/>` element
+ *
+ * This will likely be redefined within CyVerse-UI. When that
+ * happened, this can be replaced w/ the official version.
+ */
+const Code = (props) => {
+    // FIXME: don't hardcode these:
+    // - `style.color`
+    // -color in `style.borderLeft`
+    let text = props.text || "",
+        style = {
+            display: "block",
+            whiteSpace: "pre-wrap",
+            padding: "20px",
+            color: "rgba(0, 0, 0, 0.54)",
+            fontSize: "14px",
+            borderLeft: `solid rgba(0, 0, 0, 0.54) 5px`,
+            background: "rgba(0,0,0,0.03)",
+            ...marg(props)
+        };
+
+    return (
+        <pre style={style}>
+            {text}
+        </pre>
+    );
+}
+
+/**
+ * Allow a region to be collapsed and expanded to avoid
+ * over-powering the containing context.
+ *
+ * This is a candidate for extract into a common Troposphere component,
+ * or for wider review and inclusion in CyVerse-UI. For now, it begins
+ * life as a "hopefully" useful component within Admin.
+ */
+const CollapsibleOutput = React.createClass({
+    propTypes: {
+        output: React.PropTypes.string
+    },
+
+    getInitialState() {
+        return {
+            open: false
+        };
+    },
+
+    onEllipsisClick() {
+        this.setState({
+            open: !this.state.open
+        });
+    },
+
+    render() {
+        let { open } = this.state,
+            { output } = this.props,
+            content = null,
+            partial = output
+                    ? output.substring(0, 32) : '***';
+
+        if (!open) {
+            content = (
+                <span onClick={this.onEllipsisClick}>
+                    {` ${partial} `}
+                    <ShowMoreEllipsis  />
+                </span>
+            );
+        } else {
+            content = (
+                <span onClick={this.onEllipsisClick}>
+                    <ShowMoreEllipsis  />
+                    <Code text={output} />
+                </span>
+            );
+        }
+
+        return (
+            <div style={{display: "inline-block"}}>
+                    {content}
+            </div>
+        );
+    }
+});
+
+
+
+export default CollapsibleOutput;

--- a/troposphere/static/js/context.js
+++ b/troposphere/static/js/context.js
@@ -8,6 +8,9 @@ export default {
     getMaintenanceNotice: function() {
         return window.maint_notice;
     },
+    hasEmulatedSession: function() {
+        return window.emulator && window.emulator_token;
+    },
     hasLoggedInUser: function() {
         return hasLoggedInUser(this.profile);
     },


### PR DESCRIPTION
Solution: Show fault message (and traceback, if staff)

## Description

- Remove redundancy -- Use a common 'InstanceDetail' component for both 'historical' and 'active-and-in-a-project' instances.

- Create an InstanceStatusHistory table
- Add polish to the table:
- Include a refresh button
- Show additional traceback if staff user is viewing (Even when emulated!)
- Include 'hasEmulatedSession' in context based on template variables.

## Checklist before merging Pull Requests
- [x] [Review and merge Atmosphere companion PR](https://github.com/cyverse/atmosphere/pull/457)
- [x] Reviewed and approved by at least one other contributor.
