### PR TITLE
Problem: For Instance Launch, error(s) occur trying to "Save and Add Script"

### DIFF
--- a/troposphere/static/js/components/common/boot_script/CreateScript.jsx
+++ b/troposphere/static/js/components/common/boot_script/CreateScript.jsx
@@ -3,20 +3,21 @@ import RaisedButton from "material-ui/RaisedButton";
 import actions from "actions";
 
 export default React.createClass({
+    propTypes: {
+        style: React.PropTypes.object,
+        close: React.PropTypes.func.isRequired,
+        onCreate: React.PropTypes.func.isRequired,
+    },
+
     getInitialState: function() {
         return ({
             type: "URL",
             strategy: "always",
+            wait_for_deploy: true,
             title: "",
             text: "",
             validate: false
         })
-    },
-
-    propTypes: {
-        style: React.PropTypes.object,
-        close: React.PropTypes.func.isRequired,
-        onCreate: React.PropTypes.func.isRequired
     },
 
     getDefaultProps: function() {
@@ -36,6 +37,13 @@ export default React.createClass({
         let type = e.target.value;
         this.setState({
             type
+        })
+    },
+
+    onChangeDeployment: function(e) {
+        let deployType = e.target.value === "sync";
+        this.setState({
+            wait_for_deploy: deployType
         })
     },
 
@@ -78,8 +86,10 @@ export default React.createClass({
                 type: this.state.type,
                 title: this.state.title.trim(),
                 text: this.state.text.trim(),
-                strategy: this.state.strategy.trim()
+                strategy: this.state.strategy.trim(),
+                wait_for_deploy: this.state.wait_for_deploy
             });
+
             this.props.onCreate(script);
             this.props.close();
         }
@@ -186,7 +196,7 @@ export default React.createClass({
 
         return (
 
-        <div style={{ position: "reletive" }}>
+        <div>
             <h3 className="t-subheading">Create and Add a New Script</h3>
             <hr/>
             <div className="row">
@@ -202,43 +212,65 @@ export default React.createClass({
                             onBlur={this.onBlurTitle} />
                         <span className="help-block">{errorMessage}</span>
                     </div>
-                    <h4 className="t-body-2">Input Type</h4>
-                    <div className="radio-inline">
-                        <label className="radio">
-                            <input type="radio"
-                                name="optionsRadios"
-                                value="URL"
-                                defaultChecked={this.state.type === "URL"}
-                                onClick={this.onChangeType} /> URL
-                        </label>
-                    </div>
-                    <div className="radio-inline">
-                        <label className="radio">
-                            <input type="radio"
-                                name="optionsRadios"
-                                value="Raw Text"
-                                defaultChecked={this.state.type === "Raw Text"}
-                                onClick={this.onChangeType} /> Raw Text
-                        </label>
-                    </div>
-                    <h4 className="t-body-2">Boot Script Type</h4>
-                    <div className="radio-inline">
-                        <label className="radio">
-                            <input type="radio"
-                                name="optionsRadios-2"
-                                value="once"
-                                defaultChecked={this.state.strategy === "once"}
-                                onClick={this.onChangeStrategy} /> {"Run script on first boot"}
-                        </label>
-                    </div>
-                    <div className="radio-inline">
-                        <label className="radio">
-                            <input type="radio"
-                                name="optionsRadios-2"
-                                value="always"
-                                defaultChecked={this.state.strategy === "always"}
-                                onClick={this.onChangeStrategy} /> {"Run script on each deployment"}
-                        </label>
+                    <div className={classNames}>
+                        <h4 className="t-body-2">Input Type</h4>
+                        <div className="radio-inline">
+                            <label className="radio">
+                                <input type="radio"
+                                       name="optionsRadios"
+                                       value="URL"
+                                       defaultChecked={this.state.type === "URL"}
+                                       onClick={this.onChangeType} /> URL
+                            </label>
+                        </div>
+                        <div className="radio-inline">
+                            <label className="radio">
+                                <input type="radio"
+                                       name="optionsRadios"
+                                       value="Raw Text"
+                                       defaultChecked={this.state.type === "Raw Text"}
+                                       onClick={this.onChangeType} /> Raw Text
+                            </label>
+                        </div>
+                        <h4 className="t-body-2">Execution Strategy Type</h4>
+                        <div className="radio">
+                            <label className="radio">
+                                <input type="radio"
+                                       name="strategyTypeRadios"
+                                       value="once"
+                                       defaultChecked={this.state.strategy === "once"}
+                                       onClick={this.onChangeStrategy} /> {"Run script on first boot"}
+                            </label>
+                        </div>
+                        <div className="radio">
+                            <label className="radio">
+                                <input type="radio"
+                                       name="strategyTypeRadios"
+                                       value="always"
+                                       defaultChecked={this.state.strategy === "always"}
+                                       onClick={this.onChangeStrategy} /> {"Run script on each deployment"}
+                            </label>
+                        </div>
+                        <h4 className="t-body-2">Deployment Type</h4>
+                        <div className="radio">
+                            <label className="radio">
+                                <input type="radio"
+                                       name="deploymentTypeRadios"
+                                       value="once"
+                                       defaultChecked={this.state.wait_for_deploy}
+                                       onClick={this.onChangeDeployment} /> {"Wait for script to complete"}
+                            </label>
+                        </div>
+                        <div className="radio">
+                            <label className="radio">
+                                <input type="radio"
+                                       name="deploymentTypeRadios"
+                                       value="always"
+                                       defaultChecked={!this.state.wait_for_deploy}
+                                       onClick={this.onChangeDeployment} /> {"Execute script asynchronously"}
+                            </label>
+                        </div>
+
                     </div>
                 </div>
                 <div className="col-md-6">

--- a/troposphere/static/js/components/common/boot_script/EditScript.jsx
+++ b/troposphere/static/js/components/common/boot_script/EditScript.jsx
@@ -134,10 +134,11 @@ export default React.createClass({
 
             return (
             <div className={classNames}>
-                <label>
+                <label htmlFor="script-url">
                     Script URL
                 </label>
-                <input className="form-control"
+                <input id="script-url"
+                    className="form-control"
                     placeholder="http://yourscript.org"
                     value={this.state.text}
                     onChange={this.onChangeText}
@@ -156,11 +157,12 @@ export default React.createClass({
             }
 
             return (
-            <div className={classNames}>
-                <label>
+            <div className={classNames} >
+                <label htmlFor="script-raw-text">
                     Raw Text
                 </label>
-                <textarea className="form-control"
+                <textarea id="script-raw-text"
+                    className="form-control"
                     placeholder="#!/bin/bash"
                     rows="6"
                     value={this.state.text}
@@ -245,15 +247,15 @@ export default React.createClass({
             <div className="help-block">
                 {"Stdout will be logged on the VM at: "}
                 <br/>
-                {stdoutPath}
+                <code>{stdoutPath}</code>
                 <br/>
                 {"Stderr will be logged on the VM at: "}
                 <br/>
-                {stderrPath}
+                <code>{stderrPath}</code>
             </div>
         );
-
     },
+
     renderDeploymentOptions() {
         // deploymentType is a key into options 'type', i.e. ("sync","async",...)
         let options = [
@@ -304,13 +306,12 @@ export default React.createClass({
     },
 
     render: function() {
-        let classNames = "form-group";
-        let errorMessage = null;
-        let notSubmittable = false;
-        let headerText = (this.props.script) ? "Edit Script" : "Create Script";
-        let {title} = this.state;
+        let { title } = this.state;
 
-
+        let classNames = "form-group",
+            headerText = (this.props.script) ? "Edit Script" : "Create Script",
+            errorMessage = null,
+            notSubmittable = false;
 
         if (this.state.validate) {
             if (!this.isValidString(title)) {
@@ -324,24 +325,30 @@ export default React.createClass({
         <div style={this.props.style}>
             <h3 className="t-subheading">{headerText}</h3>
             <hr/>
-            <div className="row">
+            <div>
                 <div className={classNames}>
                     <label>{"Script Title"}</label>
                     <input className="form-control"
                         placeholder="My Script"
-                        value={this.state.title}
+                        value={title}
                         onChange={this.onChangeTitle}
                         onBlur={this.onBlurTitle} />
                     <span className="help-block">{errorMessage}</span>
                 </div>
                 <h4 className="t-body-2">{"Strategy"}</h4>
+                <div className={classNames}>
                 { this.renderStrategyOptions() }
+                </div>
                 <h4 className="t-body-2">{"Deployment"}</h4>
+                <div className={classNames}>
                 { this.renderDeploymentOptions() }
                 { this.renderDeploymentOptionsHint() }
+                </div>
                 <h4 className="t-body-2">{"Input Type"}</h4>
+                <div className={classNames}>
                 {this.renderInputOptions()}
-                <div className="col-md-6">
+                </div>
+                <div>
                     {this.renderInputType()}
                 </div>
             </div>

--- a/troposphere/static/js/components/modals/instance/launch/components/BootScriptOption.jsx
+++ b/troposphere/static/js/components/modals/instance/launch/components/BootScriptOption.jsx
@@ -38,7 +38,9 @@ export default React.createClass({
 
     renderCreateScript: function() {
         return (
-        <CreateScript {...this.props} close={this.onCloseCreateScript} />
+        <CreateScript {...this.props}
+            close={this.onCloseCreateScript}
+            onCreate={this.props.onAddAttachedScript} />
         )
     },
 

--- a/troposphere/static/js/components/modals/script/ScriptCreateModal.jsx
+++ b/troposphere/static/js/components/modals/script/ScriptCreateModal.jsx
@@ -38,7 +38,9 @@ export default React.createClass({
                 <div className="modal-content">
                     <div className="modal-header">
                         {this.renderCloseButton()}
-                        <h1 className="t-title">{(this.props.script) ? "Update Deployment Script" : "Add a new Deployment Script"}</h1>
+                        <h1 className="t-title">
+                            {(this.props.script) ? "Update Deployment Script" : "Add New Deployment Script"}
+                        </h1>
                     </div>
                     <div className="modal-body">
                         {this.renderBody()}

--- a/troposphere/static/js/components/settings/advanced/ScriptListView.jsx
+++ b/troposphere/static/js/components/settings/advanced/ScriptListView.jsx
@@ -22,6 +22,7 @@ const ScriptListView = React.createClass({
             //Do this on success.
         });
     },
+
     destroyScript: function(script) {
 
         // EmitChange is responsible for triggering the rerender, which
@@ -73,8 +74,10 @@ const ScriptListView = React.createClass({
                 {script.get("type")}
             </td>
             <td>
-                <a onClick={this.editScript.bind(this, script)}><i className="glyphicon glyphicon-pencil" /></a>{" "}
-                <a onClick={this.destroyScript.bind(this, script)}><i style={{ color: "crimson" }} className="glyphicon glyphicon-trash" /></a>
+                <a onClick={this.editScript.bind(this, script)}>
+                    <i className="glyphicon glyphicon-pencil" /></a>{" "}
+                <a onClick={this.destroyScript.bind(this, script)}>
+                    <i style={{ color: "crimson" }} className="glyphicon glyphicon-trash" /></a>
             </td>
         </tr>
         );
@@ -89,7 +92,7 @@ const ScriptListView = React.createClass({
 
         return (
             <div>
-                <h3>Boot Scripts</h3>
+                <h3>Deployment Scripts (formerly Boot Scripts)</h3>
                 <div style={{maxWidth: "600px"}}>
                     <p>
                         Use the table below to create and/or edit existing


### PR DESCRIPTION
## Description

Changes related to PR #703 caused an error when using the Advanced Options of Instance Launch Modal when trying to "Save and Add" a new script (Deployment Script, aka Boot Script).

The error was three fold:

- the new Deployment type value modeled in this.state
- no handler for `onCreate` was passed, *required*
- no form-element present to choose Deployment type

This area is _hidden_ within the app, but is accessible via an hyperlink after an Image is selected.

To understand where the error is/was, here are step to reproduced:
- Go to Projects tab
- Select any Project
- Click "NEW > Instance"
- Select any Image
- Click on "Advanced Options" in bottom, left of modal
- Click on "Create a New Script"

This work resolves the issue and restores the expect flow for creating new scripts via this "advanced" selection flow.

See also [ATMO-2023](https://pods.iplantcollaborative.org/jira/browse/ATMO-2023)

<details>

## After the fix ... 

Here is a screen capture showing the work done in this pull request:
- http://recordit.co/m8igBGUPIc/

## Markup Changes for "Add New Deployment Script" Modal

![screen shot 2017-10-07 at 12 50 45 pm](https://user-images.githubusercontent.com/5923/31311318-7a2beca2-ab5e-11e7-845c-89b50a807acd.png)
