### PR TITLE
Problem: cannot associated DOI with Image Version

### DIFF
--- a/troposphere/static/js/actions/ImageVersionLicenseActions.js
+++ b/troposphere/static/js/actions/ImageVersionLicenseActions.js
@@ -16,7 +16,7 @@ export default {
             imageVersionLicense = new ImageVersionLicense(),
             data = {
                 image_version: image_version.id,
-                license: license.uuid
+                license: license.get("uuid")
             };
 
         imageVersionLicense.save(null, {

--- a/troposphere/static/js/components/images/detail/versions/Version.jsx
+++ b/troposphere/static/js/components/images/detail/versions/Version.jsx
@@ -2,7 +2,6 @@ import React from "react";
 import Backbone from "backbone";
 import CryptoJS from "crypto-js";
 
-import Glyphicon from 'components/common/Glyphicon';
 import Gravatar from "components/common/Gravatar";
 import Ribbon from "components/common/Ribbon";
 import MediaCard from "components/common/ui/MediaCard";

--- a/troposphere/static/js/components/images/detail/versions/Version.jsx
+++ b/troposphere/static/js/components/images/detail/versions/Version.jsx
@@ -2,10 +2,12 @@ import React from "react";
 import Backbone from "backbone";
 import CryptoJS from "crypto-js";
 
+import Glyphicon from 'components/common/Glyphicon';
 import Gravatar from "components/common/Gravatar";
 import Ribbon from "components/common/Ribbon";
 import MediaCard from "components/common/ui/MediaCard";
 import AvailabilityView from "../availability/AvailabilityView";
+import { Pill } from 'cyverse-ui';
 
 import stores from "stores";
 import context from "context";
@@ -131,6 +133,24 @@ export default React.createClass({
        );
     },
 
+    renderDocObjectId() {
+        let { version } = this.props,
+            hasDOI = version && version.hasDOI(),
+            doi = version ? version.get("doc_object_id") : "",
+            doiLink = null;
+
+        if (hasDOI) {
+            doiLink = (
+                <a href={`https://doi.org/${doi}`}>{`${doi}`}</a>
+            );
+        }
+        return (
+            <div style={{marginBottom: "15px"}}>
+                <strong>{`DOI: `}</strong>{doiLink}
+            </div>
+        );
+    },
+
     renderSummary() {
         let { version } = this.props;
         let styles = this.styles();
@@ -176,6 +196,7 @@ export default React.createClass({
         <div style={ styles.content }>
             { this.renderEndDated() }
             { this.renderChangeLog() }
+            { this.renderDocObjectId() }
             <div style={ styles.availability } >
                 { providerAvailability }
             </div>
@@ -195,12 +216,18 @@ export default React.createClass({
 
     render() {
         // todo: figure out if anything is ever recommended, or if it's just a concept idea
-        let { version, image } = this.props;
+        let { version, image } = this.props,
+            versionHash = CryptoJS.MD5(version.id.toString()).toString(),
+            type = stores.ProfileStore.get().get("icon_set"),
+            owner = image.get("created_by").username,
+            date = this.renderDateString(version);
 
-        let versionHash = CryptoJS.MD5(version.id.toString()).toString();
-        let type = stores.ProfileStore.get().get("icon_set");
-        let owner = image.get("created_by").username;
-        let date = this.renderDateString(version);
+        let title = !version.hasDOI() ? version.get("name") : (
+            <span>
+                {`${ version.get("name")} `}
+                <Pill>DOI</Pill>
+            </span>
+        );
 
         let subheading =  (
             <span>
@@ -213,7 +240,7 @@ export default React.createClass({
             <MediaCard
                 onCardClick={ this.onCardClick }
                 isOpen={ this.state.isOpen }
-                title={ version.get("name") }
+                title={ title }
                 subheading={ subheading }
                 avatar={
                     <Gravatar

--- a/troposphere/static/js/components/images/detail/versions/VersionList.jsx
+++ b/troposphere/static/js/components/images/detail/versions/VersionList.jsx
@@ -34,7 +34,7 @@ export default React.createClass({
     },
     onCompletedEdit: function(version, name, changeLog, end_date,
                               canImage, image, minCPU, minMem,
-                              versionMembership) {
+                              versionMembership, docObjectId) {
         if (end_date) {
             // Move from datestring to ISO string
             end_date = new Date(Date.parse(end_date)).toISOString()
@@ -49,7 +49,8 @@ export default React.createClass({
             image: image.id,
             min_cpu: minCPU,
             min_mem: minMem,
-            membership: versionMembership
+            membership: versionMembership,
+            doc_object_id: docObjectId
         });
     },
     renderVersion: function(version) {

--- a/troposphere/static/js/components/modals/image_version/ImageVersionEditModal.jsx
+++ b/troposphere/static/js/components/modals/image_version/ImageVersionEditModal.jsx
@@ -9,6 +9,7 @@ import EditMembershipView from "./membership/EditMembershipView";
 import EditLicensesView from "./licenses/EditLicensesView";
 import EditScriptsView from "./scripts/EditScriptsView";
 import EditMinimumRequirementsView from "./requirements/EditMinimumRequirementsView";
+import AddDocumentObjectIdentifier from "./doc_object_id/AddDocumentObjectIdentifier";
 import ImageSelect from "components/modals/image_version/ImageSelect";
 import stores from "stores";
 import actions from "actions";
@@ -43,6 +44,7 @@ export default React.createClass({
             versionCanImage: version.get("allow_imaging"),
             versionParentID: (parent_version == null) ? "" : parent_version.id,
             versionLicenses: null,
+            docObjectId: version.get("doc_object_id"),
             versionScripts: null,
             versionMemberships: null,
             versionMinCPU: (version.get("min_cpu") == null) ? 0 : version.get("min_cpu"),
@@ -159,7 +161,8 @@ export default React.createClass({
             this.state.versionMinCPU,
             // convert RAM to MB
             this.state.versionMinMem * 1024,
-            this.state.versionMembership
+            this.state.versionMembership,
+            this.state.docObjectId
         );
     },
 
@@ -322,7 +325,11 @@ export default React.createClass({
         }
     },
 
-
+    onDocObjectIdChange: function(doi) {
+        this.setState({
+            docObjectId: doi
+        });
+    },
 
     //
     //
@@ -423,6 +430,13 @@ export default React.createClass({
 
     },
 
+    renderDocObjectIdView: function () {
+        return (
+            <AddDocumentObjectIdentifier currentDOI={this.state.docObjectId}
+                                         onChange={this.onDocObjectIdChange} />
+        );
+    },
+
     renderAdvancedOptions: function() {
 
         return (
@@ -432,6 +446,8 @@ export default React.createClass({
                 {this.renderMembershipsView()}
                 <hr />
                 {this.renderLicenseView()}
+                <hr />
+                {this.renderDocObjectIdView()}
                 <hr />
                 {this.renderScriptsView()}
                 <hr />

--- a/troposphere/static/js/components/modals/image_version/doc_object_id/AddDocumentObjectIdentifier.jsx
+++ b/troposphere/static/js/components/modals/image_version/doc_object_id/AddDocumentObjectIdentifier.jsx
@@ -1,0 +1,152 @@
+import React from "react";
+
+/**
+ * https://regex101.com/r/2wzS9M/1
+ */
+const doiRegex = /\b(10\.[0-9]{4,}(?:\.[0-9]+)*\/(?:(?![\"&\'])\S)+)\b/im;
+
+
+
+const AddDocumentObjectIdentifier = React.createClass({
+    displayName: "AddDocumentObjectIdentifier",
+
+    propTypes: {
+        currentDOI: React.PropTypes.string,
+        onChange: React.PropTypes.func.isRequired
+    },
+
+    getInitialState: function() {
+        return {
+            doi: this.props.currentDOI || "",
+            invalid: false
+        };
+    },
+
+    onChange: function(e) {
+        /**
+         * It seems like one of the shortest DOIs you could
+         * have, and be valid, is about 8 characters.
+         * For the CyVerse Data Commons, you see DOIs like:
+         *
+         *   10.7946/P23011
+         *
+         * So, we'll avoid doing a regular expression "test"
+         * until we have a DOI over 8 characters
+         */
+        let doiInput = e.target.value,
+            shouldTest = doiInput && doiInput.length > 8;
+
+        // validate it with the regex ...
+        // if valid ... setState
+        if (shouldTest && doiRegex.test(doiInput)) {
+            this.setState({
+                doi: doiInput,
+                invalid: false
+            });
+            if (this.props.onChange) {
+                this.props.onChange(doiInput);
+            }
+        } else if (shouldTest) {
+            this.setState({
+                doi: doiInput,
+                invalid: true
+            });
+        } else {
+            this.setState({
+                doi: doiInput,
+            });
+        }
+
+    },
+
+    onBlur: function(e) {
+        let doiInput = e.target.value;
+
+        if (doiRegex.test(doiInput)) {
+            this.setState({
+                doi: doiInput,
+                invalid: false,
+                // indicate we've exited so a "green", okay can be shown
+                success: true
+            });
+            if (this.props.onChange) {
+                this.props.onChange(doiInput);
+            }
+        } else {
+            let invalid = doiInput && doiInput.length > 0;
+
+            this.setState({
+                doi: doiInput,
+                invalid
+            });
+            /**
+             * only inform callback the DOI is "cleared" out
+             *
+             * we're looking to avoid "bubbling" up invalid
+             * DOIs to the parent component, so only signal
+             * a change when this is a "removal" change.
+             */
+            if (doiInput == "" && this.props.onChange) {
+                this.props.onChange(doiInput);
+            }
+        }
+    },
+
+    render() {
+        let title = "Document Object Identifier (DOI)",
+            helpMessage = null,
+            hasValidationClass = null;
+
+        let { doi, invalid, success } = this.state;
+
+        let btnStyle = {
+            lineHeight: "1.47",
+            borderTopRightRadius: "5px",
+            borderBottomRightRadius: "5px"
+        };
+
+        if (invalid) {
+            helpMessage = "Value provided is not a valid DOI";
+            hasValidationClass = "has-error";
+        } else if (success) {
+            helpMessage = (
+                <span>
+                    <i className="glyphicon glyphicon-ok" /> {" Valid DOI"}
+                </span>
+            );
+            hasValidationClass = "has-success";
+        }
+
+        return (
+        <div>
+            <h4 className="t-body-2">{title}</h4>
+            <div className="help-block">
+                <p>
+                If you have a Document Object Identifier (DOI) issued by a journal or
+                organization the represents this image version, you can associated it
+                with this image version by entering it in the field below.
+                </p>
+            </div>
+            <div className="alert alert-info">
+                <p className="info">
+                CyVerse will offer DOI issuance for virtual machine images in the future.
+                </p>
+            </div>
+            <div className={"form-group " + hasValidationClass }>
+                <input id="doiInput"
+                       type="text"
+                       className="form-control"
+                       value={doi}
+                       onChange={this.onChange}
+                       onBlur={this.onBlur} />
+                <span className="help-block">{helpMessage}</span>
+            </div>
+        </div>
+        );
+    },
+
+
+
+});
+
+export default AddDocumentObjectIdentifier;

--- a/troposphere/static/js/components/modals/image_version/doc_object_id/AddDocumentObjectIdentifier.jsx
+++ b/troposphere/static/js/components/modals/image_version/doc_object_id/AddDocumentObjectIdentifier.jsx
@@ -1,7 +1,8 @@
 import React from "react";
 
 /**
- * https://regex101.com/r/2wzS9M/1
+ * An explanation of the regular expression below, by 'component' is
+ * available at: https://regex101.com/r/2wzS9M/1
  */
 const doiRegex = /\b(10\.[0-9]{4,}(?:\.[0-9]+)*\/(?:(?![\"&\'])\S)+)\b/im;
 
@@ -98,12 +99,6 @@ const AddDocumentObjectIdentifier = React.createClass({
             hasValidationClass = null;
 
         let { doi, invalid, success } = this.state;
-
-        let btnStyle = {
-            lineHeight: "1.47",
-            borderTopRightRadius: "5px",
-            borderBottomRightRadius: "5px"
-        };
 
         if (invalid) {
             helpMessage = "Value provided is not a valid DOI";

--- a/troposphere/static/js/models/ImageVersion.js
+++ b/troposphere/static/js/models/ImageVersion.js
@@ -37,5 +37,10 @@ export default Backbone.Model.extend({
         }
 
         return result;
+    },
+
+    hasDOI: function() {
+        // convert value to a Boolean when returned
+        return !!this.get("doc_object_id");
     }
 });


### PR DESCRIPTION
## Description

Leverage API changes from: https://github.com/cyverse/atmosphere/pull/553

This allows a Document Object Identifier (DOI) issued by an external entity (Institution, Journal, etc) to be associated with a version of an Image within Atmosphere. 

This is done by editing the ImageVersion from the ImageDetail page (see details for screenshots). The interaction define by this pull request can be seen in an animated screen capture [here](http://recordit.co/3TIBiGLIvP). This includes resolving the DOI as a clickable hyperlink within the opened ImageVersion detail section.

See [ATMO-1531](https://pods.iplantcollaborative.org/jira/browse/ATMO-1531).

<details>

## Interaction

Associating a DOI with an ImageVersion is captured here: http://recordit.co/3TIBiGLIvP

## Valid DOI format indication

<img width="647" alt="atmo-1531-input-doi-valid" src="https://user-images.githubusercontent.com/5923/33458449-7ed66548-d5e3-11e7-9a93-70650098e56a.png">

## Invalid DOI format indication

<img width="650" alt="atmo-1531-input-doi-invalid" src="https://user-images.githubusercontent.com/5923/33458448-7ebe1844-d5e3-11e7-8eca-b223aaa1ab54.png">

## DOI indicator

The presence of a DOI on an ImageVersion is indicated by including "pill" after version number.

<img width="789" alt="atmo-1531-image-version-closed-with-pill" src="https://user-images.githubusercontent.com/5923/33458450-7eeb1bfa-d5e3-11e7-9021-90fee97fa8fc.png">

## DOI as clickable hyperlink

When the ImageVersion component is open, the DOI is the label text is hyperlinked (via  an anchor tag). This resolves with doi.org, and points to the landing page indicated when "issued" with the external entity ([hyperlink guidelines](https://www.crossref.org/display-guidelines/)).

<img width="796" alt="atmo-1531-image-version-open-with-doi-as-hyperlink" src="https://user-images.githubusercontent.com/5923/33458451-7efbacea-d5e3-11e7-9014-83aa67d25f83.png">

</details>

## Checklist before merging Pull Requests
- [ ] ~New test(s) included to reproduce the bug/verify the feature~
- [ ] ~Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [x] Reviewed and approved by at least one other contributor.
- [ ] ~New variables supported in Clank~
- [ ] ~New variables committed to secrets repos~
