### PR TITLE
Problem: attempted fetch of Image for undefined Instance

### DIFF
--- a/troposphere/static/js/components/projects/resources/instance/details/sections/details/CreatedFrom.jsx
+++ b/troposphere/static/js/components/projects/resources/instance/details/sections/details/CreatedFrom.jsx
@@ -15,8 +15,10 @@ export default React.createClass({
     },
 
     render: function() {
-        var instance = this.props.instance,
-            image = stores.ImageStore.get(instance.get("image").id);
+        let { instance } = this.props,
+            image = instance ?
+                    stores.ImageStore.get(instance.get("image").id)
+                  : null;
 
         if (!image) {
             return (


### PR DESCRIPTION
## Description

Here we want to until look for the image associated with an instance if
that `instance` is provided via `this.props`.

See also ATMO-1759, issue occurred within production; logged by Sentry

## Checklist before merging Pull Requests
- [ ] ~New test(s) included to reproduce the bug/verify the feature~
- [ ] ~Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Reviewed and approved by at least one other contributor.
- [ ] ~New variables supported in Clank~
- [ ] ~New variables committed to secrets repos~
