### PR TITLE
Problem: UI logout does not log user out of the API

### DIFF
--- a/troposphere/static/js/components/Header.jsx
+++ b/troposphere/static/js/components/Header.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Link } from 'react-router';
 import Backbone from 'backbone';
 import toastr from 'toastr';
+import $ from "jquery";
 
 import MaintenanceMessageBanner from './MaintenanceMessageBanner';
 import Glyphicon from 'components/common/Glyphicon';
@@ -104,8 +105,15 @@ let LogoutLink = React.createClass({
 
     onLogout: function(e) {
         e.preventDefault();
-        deleteCookie('auth_token');
-        window.location = '/logout?force=true&airport_ui=false';
+        var api_logout_url = globals.API_V2_ROOT.replace("/api/v2","/api-auth/logout/");
+        var self = this;
+        $.ajax(api_logout_url, {
+            contentType: "application/json",
+            success: function() {
+                deleteCookie('auth_token');
+                window.location = '/logout?force=true';
+            }
+        });
     },
 
     onExpiredPassword: function(e) {

--- a/troposphere/static/js/components/Header.jsx
+++ b/troposphere/static/js/components/Header.jsx
@@ -106,7 +106,6 @@ let LogoutLink = React.createClass({
     onLogout: function(e) {
         e.preventDefault();
         var api_logout_url = globals.API_V2_ROOT.replace("/api/v2","/api-auth/logout/");
-        var self = this;
         $.ajax(api_logout_url, {
             contentType: "application/json",
             success: function() {


### PR DESCRIPTION
Solution: Logout of API and then redirect to UI-logout

(Note this is only a problem when using the OpenstackLoginBackend -- does not need to be 'hotfixed' for production servers.)