### PR TITLE
Problem: Manual uWSGI reload in dev environment - Nope

### DIFF
--- a/extras/troposphere.uwsgi.ini.j2
+++ b/extras/troposphere.uwsgi.ini.j2
@@ -10,7 +10,10 @@ enable-threads = true
 processes = {{ NUM_PROCESSES }}
 uid = {{ UWSGI_USER }}
 gid = {{ UWSGI_GROUP }}
-{% if LOCAL_DEV %}chmod-socket = 776{% endif %}
+{% if LOCAL_DEV -%}
+chmod-socket = 776
+python-autoreload = 1
+{% endif -%}
 vacuum = true
 max-requests = 10000
 daemonize = {{ UWSGI_LOG_PATH }}


### PR DESCRIPTION
Solution: Use `LOCAL_DEV: True` variable to enable uWSGI
`python-autoreload` feature.

## Checklist before merging Pull Requests
- ~[ ] New test(s) included to reproduce the bug/verify the feature~
- ~[ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [x] Reviewed and approved by at least one other contributor.
- ~[ ] New variables supported in Clank~
- ~[] New variables committed to secrets repos~
