### PR TITLE
Problem: Web Desktop integration link only appears after refresh

### DIFF
--- a/troposphere/static/js/models/Instance.js
+++ b/troposphere/static/js/models/Instance.js
@@ -46,6 +46,8 @@ export default Backbone.Model.extend({
         Backbone.sync("read", this, {
             url: url
         }).done(function(attrs, status, response) {
+            // set attributes that need to be updated
+            // following a poll, "from cloud" will be latest
             var statusSplit = attrs.status.split(" - ");
             this.set("ip_address", attrs.ip_address);
             this.set("status", attrs.status);
@@ -54,6 +56,8 @@ export default Backbone.Model.extend({
                 status: statusSplit[0],
                 activity: attrs.activity
             }));
+            this.set("web_desktop", attrs.web_desktop);
+            this.set("vnc", attrs.has_vnc);
             cb(response);
         }.bind(this)).fail(function(response, status, errorThrown) {
             cb(response);


### PR DESCRIPTION
## Description

To see the integration link to Web Desktop, an instance detail view would require a refresh.

In other word, if you left an InstanceDetail page open while the instance-deployment progressed,  the link would not appear. This is particularly frustrated because an instance with the capability of Web Desktop would not be obvious to a community member. 

The fix is that when we fetch the latest metadata for an Instance model from the Cloud :cloud:, we need to make sure to `.set` the `"web_desktop"` capability flag:

- https://github.com/cyverse/troposphere/blob/v27/troposphere/static/js/models/Instance.js#L48-L57

See also [ATMO-1573](https://pods.iplantcollaborative.org/jira/browse/ATMO-1573).

## Checklist before merging Pull Requests
- [ ] ~New test(s) included to reproduce the bug/verify the feature~
- [ ] ~Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Reviewed and approved by at least one other contributor.
- [ ] ~New variables supported in Clank~
- [ ] ~New variables committed to secrets repos~
