### PR TITLE
Problem: "disabled" Advanced Options still calls "onClick" handler

### DIFF
--- a/troposphere/static/js/components/modals/instance/launch/components/AdvancedOptionsFooter.jsx
+++ b/troposphere/static/js/components/modals/instance/launch/components/AdvancedOptionsFooter.jsx
@@ -19,7 +19,7 @@ export default React.createClass({
         <div className="modal-footer">
             <RaisedButton
                 style={{ float: "right" }}
-                isDisabled={this.props.footerDisabled}
+                disabled={this.props.footerDisabled}
                 label="Continue to Launch"
                 onTouchTap={this.props.onSaveAdvanced}
             />

--- a/troposphere/static/js/components/modals/instance/launch/components/InstanceLaunchFooter.jsx
+++ b/troposphere/static/js/components/modals/instance/launch/components/InstanceLaunchFooter.jsx
@@ -53,6 +53,19 @@ export default React.createClass({
         )
     },
 
+    onAdvancedClick: function() {
+        let { advancedIsDisabled,
+              waitingOnLaunch,
+              viewAdvanced } = this.props,
+            canView = !(advancedIsDisabled || waitingOnLaunch);
+
+        // when the modal is waiting on a launch, or the "advanced"
+        // section has been actively disable, we cannot view
+        if (canView && viewAdvanced) {
+            viewAdvanced();
+        }
+    },
+
     renderBack: function() {
         let { backIsDisabled,
               waitingOnLaunch } = this.props;
@@ -85,7 +98,7 @@ export default React.createClass({
             {this.renderBack()}
             <a className="pull-left btn"
                disabled={advancedIsDisabled || waitingOnLaunch}
-               onClick={() => { if (!waitingOnLaunch) { this.props.viewAdvanced() } }}>
+               onClick={this.onAdvancedClick}>
                 {this.advancedIcon()}
                 {" Advanced Options"}
             </a>


### PR DESCRIPTION
## Description

The `disabled` HTML attributes on an `<a>...</a>` does not deactivate or block an "onClick" from being received. For an onHover, we do see a "disable" indicator. However, a click in the first view of the `<InstanceLaunchWizardModal />` does generate an error. 

It looks like Chrome and other browser may be generous here [too, according to MDN `<a>` does not have `disabled` as an attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a).

<details>

## Before: clicks generate errors 

http://recordit.co/6JbrJI2yhZ

## After: clicks do not generate errors

http://recordit.co/k8MLBp46l7

</details>

## Checklist before merging Pull Requests
- [ ] ~New test(s) included to reproduce the bug/verify the feature~
- [ ] ~Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Reviewed and approved by at least one other contributor.
- [ ] ~New variables supported in Clank~
- [ ] ~New variables committed to secrets repos~
