### PR TITLE
Provide noop onChange handler, when not supplied by user

### DIFF
--- a/troposphere/static/js/components/common/EditableInputField.jsx
+++ b/troposphere/static/js/components/common/EditableInputField.jsx
@@ -8,7 +8,16 @@ export default React.createClass({
     displayName: "EditableInputField",
 
     propTypes: {
-        text: React.PropTypes.string
+        text: React.PropTypes.string.isRequired,
+        onChange: React.PropTypes.func,
+        onDoneEditing: React.PropTypes.func,
+    },
+
+    getDefaultProps() {
+        return {
+           onChange: () => {},
+           onDoneEditing: () => {}
+        }
     },
 
     componentDidMount: function() {


### PR DESCRIPTION
## Description
**Problem:**
EditableInputField threw exception if onChange prop didn't exist

**Solution:**
Don't require onChange prop if its not necessary

**Explanation:**
This resolves an issue where editing the volume name in the volume details threw an exception. EditableInputField was calling props.onChange when it the handler was never provided, and VolumeDetailsPage didn't need to listen onChange.


## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature
- [x] Reviewed and approved by at least one other contributor.
- [ ] New variables supported in Clank
- [ ] New variables committed to secrets repos
