### PR TITLE
Problem: component is not handled undefined/null "size"s

### DIFF
--- a/troposphere/static/js/components/dashboard/plots/ProviderSummaryLinePlot.jsx
+++ b/troposphere/static/js/components/dashboard/plots/ProviderSummaryLinePlot.jsx
@@ -3,6 +3,15 @@ import Backbone from "backbone";
 
 import PercentageGraph from "components/common/ui/PercentageGraph";
 
+/**
+ * Cautiously retrieves the attribute by name.
+ */
+const getModelAttr = (model, attrName, defaultValue) => {
+    defaultValue = defaultValue || 0;
+    return model && model["get"] ? model.get(attrName) : defaultValue;
+};
+
+
 export default React.createClass({
     displayName: "ProviderSummaryLinePlot",
 
@@ -103,7 +112,7 @@ export default React.createClass({
 
         var currentCpuCount = instances.reduce(function(memo, instance) {
             var size = sizes.get(instance.get("size").id);
-            return memo + size.get("cpu");
+            return memo + getModelAttr(size, "cpu");
         }.bind(this), 0);
 
         return {
@@ -118,7 +127,7 @@ export default React.createClass({
 
         var currentMemory = instances.reduce(function(memo, instance) {
             var size = sizes.get(instance.get("size").id);
-            return memo + size.get("mem");
+            return memo + getModelAttr(size, "mem");
         }.bind(this), 0);
 
         return {
@@ -132,7 +141,7 @@ export default React.createClass({
         var maxStorage = quota.storage;
 
         var currentStorage = volumes.reduce(function(memo, volume) {
-            return memo + volume.get("size")
+            return memo + getModelAttr(volume, "size");
         }.bind(this), 0);
 
         return {


### PR DESCRIPTION
## Description

When gather usage data for the provider summary line plots, there is the potential for fetches of a size to be either undefined or null. We have seen this occur in production environments, thanks to Sentry. 

So the following code does not handle with `sizes.get(...)` returns a false-y result:
```
        var currentCpuCount = instances.reduce(function(memo, instance) {
            var size = sizes.get(instance.get("size").id);
            return memo + size.get("cpu");
        }.bind(this), 0);
```
Source: [components/dashboard/plots/ProviderSummaryLinePlot.jsx#L104-L107](https://github.com/cyverse/troposphere/blob/2a40117ba91be53e5137aa4640d10c2554b2f40c/troposphere/static/js/components/dashboard/plots/ProviderSummaryLinePlot.jsx#L104-L107)

This pull request introduces a private, utility method that will be retrieve an attribute from a model or return a _default_ value. 

See [ATMO-1757](https://pods.iplantcollaborative.org/jira/browse/ATMO-1757).

## Checklist before merging Pull Requests
- [ ] ~New test(s) included to reproduce the bug/verify the feature~
- [ ] ~Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Reviewed and approved by at least one other contributor.
- [ ] ~New variables supported in Clank~
- [ ] ~New variables committed to secrets repos~
