### PR TITLE
Fix volume update issues (updating a project, updating a name)

### DIFF
--- a/troposphere/static/js/actions/NullProjectActions.js
+++ b/troposphere/static/js/actions/NullProjectActions.js
@@ -1,7 +1,5 @@
 import Backbone from "backbone";
 
-import { appBrowserHistory } from "utilities/historyFunctions";
-
 import Utils from "./Utils";
 import actions from "actions";
 import context from "context";
@@ -59,15 +57,6 @@ export default {
             }
         }
     },
-
-    _migrateResourcesIntoProject: function(resources, project) {
-        resources.map(function(resource) {
-            this._migrateResourceIntoProject(resource, project);
-        }.bind(this));
-
-        appBrowserHistory.push(`/projects/${project.id}/resources`);
-    },
-
 
     // ------------------------
     // Exposed Operations

--- a/troposphere/static/js/actions/volume/update.js
+++ b/troposphere/static/js/actions/volume/update.js
@@ -1,5 +1,9 @@
 import VolumeConstants from "constants/VolumeConstants";
+import ProjectVolumeConstants from "constants/ProjectVolumeConstants";
 import Utils from "../Utils";
+import Backbone from "backbone";
+import ProjectVolume from "models/ProjectVolume";
+import ProjectVolumeStore from "stores/ProjectVolumeStore";
 
 export default {
     update: function(volume, newAttributes) {
@@ -8,21 +12,42 @@ export default {
         if (!newAttributes || (!newAttributes.name && !newAttributes.project))
             throw new Error("Expected name and/or project in attributes. received " + newAttributes)
 
-        let project = newAttributes.project || volume.get('project');
-        volume.set(newAttributes);
+        let project = newAttributes.project || volume.get("project");
+        let name = newAttributes.name || volume.get("name");
 
+        let originalVolume = volume.clone();
+        let originalProject = originalVolume.get('project');
+
+        volume.set(newAttributes);
         Utils.dispatch(VolumeConstants.UPDATE_VOLUME, {
             volume: volume
         });
 
+        let originalProjectVolume = ProjectVolumeStore.findOne({
+            "project.id": originalProject.id,
+            "volume.id": originalVolume.id
+        });
+        if (originalProjectVolume) {
+            Utils.dispatch(ProjectVolumeConstants.REMOVE_PROJECT_VOLUME, { projectVolume: originalProjectVolume });
+        }
+
+        // Note this resource being added doesn't have an id. Its like a
+        // pending resource. It will be removed, when we
+        // fetchWhereNoCache() which syncs the project volume store with
+        // the api.
+        let projectVolume = new ProjectVolume({
+            project: project instanceof Backbone.Model ? project.toJSON() : project,
+            volume: volume.toJSON()
+        });
+        Utils.dispatch(ProjectVolumeConstants.ADD_PROJECT_VOLUME, { projectVolume: projectVolume });
+
+
         volume.save({
-            name: volume.get("name"),
+            name: name,
             project: project.id
         }, {
             patch: true,
             merge: true
-        }).done(function() {
-            // Nothing to do here
         }).fail(function(response) {
             Utils.displayError({
                 title: "Volume could not be updated",
@@ -35,6 +60,10 @@ export default {
             Utils.dispatch(VolumeConstants.POLL_VOLUME, {
                 volume: volume
             });
+
+            // Once the volume has been saved, have the ProjectVolumeStore
+            // repopulate it's models.
+            ProjectVolumeStore.fetchWhereNoCache();
         });
     }
 };

--- a/troposphere/static/js/components/common/EditableInputField.jsx
+++ b/troposphere/static/js/components/common/EditableInputField.jsx
@@ -8,7 +8,16 @@ export default React.createClass({
     displayName: "EditableInputField",
 
     propTypes: {
-        text: React.PropTypes.string
+        text: React.PropTypes.string.isRequired,
+        onChange: React.PropTypes.func,
+        onDoneEditing: React.PropTypes.func,
+    },
+
+    getDefaultProps() {
+        return {
+           onChange: () => {},
+           onDoneEditing: () => {}
+        }
     },
 
     componentDidMount: function() {

--- a/troposphere/static/js/components/dashboard/DashboardPage.jsx
+++ b/troposphere/static/js/components/dashboard/DashboardPage.jsx
@@ -66,7 +66,7 @@ export default React.createClass({
             images = stores.ImageStore.getAll(),
             instances = stores.InstanceStore.getAll(),
             volumes = stores.VolumeStore.getAll(),
-            sizes = stores.SizeStore.fetchWhereNoCache({
+            sizes = stores.SizeStore.fetchWhere({
                 "archived": "true",
                 "page_size": 250
             });

--- a/troposphere/static/js/stores/BaseStore.js
+++ b/troposphere/static/js/stores/BaseStore.js
@@ -79,6 +79,9 @@ _.extend(Store.prototype, Backbone.Events, {
     // --------------
 
     add: function(payload) {
+        if (!this.models) {
+            this.models = new this.collection();
+        }
         if ("at" in payload) {
             this.models.add(payload.data, {
                 at: payload.at
@@ -107,13 +110,15 @@ _.extend(Store.prototype, Backbone.Events, {
     },
 
     remove: function(model) {
-        this.models.remove(model);
+        // Only remove models if we have models in the cache
+        if (this.models) {
+            this.models.remove(model);
+        }
 
         // If already polling, Remove model from polling dictionary
         if (this.pollingModels[model.cid]) {
             delete this.pollingModels[model.cid];
         }
-        return;
     },
 
     // --------------

--- a/troposphere/static/js/stores/BaseStore.js
+++ b/troposphere/static/js/stores/BaseStore.js
@@ -342,16 +342,11 @@ _.extend(Store.prototype, Backbone.Events, {
         return this.queryModels[queryString];
     },
 
-    // Fetches the first page of data for the given set of queryParams
-    // Example: params = {page_size: 1000, search: 'featured'}
-    // will be convereted to ?page_size=1000&search=featured
     fetchWhereNoCache: function(queryParams) {
         queryParams = queryParams || {};
 
         // Build the query string
         var queryString = this.buildQueryStringFromQueryParams(queryParams);
-
-        if (this.queryModels[queryString]) return this.queryModels[queryString];
 
         if (!this.isFetchingQuery[queryString]) {
             this.isFetchingQuery[queryString] = true;
@@ -365,6 +360,7 @@ _.extend(Store.prototype, Backbone.Events, {
             }.bind(this));
         }
     },
+
     appendModels: function(moreModels) {
         if (!this.models) {
             this.models = moreModels;

--- a/troposphere/static/js/stores/ProjectVolumeStore.js
+++ b/troposphere/static/js/stores/ProjectVolumeStore.js
@@ -4,11 +4,8 @@ import BaseStore from "stores/BaseStore";
 import ProjectVolumeCollection from "collections/ProjectVolumeCollection";
 import ProjectVolumeConstants from "constants/ProjectVolumeConstants";
 import VolumeCollection from "collections/VolumeCollection";
-import Volume from "models/Volume";
 import stores from "stores";
 
-let _modelsFor = {};
-let _isFetchingFor = {};
 let _pendingProjectVolumes = new VolumeCollection();
 
 function addPending(model) {
@@ -22,39 +19,10 @@ function removePending(model) {
 let ProjectStore = BaseStore.extend({
     collection: ProjectVolumeCollection,
 
-    initialize: function() {
-        this.models = new ProjectVolumeCollection();
-    },
-
-    fetchModelsFor: function(projectId) {
-        if (!_modelsFor[projectId] && !_isFetchingFor[projectId]) {
-            _isFetchingFor[projectId] = true;
-            var models = new ProjectVolumeCollection();
-            models.fetch({
-                url: models.url + "?project__id=" + projectId
-            }).done(function() {
-                _isFetchingFor[projectId] = false;
-
-                // add models to existing cache
-                this.models.add(models.models);
-
-                // convert ProjectVolume collection to an VolumeCollection
-                var volumes = models.map(function(pv) {
-                    return new Volume(pv.get("volume"), {
-                        parse: true
-                    });
-                });
-                volumes = new VolumeCollection(volumes);
-
-                _modelsFor[projectId] = volumes;
-                this.emitChange();
-            }.bind(this));
-        }
-    },
     getVolumesFor: function(project) {
         var allVolumes = stores.VolumeStore.getAll();
         if (!project.id) return;
-        if (!_modelsFor[project.id]) return this.fetchModelsFor(project.id);
+        if (!this.models) return this.fetchModels();
         if (!allVolumes) return;
 
         var volumes = this.models.filter(function(pv) {


### PR DESCRIPTION
## Description

There are two issues with volumes in the v27 release. The first issue is that the name couldn't be changed (this has already been fixed in master, and brought in here as @9bc4c34). The second issue is that volumes couldn't be moved between projects. I'll describe the the latter below.

#### Why volumes couldn't be moved
The api changed, and tropo didn't get updated properly. The old API required 2 patches one to remove the old project-volume pairing, and the next to add a new project-volume pairing. The new api requires a single patch with the new project. 

#### Solution
Perform a single update on api v2 resources. This affects instances and volumes. 

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature
- [ ] Reviewed and approved by at least one other contributor.
- [ ] New variables supported in Clank
- [ ] New variables committed to secrets repos
