### PR TITLE
Revert "Remove the admin_url, which is no longer included"

### DIFF
--- a/troposphere/static/js/actions/HelpActions.js
+++ b/troposphere/static/js/actions/HelpActions.js
@@ -62,12 +62,14 @@ export default {
             actions.BadgeActions.askSupport();
         }
 
-        var data = {
+        let admin_url = window.location.origin + "/application/admin/resource-requests/";
+        let data = {
             request: params.quota,
-            description: params.reason
+            description: params.reason,
+            admin_url: admin_url
         };
 
-        var requestUrl = globals.API_V2_ROOT + "/resource_requests";
+        let requestUrl = globals.API_V2_ROOT + "/resource_requests";
 
         $.ajax(requestUrl, {
             type: "POST",


### PR DESCRIPTION
Problem: attempt at removing RT from resource request approval was too ambitious
Solution: send resource requests to RT

We are going to continue sending resource requests to RT until the admin
resource request view is a closer replacement. Right now there's no way to
view closed requests and no way to reach out to the user for clarification.

This reverts commit acbf080.

Dependent pr https://github.com/cyverse/atmosphere/pull/555
## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature
- [x] Reviewed and approved by at least one other contributor.
- [ ] New variables supported in Clank
- [ ] New variables committed to secrets repos
