### PR TITLE
Don't fetch images when the query changes in render

### DIFF
--- a/troposphere/static/js/components/images/list/ImageListView.jsx
+++ b/troposphere/static/js/components/images/list/ImageListView.jsx
@@ -36,7 +36,7 @@ export default React.createClass({
         if (newProps.query != this.props.query) {
             this.setState({
                 query: newProps.query || ""
-            });
+            }, this.updateState);
         }
     },
 
@@ -196,7 +196,7 @@ export default React.createClass({
 
         let images;
         if (query) {
-            images = stores.ImageStore.fetchWhere({
+            images = stores.ImageStore.getWhere({
                 search: query
             });
         } else {


### PR DESCRIPTION
## Description

**Problem:**
Image search is really slow
**Solution:**
Don't make unnecessary queries

We were making so many queries that browser became backlogged on requests,
making search very slow.

Render must use getWhere (as opposed to fetchWhere), otherwise every render
results in a search query. That way fetching occurs after user has finished
typing their query, which is triggered by 500ms of no further input.

See  [awaitingTimeout](https://github.com/cyverse/troposphere/blob/1577344f1f26c6cf927bd9e8d96f5fedaebbcc21/troposphere/static/js/components/mixins/ComponentHandleInputWithDelay.js#L23-L25) and [callIfNotInterruptedAfter](https://github.com/cyverse/troposphere/blob/1577344f1f26c6cf927bd9e8d96f5fedaebbcc21/troposphere/static/js/components/mixins/ComponentHandleInputWithDelay.js#L27-L39)

## Checklist before merging Pull Requests
- [ ] ~New test(s) included to reproduce the bug/verify the feature~
- [ ] ~Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [x] Reviewed and approved by at least one other contributor.
- [ ] ~New variables supported in Clank~
- [ ] ~New variables committed to secrets repos~
