### PR TITLE
Problem: Cannot add a software license to a ImageVersion

### DIFF
--- a/troposphere/static/js/actions/ImageVersionLicenseActions.js
+++ b/troposphere/static/js/actions/ImageVersionLicenseActions.js
@@ -16,7 +16,7 @@ export default {
             imageVersionLicense = new ImageVersionLicense(),
             data = {
                 image_version: image_version.id,
-                license: license.uuid
+                license: license.get("uuid")
             };
 
         imageVersionLicense.save(null, {


### PR DESCRIPTION
## Description

This fixes an error that occurs when trying to add a software license to an Image Version. 

There is no `license.uuid`, it's `undefined`. But the Model object has a `uuid` attribute that can be retrieved via `license.get("uuid")`. 

<details>

## Example of the error ... 

![screen shot 2017-11-28 at 4 01 14 pm](https://user-images.githubusercontent.com/5923/33348973-77ee0a72-d455-11e7-86e8-5e9ba3b54983.png)

</details>

## Checklist before merging Pull Requests
- [ ] ~New test(s) included to reproduce the bug/verify the feature~
- [ ] ~Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Reviewed and approved by at least one other contributor.
- [ ] ~New variables supported in Clank~
- [ ] ~New variables committed to secrets repos~
