### PR TITLE
Handle Instance Launch submission before closing modal

### DIFF
--- a/troposphere/static/js/actions/InstanceActions.js
+++ b/troposphere/static/js/actions/InstanceActions.js
@@ -25,7 +25,6 @@ export default {
     redeploy: IRedeploy.redeploy,
     poll: IPoll.poll,
     launch: ILaunch.launch,
-    createProjectAndLaunchInstance: ILaunch.createProjectAndLaunchInstance,
     destroy: IDestroy.destroy,
     update: IUpdate.update,
     report: IReport.report,

--- a/troposphere/static/js/actions/instance/launch.js
+++ b/troposphere/static/js/actions/instance/launch.js
@@ -7,13 +7,11 @@ import Utils from "../Utils";
 //
 import InstanceConstants from "constants/InstanceConstants";
 import ProjectInstanceConstants from "constants/ProjectInstanceConstants";
-import ProjectConstants from "constants/ProjectConstants";
 
 //
 // Models
 //
 import Instance from "models/Instance";
-import Project from "models/Project";
 import ProjectInstance from "models/ProjectInstance";
 
 import globals from "globals";
@@ -147,47 +145,5 @@ function launch(params) {
 }
 
 export default {
-
-    createProjectAndLaunchInstance: function(params) {
-        if (!params.projectName)
-            throw new Error("Missing projectName");
-
-        var projectName = params.projectName,
-            project = new Project({
-                name: projectName,
-                description: projectName,
-                instances: [],
-                volumes: []
-            });
-
-        Utils.dispatch(ProjectConstants.ADD_PROJECT, {
-            project: project
-        });
-
-        project.save().done(function() {
-            Utils.dispatch(ProjectConstants.UPDATE_PROJECT, {
-                project: project
-            });
-
-            // launch the instance into the project
-            params.project = project;
-            delete params["projectName"];
-            launch(params);
-
-            // Since this is triggered from the images page, navigate off
-            // that page and back to the instance list so the user can see
-            // their instance being created
-            appBrowserHistory.push(`/projects/${project.id}/resources`);
-        }).fail(function(response) {
-            Utils.dispatch(ProjectConstants.REMOVE_PROJECT, {
-                project: project
-            });
-            Utils.displayError({
-                title: "Project could not be created",
-                response: response
-            });
-        });
-    },
-
-    launch: launch
+    launch
 };

--- a/troposphere/static/js/actions/instance/launch.js
+++ b/troposphere/static/js/actions/instance/launch.js
@@ -39,12 +39,14 @@ function launch(params) {
     if (!params.machine)
         throw new Error("Missing machine");
 
-    let project = params.project,
-        instanceName = params.instanceName,
-        identity = params.identity,
-        size = params.size,
-        machine = params.machine,
-        scripts = params.scripts;
+    let { project,
+          instanceName,
+          identity,
+          size,
+          machine,
+          scripts,
+          onSuccess,
+          onFail } = params;
 
     let instance = new Instance({
         name: instanceName,
@@ -116,13 +118,10 @@ function launch(params) {
                 });
             });
 
-            // // Save projectInstance to db
-            // projectInstance.save(null, {
-            //     attrs: {
-            //         project: project.id,
-            //         instance: instance.id
-            //     }
-            // });
+            onSuccess();
+
+            // only change _context_ if we have succeeded in launching
+            appBrowserHistory.push(`/projects/${project.id}/resources`);
 
         }).fail(function(response) {
             // Remove instance from stores
@@ -136,12 +135,9 @@ function launch(params) {
                 title: "Instance could not be launched",
                 response: response
             });
-    });
 
