### PR TITLE
Fix admin cannot update another user's identity

### DIFF
--- a/troposphere/static/js/components/admin/ResourceRequest/ResourceRequest.jsx
+++ b/troposphere/static/js/components/admin/ResourceRequest/ResourceRequest.jsx
@@ -62,17 +62,24 @@ export default React.createClass({
 
     onIdentitySave(identity) {
         let { selectedRequest: request } = this.props;
+        let username = request.get("created_by").username;
         let quota = new Quota(_.omit(identity.get('quota'), ["id", "uuid"]));
         let promise = Promise.resolve(quota.save())
             .then(
-                () => identity.save({ 'quota': quota.pick("id") }, { patch: true })
+                () => {
+                    // The api expects a username query paramater for an admin
+                    // to update another users' identity. This will be
+                    // changed.
+                    let urlByUsername = `${identity.url()}?username=${username}`;
+                    return identity.save({ 'quota': quota.pick("id") }, { patch: true, url: urlByUsername })
+                }
             );
 
         promise
             .then(() => {
                 Utils.dispatch(IdentityConstants.UPDATE, {
                     identity,
-                    username: request.get("created_by").username
+                    username
                 });
             })
             .catch(errorHandler);


### PR DESCRIPTION
## Description

#### Problem
When an admin would save a quota in the admin resource request view, the save would fail.

#### Solution
Pass a username query paramater in the url

#### Background
When the admin clicked 'save', a patch was submitted to /api/v2/identities/<id>. The response was a 404.
Normally that endpoint only operates the current user's identities. Any attempt to request or update another users' identities returns a 404. The current atmosphere implementation expected a query param to be passed: `username`. This signals the api to know that a user (must be an admin) wishes to updates models they don't own.
Because bunching all this functionality into a single end-point doesn't jive with our models/stores. We created api/v2/admin/<model> endpoints so that queryparams don't result in completely different behavior. This hotfix is temporary, and I'll add an admin endpoint/store for identities, so that the requests to update/fetch/save are simple.

## Checklist before merging Pull Requests
- [ ] ~New test(s) included to reproduce the bug/verify the feature~
- [ ] ~Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [x] Reviewed and approved by at least one other contributor.
- [ ] ~New variables supported in Clank~
- [ ] ~New variables committed to secrets repos~
