### PR TITLE
Filter quota section to only show active identities

### DIFF
--- a/troposphere/static/js/components/admin/ResourceRequest/ResourceRequestView.jsx
+++ b/troposphere/static/js/components/admin/ResourceRequest/ResourceRequestView.jsx
@@ -72,8 +72,16 @@ export default React.createClass({
         let { identities, onIdentitySave: onSave } = this.props;
         let { section } = this.style();
 
-        let body = <p>There are no identities</p>;
+        // Filter identities to only include active identities
         if (identities) {
+            identities = identities.filter(i => i.get("provider").active);
+        }
+
+        // Before identities load, render empty string
+        let body = "";
+        if (identities && identities.length === 0) {
+            body = <p>This user doesn't have access to any active providers</p>;
+        } else if (identities) {
             body = identities.map(identity => {
                 let id = identity.get("id");
                 let props = {
@@ -85,7 +93,7 @@ export default React.createClass({
                     <IdentityView { ...props}/>
                 </div>
                 )
-            })
+            });
         }
 
         return (


### PR DESCRIPTION
## Description

This change affects the quota section under _Update the user's current resources_
![image](https://user-images.githubusercontent.com/3847314/33630043-337a9fe0-d9c3-11e7-8d54-de99fc7b4dbc.png)

Problem: The quota section contains providers that are no longer active
Solution: Filter the section to remove inactive providers
## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature
- [x] Reviewed and approved by at least one other contributor.
- [ ] New variables supported in Clank
- [ ] New variables committed to secrets repos
