### PR TITLE
Problem: Trying hide an unmounted modal component

### DIFF
--- a/troposphere/static/js/components/modals/instance/InstanceLaunchWizardModal.jsx
+++ b/troposphere/static/js/components/modals/instance/InstanceLaunchWizardModal.jsx
@@ -437,11 +437,18 @@ export default React.createClass({
         });
     },
 
-
     onLaunchFailed: function() {
         this.setState({
             waitingOnLaunch: false
         });
+    },
+
+    onLaunchSuccess: function() {
+        let modalEl = document.getElementById("modal");
+        // hide if there is a modal visible (present in DOM)
+        if (modalEl && modalEl.childElementCount > 0) {
+            this.hide();
+        }
     },
 
     filterSizeList(provider, sizes, imageVersion) {
@@ -478,7 +485,7 @@ export default React.createClass({
                 size: this.state.providerSize,
                 version: this.state.imageVersion,
                 scripts: this.state.attachedScripts,
-                onSuccess: () => { this.hide(); },
+                onSuccess: () => { this.onLaunchSuccess(); },
                 onFail: () => { this.onLaunchFailed(); }
             };
 


### PR DESCRIPTION
## Description

### Background

With the v27 release, we shifted how the Instance Launch Wizard Modal performing a "launch". The modal remains open until the launch is successful, or returns to a "launch-ready" form on-failure (to allow changes in Size or Provider). 

But, this means the an `onSuccess(...)` callback function is now passed into a Promise-context, within the action. 

### Solution

We want to be cautious in when we call `hide(..)` on a modal since it can generate an uncaught exception. So, we use a document selector, by ID, to determine if a modal is _mounted_ and **visible** to the community member. If there are no children for `div#modal`, then we no there is not a mounted modal component. 

Tracked within Sentry as `issues/334233103`

## Checklist before merging Pull Requests
- [ ] ~New test(s) included to reproduce the bug/verify the feature~
- [ ] ~Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Reviewed and approved by at least one other contributor.
- [ ] ~New variables supported in Clank~
- [ ] ~New variables committed to secrets repos~
