### PR TITLE
Problem: Copy Button appears next to invalid IP Addresses

### DIFF
--- a/troposphere/static/js/components/projects/resources/instance/details/sections/details/IpAddress.jsx
+++ b/troposphere/static/js/components/projects/resources/instance/details/sections/details/IpAddress.jsx
@@ -14,14 +14,15 @@ export default React.createClass({
         var instance = this.props.instance,
             address = instance.get("ip_address");
 
-        if (!address || address.charAt(0) == "0") {
+        let missingAddress = !address || address.charAt(0) == "0";
+        if (missingAddress) {
             address = "N/A";
         }
 
         return (
         <ResourceDetail label="IP Address">
             {address}
-            <CopyButton text={ address }/>
+            {!missingAddress ? <CopyButton text={ address }/> : null}
         </ResourceDetail>
         );
     }


### PR DESCRIPTION
## Description

The helpful "copy" hyperlink button is shown when an Instance is without an IP address. 

This work will only hide `<CopyButton />` when an IP is not applicable (aka invalid). It will show for floating and fixed IP addresses.

<details>

## Before the Pull Request

Here is the interaction that we are addressing:
http://g.recordit.co/rn45LezrcJ.gif

## After

### Detail, Copy "Not" Shown (expected after merge)

<img width="416" alt="after-fix-copy-not-shown-detail" src="https://user-images.githubusercontent.com/5923/28991417-fbed4394-793b-11e7-8f65-57ad9485c236.png">

### Wider Context, Copy "Not" Shown (expected after merge)

<img width="733" alt="after-fix-copy-not-shown" src="https://user-images.githubusercontent.com/5923/28991418-fc0fe3f4-793b-11e7-9592-d9832113279e.png">

### Fixed IP Shown (behavior remains the same)
<img width="589" alt="after-fix-copy-still-shown-for-fixed-ip" src="https://user-images.githubusercontent.com/5923/28991416-fbeb912a-793b-11e7-8c8d-f37ab0f542ff.png">


</details>

## Checklist before merging Pull Requests
- [ ] ~New test(s) included to reproduce the bug/verify the feature~
- [ ] ~Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [x] Reviewed and approved by at least one other contributor.
- [ ] ~New variables supported in Clank~
- [ ] ~New variables committed to secrets repos~
