### PR TITLE
Problem: creating instance size label results in error

### DIFF
--- a/troposphere/static/js/components/admin/ImageRequest.jsx
+++ b/troposphere/static/js/components/admin/ImageRequest.jsx
@@ -8,6 +8,18 @@ import ImageRequestActions from "actions/ImageRequestActions";
 import subscribe from "utilities/subscribe";
 
 /**
+ * Create a string representing an instance's size (aka flavor)
+ */
+const buildInstanceSizeLabel = (size) => {
+    if (!size) {
+        return "(size unavailable)";
+    } else {
+        let { name, alias, cpu, mem, disk } = size;
+        return `${name}(${alias}) : ${cpu} CPU, ${mem} MB Memory, ${disk} Disk`;
+    }
+};
+
+/**
  * A consistently styled `<code/>` element
  *
  * This will likely be redefined within CyVerse-UI. When that
@@ -150,11 +162,7 @@ const ImageRequest = React.createClass({
             new_provider = request.get("new_machine_provider"),
             instance = request.get("instance"),
             size = instance.size,
-            instance_size_str = size.name
-                + "(" + size.alias + ") : "
-                + size.cpu + " CPU, "
-                + size.mem + " MB Memory, "
-                + size.disk + " Disk",
+            instance_size_str = buildInstanceSizeLabel(size),
             instance_mach_str = instance.image.name + " v." + machine.version,
             membership_list,
             access_list,


### PR DESCRIPTION
## Define utility method to safely build size label

This is another "handle undefined & null" still helper, or utility method. I think this ought to be a utility given the complexity of the format for Instance Size(s). I did waffled on whether to destructure the `size` model to remove the repeated `{$size.attr}` without the
string template literal. It might be a waste of defining local variables for something like this, so if desired - those could be inlined.

See also [ATMO-1754](https://pods.iplantcollaborative.org/jira/browse/ATMO-1754)

## Checklist before merging Pull Requests
- ~[ ] New test(s) included to reproduce the bug/verify the feature~
- ~[ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Reviewed and approved by at least one other contributor.
- [ ] ~New variables supported in Clank~
- [ ] ~New variables committed to secrets repos~
