### PR TITLE
Fix repeated SizeStore event

### DIFF
--- a/troposphere/static/js/components/dashboard/DashboardPage.jsx
+++ b/troposphere/static/js/components/dashboard/DashboardPage.jsx
@@ -42,7 +42,6 @@ export default React.createClass({
         stores.ImageStore.addChangeListener(this.updateState);
         stores.InstanceStore.addChangeListener(this.updateState);
         stores.VolumeStore.addChangeListener(this.updateState);
-        stores.SizeStore.addChangeListener(this.updateState);
     },
 
     componentWillUnmount: function() {
@@ -54,7 +53,6 @@ export default React.createClass({
         stores.ImageStore.removeChangeListener(this.updateState);
         stores.InstanceStore.removeChangeListener(this.updateState);
         stores.VolumeStore.removeChangeListener(this.updateState);
-        stores.SizeStore.removeChangeListener(this.updateState);
     },
 
     render: function() {


### PR DESCRIPTION
## Description

This might be intentional (I am not sure), but we have `SizeStore` called twice in both `componentDidMount` and `componentWillUnmount`.

Please feel free to close this PR if that is indeed intentional. :) 

This solves: https://github.com/cyverse/troposphere/issues/705
Thanks
Lucas

## Checklist before merging Pull Requests
- [x] Reviewed and approved by at least one other contributor.

