### PR TITLE
Problem: Emulated sessions are not flagged for Sentry

### DIFF
--- a/troposphere/static/js/components/Master.jsx
+++ b/troposphere/static/js/components/Master.jsx
@@ -114,6 +114,12 @@ export default React.createClass({
             email: profile.get('email'),
             username: profile.get('username'),
         }
+
+        if (context.hasEmulatedSession()) {
+            userContext.emulated = true;
+            userContext.emulator = context.getEmulator();
+        }
+
         Raven.setUserContext(userContext);
         Raven.setTagsContext(window.SENTRY_TAGS);
     },

--- a/troposphere/static/js/context.js
+++ b/troposphere/static/js/context.js
@@ -8,6 +8,9 @@ export default {
     getMaintenanceNotice: function() {
         return window.maint_notice;
     },
+    getEmulator: function() {
+        return window.emulator;
+    },
     hasEmulatedSession: function() {
         return window.emulator && window.emulator_token;
     },


### PR DESCRIPTION
## Description

If we are emulating another community member, include the emulator and
a flag indicating that this is an emulated session.

## Checklist before merging Pull Requests
- [ ] ~New test(s) included to reproduce the bug/verify the feature~
- [ ] ~Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Reviewed and approved by at least one other contributor.
- [ ] ~New variables supported in Clank~
- [ ] ~New variables committed to secrets repos~
