### PR TITLE
Problem: Version of instance not visible after launch

### DIFF
--- a/troposphere/static/js/components/projects/resources/instance/details/sections/details/CreatedFrom.jsx
+++ b/troposphere/static/js/components/projects/resources/instance/details/sections/details/CreatedFrom.jsx
@@ -15,19 +15,29 @@ export default React.createClass({
     },
 
     render: function() {
+        //Future-FIXME: Include bootable volume support && link.
         var instance = this.props.instance,
-            image = stores.ImageStore.get(instance.get("image").id);
+            instance_image = instance.get("image"),
+            version = instance.get('version'),
+            version_separator = "v.",  // Future-FIXME: This is a configurable in atmosphere that could be passed through clank and used..
+            image_name = "",
+            version_name = "",
+            label = "",
+            image = (instance_image) ? stores.ImageStore.get(instance_image.id) : null; //Bootable volumes have no image ID..
 
-        if (!image) {
+        if(!instance_image || !image) {
             return (
             <div className="loading-tiny-inline"></div>
             );
         }
+        image_name = image.get('name');
+        version_name = (version && version.name) ? version.name : "";
+        label = (version_name) ? image_name+" "+version_separator+version_name : image_name;
 
         return (
         <ResourceDetail label="Based on">
             <Link to={`images/${image.id}`}>
-                {image.get("name")}
+                {label}
             </Link>
         </ResourceDetail>
         );


### PR DESCRIPTION
## Solution: Include version in the Instance Details page.

- Safety-checks to avoid failing on bootable volumes.
- Future-FIXMEs added as a reminder to include additional support for bootable volumes.

## Checklist before merging Pull Requests
- [x] Reviewed and approved by at least one other contributor.
- [x] Create [JIRA ticket](https://pods.iplantcollaborative.org/jira/browse/ATMO-2049) for Future-FIXME items.