### PR TITLE
Problem: Emulate component is using the wrong URL 

### DIFF
--- a/troposphere/static/js/components/admin/Emulate.jsx
+++ b/troposphere/static/js/components/admin/Emulate.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Link } from 'react-router';
 import Tooltip from "react-tooltip";
 
 
@@ -13,7 +14,8 @@ export default React.createClass({
         let { username } = this.props;
 
         return (
-        <a href={`emulate/${username}`}>
+        <Link to={`emulate/${username}`}
+              activeClassName="active">
             <i className={"glyphicon glyphicon-user"}
                data-for={username}
                data-tip="Emulate"
@@ -21,7 +23,7 @@ export default React.createClass({
             <Tooltip id={username}
                      place="top"
                      effect="solid" />
-        </a>
+        </Link>
         );
     }
 


### PR DESCRIPTION
## Description

When you try to emulate a user within the "Admin > Manage Users" view, you are incorrectly redirected to `.../application/admin/emulate/:username`. This is an invalid URL.

With this work, the expected URL `.../application/emulate/:username` is used.

The root cause here is that the HTML `<a>` is not wise to the `basename` for the application. By using the `<Link />` component, we have the `basename` from `appBrowserHistory` appended to the `to={...}` prop.

See also [ATMO-1990](https://pods.iplantcollaborative.org/jira/browse/ATMO-1990)

## Checklist before merging Pull Requests
- [ ] ~New test(s) included to reproduce the bug/verify the feature~
- [ ] ~Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Reviewed and approved by at least one other contributor.
- [ ] ~New variables supported in Clank~
- [ ] ~New variables committed to secrets repos~
