### PR TITLE
Fix instance rows to have hyperlinks in project details

### DIFF
--- a/troposphere/static/js/components/projects/detail/resources/tableData/instance/Name.jsx
+++ b/troposphere/static/js/components/projects/detail/resources/tableData/instance/Name.jsx
@@ -1,12 +1,12 @@
 import React from "react";
 import Backbone from "backbone";
 import { Link } from "react-router";
-import stores from "stores";
 import context from "context";
 import ShareIcon from "components/common/ui/ShareIcon";
+import subscribe from "utilities/subscribe";
 
 
-export default React.createClass({
+const Name = React.createClass({
     displayName: "Name",
 
     contextTypes: {
@@ -30,9 +30,10 @@ export default React.createClass({
                 />);
     },
     render: function() {
+        let IdentityStore = this.props.subscriptions.IdentityStore;
         var instance = this.props.instance,
             name = instance.get("name").trim() || "[no instance name]",
-            identity = stores.IdentityStore.get(instance.get('identity').id),
+            identity = IdentityStore.get(instance.get('identity').id),
             projectId = this.context.projectId;
 
         if ((instance && !instance.get("id") ) || !identity) {
@@ -49,3 +50,5 @@ export default React.createClass({
         );
     }
 });
+
+export default subscribe(Name, ["IdentityStore"]);


### PR DESCRIPTION
## Description

The Name component renders the hyperlink for an instance. It was trying to use
the identity store to retrieve an Identity, but it was never listening to the
store for changes.


## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature
- [x] Reviewed and approved by at least one other contributor.
- [ ] New variables supported in Clank
- [ ] New variables committed to secrets repos
