### PR TITLE
Problem: retrieving help link can cause error

### DIFF
--- a/troposphere/static/js/components/modals/instance/image/steps/ImageInfoStep.jsx
+++ b/troposphere/static/js/components/modals/instance/image/steps/ImageInfoStep.jsx
@@ -9,6 +9,8 @@ import Description from "../components/Description";
 import Tags from "../components/Tags";
 import TagCollection from "collections/TagCollection";
 
+import { captureMessage } from "utilities/capture";
+
 import actions from "actions";
 import stores from "stores";
 
@@ -135,7 +137,16 @@ export default React.createClass({
     },
     renderBody: function(instance) {
         let { helpLink } = this.props,
-            link = helpLink ? helpLink.get("href") : "#";
+            link;
+
+        if (helpLink) {
+            link = helpLink.get("href");
+        } else {
+            link = "#";
+            captureMessage("HelpLink unavailable on render", {
+                component: this.displayName
+            });
+        }
 
         return (
         <div>

--- a/troposphere/static/js/components/modals/instance/image/steps/ImageInfoStep.jsx
+++ b/troposphere/static/js/components/modals/instance/image/steps/ImageInfoStep.jsx
@@ -143,6 +143,7 @@ export default React.createClass({
             link = helpLink.get("href");
         } else {
             link = "#";
+            // NOTE: not truly an exception, just unexpected
             captureMessage("HelpLink unavailable on render", {
                 component: this.displayName
             });

--- a/troposphere/static/js/components/modals/instance/image/steps/ImageInfoStep.jsx
+++ b/troposphere/static/js/components/modals/instance/image/steps/ImageInfoStep.jsx
@@ -134,6 +134,9 @@ export default React.createClass({
         );
     },
     renderBody: function(instance) {
+        let { helpLink } = this.props,
+            link = helpLink ? helpLink.get("href") : "#";
+
         return (
         <div>
             <div className="alert alert-danger">
@@ -141,7 +144,7 @@ export default React.createClass({
             </div>
             <p className="alert alert-info">
                 {"Please read the "}
-                <a href={this.props.helpLink.get("href")} target="_blank">wiki page about requesting an image of your instance</a>
+                <a href={link} target="_blank">wiki page about requesting an image of your instance</a>
                 {" before completing the form below."}
             </p>
             <p>

--- a/troposphere/static/js/components/modals/volume/VolumeReportModal.jsx
+++ b/troposphere/static/js/components/modals/volume/VolumeReportModal.jsx
@@ -113,15 +113,19 @@ export default React.createClass({
     },
 
     renderIntroduction: function(volume) {
+        let { helpLink, troubleshooting } = this.props,
+            linkVolume = helpLink ? helpLink.get("href") : "#",
+            linkTriage = troubleshooting ? troubleshooting.get("href") : "#";
+
         return (
         <p className="alert alert-info">
             <Glyphicon name="info-sign" />
             {" Is the volume "}
             <code>{volume.get("name")}</code>
             {" exhibiting unexpected behavior? First, it may help to read about "}
-            <a href={this.props.helpLink.get("href")}>using volumes</a>
+            <a href={linkVolume}>using volumes</a>
             {" and "}
-            <a href={this.props.troubleshooting.get("href")}>troubleshooting volumes</a>
+            <a href={linkTriage}>troubleshooting volumes</a>
             {"."}
         </p>
         );

--- a/troposphere/static/js/components/modals/volume/VolumeReportModal.jsx
+++ b/troposphere/static/js/components/modals/volume/VolumeReportModal.jsx
@@ -3,7 +3,24 @@ import React from "react";
 import RaisedButton from "material-ui/RaisedButton";
 import BootstrapModalMixin from "components/mixins/BootstrapModalMixin";
 import Glyphicon from "components/common/Glyphicon";
-import { trackAction } from "../../../utilities/userActivity";
+
+import { trackAction } from "utilities/userActivity";
+import { captureMessage } from "utilities/capture";
+
+
+const defaultHelpLink = (link) => {
+    let href;
+
+    if (link) {
+        href = link.get("href");
+    } else {
+        href = "#";
+        captureMessage("HelpLink unavailable on render", {
+            component: "VolumeReportModal"
+        });
+    }
+    return href;
+};
 
 export default React.createClass({
     displayName: "VolumeReportModal",
@@ -114,8 +131,8 @@ export default React.createClass({
 
     renderIntroduction: function(volume) {
         let { helpLink, troubleshooting } = this.props,
-            linkVolume = helpLink ? helpLink.get("href") : "#",
-            linkTriage = troubleshooting ? troubleshooting.get("href") : "#";
+            linkVolume = defaultHelpLink(helpLink),
+            linkTriage = defaultHelpLink(troubleshooting);
 
         return (
         <p className="alert alert-info">

--- a/troposphere/static/js/components/modals/volume/VolumeReportModal.jsx
+++ b/troposphere/static/js/components/modals/volume/VolumeReportModal.jsx
@@ -15,6 +15,7 @@ const defaultHelpLink = (link) => {
         href = link.get("href");
     } else {
         href = "#";
+        // NOTE: not truly an exception, just unexpected
         captureMessage("HelpLink unavailable on render", {
             component: "VolumeReportModal"
         });

--- a/troposphere/static/js/utilities/capture.js
+++ b/troposphere/static/js/utilities/capture.js
@@ -1,10 +1,13 @@
 import Raven from "raven-js";
 
 /**
- * Send message out to logging/context capture service
+ * Send _message_ out to logging/context capture service
  *
  * @param {string} message short description of occurrence
  * @param {object} data any extra context to associate
+ *
+ * This is _not_ capture an exception nor system fault. This
+ * is meant to capture context of a noteworthy occurrence.
  *
  * Additional data can be passed as the second parameter to
  * `captureMessage` and will be merged with any global

--- a/troposphere/static/js/utilities/capture.js
+++ b/troposphere/static/js/utilities/capture.js
@@ -1,0 +1,44 @@
+import Raven from "raven-js";
+
+/**
+ * Send message out to logging/context capture service
+ *
+ * @param {string} message short description of occurrence
+ * @param {object} data any extra context to associate
+ *
+ * Additional data can be passed as the second parameter to
+ * `captureMessage` and will be merged with any global
+ * context set on the raven client.
+ *
+ * There are some 'keyword' properties, like `level`. The
+ * example below is provided in the Sentry docs:
+ * ```
+ *   Raven.captureMessage('Something happened', {
+ *     level: 'info' // one of 'info', 'warning', or 'error'
+ *   });
+ * ```
+ *
+ * Though, you can pass keys in and they will be merged with
+ * the existing context.
+ *
+ * (Note: believe the global context will overwrite data
+ * passed in. You can verify this in the raven-js source,
+ * look for `objectMerge()`)
+ *
+ * ```
+ *   Raven.captureMessage('Something happened', {
+ *     instance: '<uuid>',
+ *     troposphere_context: 'page-view'
+ *   });
+ * ```
+ */
+const captureMessage = (message, data) => {
+    // only call if we have a configuration client available
+    if (Raven && Raven.isSetup()) {
+        Raven.captureMessage(message, {
+            extra: data
+        });
+    }
+}
+
+export { captureMessage };


### PR DESCRIPTION
## Ensure retrieving HREF from model is safe

Here, we mean "safe" in that an attempt to `.get("href")` will not result in an error.

An error relates to the help link missing was observed [0]. In this commit, we favor the "empty" document fragment [1], so this may pop the to the top of the viewport. But, it will not cause an unhandled error.

[0] https://pods.iplantcollaborative.org/jira/browse/ATMO-1752
[1] https://www.w3.org/TR/html5/browsers.html#scroll-to-fragid

Addresses the following internal tickets:
- [ATMO-1752](https://pods.iplantcollaborative.org/jira/browse/ATMO-1752)
- [ATMO-1753](https://pods.iplantcollaborative.org/jira/browse/ATMO-1753)

## Checklist before merging Pull Requests
- [ ] ~New test(s) included to reproduce the bug/verify the feature~
- [ ] ~Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Reviewed and approved by at least one other contributor.
- [ ] ~New variables supported in Clank~
- [ ] ~New variables committed to secrets repos~
