### PR TITLE
Problem: a list of "null" sent for scripts on launch

### DIFF
--- a/troposphere/static/js/models/Instance.js
+++ b/troposphere/static/js/models/Instance.js
@@ -83,7 +83,7 @@ export default Backbone.Model.extend({
             project = options.project.get('uuid'),
             allocation_source_id = options.allocation_source_id,
             scripts = (options.scripts) ? options.scripts.map(function(script) {
-                return script.uuid; //FIXME: Verify if this should be `.get('uuid')`
+                return script.get('uuid');
             }) : [];
 
         var url = (


### PR DESCRIPTION
## Description

The error was that the `scripts.map(...)` was returns an undefined attribute from the boot script models. 

This work properly translates the list of attached scripts (boot script models) to a list of UUIDs when creating the `models/Instance` on `api/v2/instances`. 

## Checklist before merging Pull Requests
- [ ] ~New test(s) included to reproduce the bug/verify the feature~
- [ ] ~Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Reviewed and approved by at least one other contributor.
- [ ] ~New variables supported in Clank~
- [ ] ~New variables committed to secrets repos~