-    // Since this is triggered from the images page, navigate off
-    // that page and back to the instance list so the user can see
-    // their instance being created
-    appBrowserHistory.push(`/projects/${project.id}/resources`);
+            onFail();
+        });
 }
 
 export default {

--- a/troposphere/static/js/actions/instance/launch.js
+++ b/troposphere/static/js/actions/instance/launch.js
@@ -94,7 +94,7 @@ function launch(params) {
         payload.allocation_source_id = params.allocation_source_uuid;
     }
 
-    // Create Instance (v2)
+    // Create Instance using the v2 API endpoint
     instance.create(payload)
         .done(function(attrs, status, response) {
             instance.set("id", attrs.id);

--- a/troposphere/static/js/components/modals/instance/InstanceLaunchWizardModal.jsx
+++ b/troposphere/static/js/components/modals/instance/InstanceLaunchWizardModal.jsx
@@ -79,7 +79,8 @@ export default React.createClass({
             providerSize: null,
             identityProvider: null,
             attachedScripts: [],
-            allocationSource: null
+            allocationSource: null,
+            waitingOnLaunch: false
         }
     },
 
@@ -436,6 +437,13 @@ export default React.createClass({
         });
     },
 
+
+    onLaunchFailed: function() {
+        this.setState({
+            waitingOnLaunch: false
+        });
+    },
+
     filterSizeList(provider, sizes, imageVersion) {
         let selectedMachine =
             imageVersion.get('machines')
@@ -469,7 +477,9 @@ export default React.createClass({
                 identity: this.state.identityProvider,
                 size: this.state.providerSize,
                 version: this.state.imageVersion,
-                scripts: this.state.attachedScripts
+                scripts: this.state.attachedScripts,
+                onSuccess: () => { this.hide(); },
+                onFail: () => { this.onLaunchFailed(); }
             };
 
             if (globals.USE_ALLOCATION_SOURCES) {
@@ -477,10 +487,18 @@ export default React.createClass({
             }
 
             actions.InstanceActions.launch(launchData);
-            this.hide();
+
+            // enter into a "waiting" state to determine
+            // result of launch operation
+            this.setState({
+                waitingOnLaunch: true
+            });
+
             return
         }
 
+        // if we cannot launch, we are in a world of hurt
+        // - show some indication of that
         this.setState({
             showValidationErr: true
         })
@@ -623,12 +641,12 @@ export default React.createClass({
     },
 
     renderBasicOptions: function() {
-
         let provider = this.state.provider;
         let providerSize = this.state.providerSize;
         let project = this.state.project;
         let image = this.state.image;
         let imageVersion = this.state.imageVersion;
+        let waitingOnLaunch = this.state.waitingOnLaunch;
 
         let projectList = stores.ProjectStore.getAll() || null;
 
@@ -674,7 +692,7 @@ export default React.createClass({
             onBack: this.onBack, onCancel: this.hide, onNameChange: this.onNameChange, onNameBlur: this.onNameBlur, onProjectChange: this.onProjectChange, onAllocationSourceChange:
             this.onAllocationSourceChange, onProviderChange: this.onProviderChange, onRequestResources: this.onRequestResources, onSizeChange: this.onSizeChange, onSubmitLaunch:
             this.onSubmitLaunch, onVersionChange: this.onVersionChange, project, projectList, provider, providerList, providerSize, providerSizeList, resourcesUsed, viewAdvanced:
-            this.viewAdvanced, hasAdvancedOptions: this.hasAdvancedOptions(), allocationSource: this.state.allocationSource, allocationSourceList }} />
+            this.viewAdvanced, hasAdvancedOptions: this.hasAdvancedOptions(), allocationSource: this.state.allocationSource, allocationSourceList, waitingOnLaunch }} />
         )
     },
 

--- a/troposphere/static/js/components/modals/instance/launch/components/BasicInfoForm.jsx
+++ b/troposphere/static/js/components/modals/instance/launch/components/BasicInfoForm.jsx
@@ -55,7 +55,8 @@ export default React.createClass({
             project,
             projectList,
             instanceName,
-            showValidationErr
+            showValidationErr,
+            waitingOnLaunch
         } = this.props;
         let hasErrorClass;
         let errorMessage = null;
@@ -95,6 +96,7 @@ export default React.createClass({
                     Instance Name
                 </label>
                 <input required
+                    disabled={waitingOnLaunch}
                     type="Name"
                     className="form-control"
                     id="instanceName"
@@ -109,6 +111,7 @@ export default React.createClass({
                     Base Image Version
                 </label>
                 <SelectMenu current={imageVersion}
+                    disabled={waitingOnLaunch}
                     list={this.props.imageVersionList}
                     optionName={item => item.get("name")}
                     onSelect={this.props.onVersionChange} />
@@ -118,6 +121,7 @@ export default React.createClass({
                     Project
                 </label>
                 <SelectMenu current={project}
+                    disabled={waitingOnLaunch}
                     list={projectList}
                     optionName={item => item.get("name")}
                     onSelect={this.props.onProjectChange} />

--- a/troposphere/static/js/components/modals/instance/launch/components/InstanceLaunchFooter.jsx
+++ b/troposphere/static/js/components/modals/instance/launch/components/InstanceLaunchFooter.jsx
@@ -15,14 +15,15 @@ const WaitingIndicator = React.createClass({
             textTransform: "uppercase",
             userSelect: "none",
             margin: "0px",
-            paddingLeft: "6px",
+            paddingLeft: "10px",
             paddingRight: "16px",
             opacity: 1,
             color: "rgba(0, 0, 0, 0.87)"
         };
         return (
-            <div style={{height: "36px"}} className="pull-right">
-              <span style={{top: "5px"}} className="loading-tiny-inline" />
+            <div style={{height: "36px", display: "flex", alignItems: "center"}}
+                 className="pull-right">
+              <span className="loading-tiny-inline" />
               <span style={style}>{"Launching ..."}</span>
             </div>
         );
@@ -88,7 +89,7 @@ export default React.createClass({
               /> : <WaitingIndicator /> }
             <RaisedButton
                 className="pull-right"
-                style={{ marginRight: "10px" }}
+                style={{ marginRight: "20px" }}
                 onClick={this.props.onCancel}
                 label="Cancel"
             />

--- a/troposphere/static/js/components/modals/instance/launch/components/InstanceLaunchFooter.jsx
+++ b/troposphere/static/js/components/modals/instance/launch/components/InstanceLaunchFooter.jsx
@@ -64,11 +64,13 @@ export default React.createClass({
 
     render: function() {
         let disable = false;
-        let showValidationErr = this.props.showValidationErr;
+        let { showValidationErr,
+              waitingOnLaunch } = this.props;
 
         if (showValidationErr) {
             disable = this.props.launchIsDisabled;
         }
+
         return (
         <div className="modal-footer">
             {this.renderBack()}
@@ -76,13 +78,14 @@ export default React.createClass({
                 {this.advancedIcon()}
                 {" Advanced Options"}
             </a>
-            <RaisedButton
-                primary
-                disabled={disable}
-                className="pull-right"
-                onTouchTap={this.props.onSubmitLaunch}
-                label="Launch Instance"
-            />
+            { !waitingOnLaunch ?
+              <RaisedButton
+                  primary
+                  disabled={disable}
+                  className="pull-right"
+                  onTouchTap={this.props.onSubmitLaunch}
+                  label="Launch Instance"
+              /> : <WaitingIndicator /> }
             <RaisedButton
                 className="pull-right"
                 style={{ marginRight: "10px" }}

--- a/troposphere/static/js/components/modals/instance/launch/components/InstanceLaunchFooter.jsx
+++ b/troposphere/static/js/components/modals/instance/launch/components/InstanceLaunchFooter.jsx
@@ -54,11 +54,18 @@ export default React.createClass({
     },
 
     renderBack: function() {
-        if (this.props.backIsDisabled) {
+        let { backIsDisabled,
+              waitingOnLaunch } = this.props;
+
+        if (backIsDisabled) {
             return
         } else {
             return (
-            <a className="btn btn-default pull-left" style={{ marginRight: "10px" }} onClick={this.props.onBack}><span className="glyphicon glyphicon-arrow-left" /> Back</a>
+            <button className="btn btn-default pull-left"
+                    style={{ marginRight: "10px" }}
+                    disabled={waitingOnLaunch}
+                    onClick={this.props.onBack}>
+                <span className="glyphicon glyphicon-arrow-left" /> Back</button>
             )
         }
     },
@@ -66,6 +73,7 @@ export default React.createClass({
     render: function() {
         let disable = false;
         let { showValidationErr,
+              advancedIsDisabled,
               waitingOnLaunch } = this.props;
 
         if (showValidationErr) {
@@ -75,7 +83,9 @@ export default React.createClass({
         return (
         <div className="modal-footer">
             {this.renderBack()}
-            <a className="pull-left btn" disabled={this.props.advancedIsDisabled} onClick={this.props.viewAdvanced}>
+            <a className="pull-left btn"
+               disabled={advancedIsDisabled || waitingOnLaunch}
+               onClick={() => { if (!waitingOnLaunch) { this.props.viewAdvanced() } }}>
                 {this.advancedIcon()}
                 {" Advanced Options"}
             </a>

--- a/troposphere/static/js/components/modals/instance/launch/components/InstanceLaunchFooter.jsx
+++ b/troposphere/static/js/components/modals/instance/launch/components/InstanceLaunchFooter.jsx
@@ -1,6 +1,35 @@
 import React from "react";
 import RaisedButton from 'material-ui/RaisedButton';
 
+/**
+ * "material-ui/RefreshIndicator" was not used because `top` & `left` position CSS
+ * attributes were required; it seemed unlikely this was a good approach with the
+ * faux "placeholder" -- @lenards (2017-08-21)
+ */
+const WaitingIndicator = React.createClass({
+    render() {
+        let style = {
+            fontWeight: 500,
+            fontSize: "14px",
+            letterSpacing: "0px",
+            textTransform: "uppercase",
+            userSelect: "none",
+            margin: "0px",
+            paddingLeft: "6px",
+            paddingRight: "16px",
+            opacity: 1,
+            color: "rgba(0, 0, 0, 0.87)"
+        };
+        return (
+            <div style={{height: "36px"}} className="pull-right">
+              <span style={{top: "5px"}} className="loading-tiny-inline" />
+              <span style={style}>{"Launching ..."}</span>
+            </div>
+        );
+    }
+});
+
+
 export default React.createClass({
     propTypes: {
         backIsDisabled: React.PropTypes.bool.isRequired,

--- a/troposphere/static/js/components/modals/instance/launch/components/ResourcesForm.jsx
+++ b/troposphere/static/js/components/modals/instance/launch/components/ResourcesForm.jsx
@@ -74,7 +74,8 @@ const ResourcesForm = React.createClass({
     renderAllocationSourceMenu() {
         let { allocationSource,
               allocationSourceList,
-              onAllocationSourceChange } = this.props;
+              onAllocationSourceChange,
+              waitingOnLaunch } = this.props;
 
         return (
         <div className="form-group">
@@ -82,6 +83,7 @@ const ResourcesForm = React.createClass({
                 Allocation Source
             </label>
             <SelectMenu current={allocationSource}
+                disabled={waitingOnLaunch}
                 list={allocationSourceList}
                 optionName={as => as.get("name")}
                 onSelect={onAllocationSourceChange} />
@@ -136,7 +138,10 @@ const ResourcesForm = React.createClass({
         );
     },
     renderProvider() {
-        let { provider, providerList, onProviderChange } = this.props;
+        let { provider,
+              providerList,
+              onProviderChange,
+              waitingOnLaunch } = this.props;
 
         return (
             <div className="form-group">
@@ -145,6 +150,7 @@ const ResourcesForm = React.createClass({
                 </label>
                 <SelectMenu id="provider"
                             current={ provider }
+                            disabled={waitingOnLaunch}
                             optionName={ prov => prov.get('name') }
                             list={ providerList }
                             onSelect={ onProviderChange } />
@@ -152,12 +158,16 @@ const ResourcesForm = React.createClass({
         );
     },
     renderIdentity() {
-        let { identity, identityList, onIdentityChange } = this.props;
+        let { identity,
+              identityList,
+              onIdentityChange,
+              waitingOnLaunch } = this.props;
 
         return (
             <div className="form-group">
                 {this.renderIdentityLabel()}
                 <SelectMenu id="identity"
+                            disabled={waitingOnLaunch}
                             current={ identity }
                             optionName={ ident => this.identityToOptionName(ident) }
                             list={ identityList }
@@ -166,7 +176,10 @@ const ResourcesForm = React.createClass({
         );
     },
     render: function() {
-        let { providerSize, providerSizeList, onSizeChange } = this.props;
+        let { providerSize,
+              providerSizeList,
+              onSizeChange,
+              waitingOnLaunch } = this.props;
 
         return (
         <form>
@@ -179,6 +192,7 @@ const ResourcesForm = React.createClass({
                     Instance Size
                 </label>
                 <SelectMenu current={providerSize}
+                    disabled={waitingOnLaunch}
                     optionName={this.getProviderSizeName}
                     list={providerSizeList}
                     onSelect={onSizeChange} />


### PR DESCRIPTION
## Description

### Problem

When we moved to the `api/v2/instances` endpoint for launching new instances, we introduced latency to the ProjectResources view from when the instance is launched & it appears in the view (so the modal closing, but the POST is still _pending_ and could be so for 90 or more seconds). 

### Options

#### Option A

I looked into mirroring the "pending" resource approaches that is used by Volumes. This approach does an _eager-add_ into a collection that is conditionally concatenated when `getVolumesFor(project)` is called. 

I did attempt this approach first. It did not appear that the view as receiving _updates_. I was somewhat concerned with introducing the manual handling of _pending_ models. I do have the rough changes for this stashed.

#### Option B

Alter the behavior of the modal to make the Instance create submission prior to _hiding_/closing. There is an open feature request for this behavior ([ATMO-1153](https://pods.iplantcollaborative.org/jira/browse/ATMO-1153)). The reason is that when an instance launch fails, all of the "work" done selecting options is **lost**. A more _helpful_ approach would be for the launch modal to remain open. If launch fails, a different provider or different size would be selected and re-attempted. 

This has the added benefit of "distracting" anyone from the latency/delay associated with POSTing to `api/v2/instances`. 

- on success ✅  http://recordit.co/6HDS73e3Hp
- on failure :x: http://recordit.co/AFaBAvCnyC

There still needs to be some polish and improvements to the animation for "replacing" the <kbd>LAUNCH INSTANCE</kbd> with a spinner. Also, the text positioning within that placeholder could be aligned, vertically, to the baseline of the <kbd>CANCEL</kbd> text. 

**Option B** is being presented as an enhance (see ATMO-1153) and as a resolution to a visual feedback quirk regarding the appearance of the Instance within `<InstanceList />` of the Project Resources view.

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] ~Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Reviewed and approved by at least one other contributor.
- [ ] ~New variables supported in Clank~
- [ ] ~New variables committed to secrets repos~
