### PR TITLE
Make SelectMenu more lenient

### DIFF
--- a/troposphere/static/js/components/common/ui/SelectMenu.jsx
+++ b/troposphere/static/js/components/common/ui/SelectMenu.jsx
@@ -140,8 +140,10 @@ export default React.createClass({
 
             index = list.indexOf(current);
             if (current != null && index == -1) {
+                let missingName = this.props.optionName(current);
                 console.warn(
-                    "SelectMenu: The element to display ("+current+") doesn't exist in the list of available elements"
+                    `SelectMenu: The element to display: "${missingName}" doesn't`,
+                    "exist in the list of available elements"
                 );
             }
         }

--- a/troposphere/static/js/components/common/ui/SelectMenu.jsx
+++ b/troposphere/static/js/components/common/ui/SelectMenu.jsx
@@ -32,7 +32,7 @@ export default React.createClass({
         list: React.PropTypes.oneOfType([
             React.PropTypes.instanceOf(Backbone.Collection),
             React.PropTypes.array
-        ]).isRequired,
+        ]),
         disabled: React.PropTypes.bool,
         current: React.PropTypes.object,
         placeholder: React.PropTypes.string,
@@ -61,7 +61,9 @@ export default React.createClass({
         if (list instanceof Backbone.Collection) {
             list = list.toArray();
         } else if (list) {
-            list = list.slice()
+            list = list.slice();
+        } else {
+            list = [];
         }
 
         return {


### PR DESCRIPTION
## Description
**Problem:**
The instance launch wizard was rendering a select menu with an invalid property.

**Solution:**
Make the select menu more lenient.

**Explanation:**
Prior version of SelectMenu required a list prop. However, the instance wizard–which renders several –renders these views w/o any guarantee that lists exist yet (it doesn't wait for imageVersions to be loaded for example).

## Checklist before merging Pull Requests
- [ ] ~New test(s) included to reproduce the bug/verify the feature~
- [ ] ~Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [x] Reviewed and approved by at least one other contributor.
- [ ] ~New variables supported in Clank~
- [ ] ~New variables committed to secrets repos~
