### PR TITLE
Problem: ImageDetailPage won't load for Public Image Catalog

### DIFF
--- a/troposphere/static/js/components/images/ImageDetailsPage.jsx
+++ b/troposphere/static/js/components/images/ImageDetailsPage.jsx
@@ -39,9 +39,14 @@ export default React.createClass({
             allPatterns = stores.PatternMatchStore.getAll(),
             hasLoggedInUser = context.hasLoggedInUser(),
             providers = hasLoggedInUser ? stores.ProviderStore.getAll() : null,
-            identities = hasLoggedInUser ? stores.IdentityStore.getAll() : null;
+            identities = hasLoggedInUser ? stores.IdentityStore.getAll() : null,
+            requiredData = [image, tags];
 
-        if (!image || !tags || !allPatterns) return <div className="loading"/>;
+        if (hasLoggedInUser) {
+            requiredData.push(allPatterns);
+        }
+
+        if (!requiredData.every(obj => obj)) return <div className="loading"/>;
 
         if (image.status === 404) return (
             <NotFoundPage resource="image"/>

--- a/troposphere/static/js/components/images/detail/ImageDetailsView.jsx
+++ b/troposphere/static/js/components/images/detail/ImageDetailsView.jsx
@@ -1,13 +1,17 @@
 import React from "react";
 import Backbone from "backbone";
 import HeaderView from "./header/HeaderView";
-import actions from "actions";
+
 import ViewImageDetails from "./ViewImageDetails";
 import EditImageDetails from "./EditImageDetails";
 import VersionsView from "./versions/VersionsView";
 import ImageStatsView from "./stats/ImageStatsView";
+import actions from "actions";
+import context from "context";
 import modals from "modals";
+
 import { trackAction } from "../../../utilities/userActivity";
+
 
 export default React.createClass({
     displayName: "ImageDetailsView",
@@ -56,12 +60,16 @@ export default React.createClass({
 
     render: function() {
         var view,
-            statisticsView = (
-            <ImageStatsView image={ this.props.image } />
-            ),
+            statisticsView,
             versionView = (
-            <VersionsView image={this.props.image} />
+                <VersionsView image={this.props.image} />
             );
+
+        if (context.hasLoggedInUser()) {
+            statisticsView = (
+                <ImageStatsView image={ this.props.image } />
+            );
+        }
 
         if (this.state.isEditing) {
             view = (

--- a/troposphere/static/js/components/images/detail/stats/ImageStatsView.jsx
+++ b/troposphere/static/js/components/images/detail/stats/ImageStatsView.jsx
@@ -215,12 +215,12 @@ const ImageStatsView = React.createClass({
         );
         */
 
-        let image_metric = ImageMetricsStore.get(image.id);
-        if(!image_metric) {
+        let imageMetric = ImageMetricsStore.get(image.id);
+        if(!imageMetric) {
             return (<div className="loading"/>);
         }
-        let metrics = image_metric.get('metrics');
-        if(!metrics || Object.keys(metrics).length === 0) {
+
+        if(!imageMetric.hasMetrics()) {
             // Metrics unavailable//not-yet-generated for this image.
             return ;
         }
@@ -242,7 +242,7 @@ const ImageStatsView = React.createClass({
                                 {"Number of Projects including this Application"}
                                 </td>
                                 <td>
-                                {metrics.projects}
+                                {imageMetric.getProjectsTotal()}
                                 </td>
                             </tr>
                             <tr>
@@ -250,7 +250,7 @@ const ImageStatsView = React.createClass({
                                 {"Number of users who Bookmarked this Application"}
                                 </td>
                                 <td>
-                                {metrics.bookmarks}
+                                {imageMetric.getBookmarksTotal()}
                                 </td>
                             </tr>
                             <tr>
@@ -258,7 +258,7 @@ const ImageStatsView = React.createClass({
                                 {"Number of Applications based on this Application"}
                                 </td>
                                 <td>
-                                {metrics.forks}
+                                {imageMetric.getApplicationForks()}
                                 </td>
                             </tr>
                             <tr>
@@ -266,7 +266,7 @@ const ImageStatsView = React.createClass({
                                 {"Number of Instances Launched (Successful)"}
                                 </td>
                                 <td>
-                                {metrics.instances.success}
+                                {imageMetric.getInstancesSuccess()}
                                 </td>
                             </tr>
                             <tr>
@@ -274,7 +274,7 @@ const ImageStatsView = React.createClass({
                                 {"Number of Instances Launched (Total)"}
                                 </td>
                                 <td>
-                                {metrics.instances.total}
+                                {imageMetric.getInstancesTotal()}
                                 </td>
                             </tr>
                             <tr>
@@ -282,7 +282,7 @@ const ImageStatsView = React.createClass({
                                 {"Number of Instances Launched (%)"}
                                 </td>
                                 <td>
-                                {metrics.instances.percent}
+                                {imageMetric.getInstancesPercent()}
                                 </td>
                             </tr>
                         </tbody>

--- a/troposphere/static/js/models/ImageMetrics.js
+++ b/troposphere/static/js/models/ImageMetrics.js
@@ -12,5 +12,44 @@ export default Backbone.Model.extend({
     toJSON: function(options) {
         var attributes = _.clone(this.attributes);
         return attributes;
+    },
+
+    hasMetrics: function() {
+        return this.attributes.metrics && Object.keys(this.attributes.metrics).length > 0;
+    },
+
+    getProjectsTotal: function() {
+        let { projects } = this.attributes.metrics;
+        return projects || 0;
+    },
+
+    getBookmarksTotal: function() {
+        let { bookmarks } = this.attributes.metrics;
+        return bookmarks || 0;
+    },
+
+    getApplicationForks: function() {
+        let { forks } = this.attributes.metrics;
+        return forks || 0;
+    },
+
+    getInstancesTotal: function() {
+        let { instances } = this.attributes.metrics;
+        return instances ? instances.total : 0;
+    },
+
+    getInstancesSuccess: function() {
+        let { instances } = this.attributes.metrics;
+        return instances ? instances.success : 0;
+    },
+
+    getInstancesPercent: function() {
+        let { instances } = this.attributes.metrics;
+        if (instances) {
+            let percent = instances.percent;
+            return (percent) ? percent.toFixed(3) : 0;
+        } else {
+            return 0;
+        }
     }
 });

--- a/troposphere/static/js/public_site/bootstrapper.jsx
+++ b/troposphere/static/js/public_site/bootstrapper.jsx
@@ -33,6 +33,7 @@ stores.ImageStore = require("stores/ImageStore");
 stores.ImageMetricsStore = require("stores/ImageMetricsStore");
 stores.ImageBookmarkStore = require("stores/ImageBookmarkStore");
 stores.ImageVersionStore = require("stores/ImageVersionStore");
+stores.PatternMatchStore = require("stores/PatternMatchStore");
 stores.TagStore = require("stores/TagStore");
 stores.HelpLinkStore = require("stores/HelpLinkStore");
 


### PR DESCRIPTION
## Description

The `<ImageDetailsPage />` and `<ImageDetailsView />` did not handle the usage scenario for Public Image Catalog

Changes made in this pull request:

- Include PatternMatchStore in public site's `stores`
- Exclude PatternMatchStore from "ready to render" check
- Only attempt to show Image Stats when logged in (and, for staff only)

Relates to #706 work ... 

## Checklist before merging Pull Requests
- [ ] ~New test(s) included to reproduce the bug/verify the feature~
- [ ] ~Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Reviewed and approved by at least one other contributor.
- [ ] ~New variables supported in Clank~
- [ ] ~New variables committed to secrets repos~
