### PR TITLE
Use older travis image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 ---
   sudo: required
+  group: deprecated-2017Q3
   dist: trusty
   language: node_js
   node_js: 6.11


### PR DESCRIPTION
This fixes a permission issue, unrelated to our code in the build:
OSError: [Errno 13] Permission denied: '/usr/local/bin/easy_install'

Resolves: https://github.com/cyverse/troposphere/issues/702 

Thanks @xuhang57

Please describe your pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. When linking to an issue, please use `refs #...` in the description of the pull request.

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature
- [ ] Reviewed and approved by at least one other contributor.
- [ ] New variables supported in Clank
- [ ] New variables committed to secrets repos
