### PR TITLE
Problem: In Instance History, Instances still "available" do not render detail

### DIFF
--- a/troposphere/static/js/AppRoutes.jsx
+++ b/troposphere/static/js/AppRoutes.jsx
@@ -136,7 +136,7 @@ function AppRoutes(props) {
                 <Route path="resources" component={RequestHistory} />
                 <Route path="images" component={MyImageRequestsPage} />
             </Route>
-            <Route path="instances/:id" component={NewInstanceDetail} />
+            <Route path="instances/:instanceId" component={NewInstanceDetail} />
             <IndexRoute component={DashboardPage} />
             <IndexRedirect to="dashboard" />
         </Route>

--- a/troposphere/static/js/components/common/InstanceDetail.jsx
+++ b/troposphere/static/js/components/common/InstanceDetail.jsx
@@ -123,9 +123,10 @@ const InstanceDetail = React.createClass({
             instances = InstanceStore.getAll(),
             history = null;
 
+        // if we are provided w/ an instance,
+        // then fetch history using provided id in paramas
         if (!instance) {
-            let { instanceId } = this.props.params,
-                instance = instances && instances.get(instanceId);
+            let { instanceId } = this.props.params;
 
             history = InstanceHistoryStore.fetchWhere({
                 "instance": instanceId

--- a/troposphere/static/js/components/common/InstanceDetail.jsx
+++ b/troposphere/static/js/components/common/InstanceDetail.jsx
@@ -37,13 +37,12 @@ const InstanceDetail = React.createClass({
 
     onNewData: function() { this.forceUpdate(); },
 
-    renderAllocationSourceSection() {
-        let instance = this.props.params,
-            instance_username = instance.get('user').username,
-            current_username = context.profile.get('username'),
-            disabled = (current_username != instance_username);
+    renderAllocationSourceSection(instance) {
+        let instanceUsername = instance.get('user').username,
+            currentUsername = context.profile.get('username');
+
         let props = {
-            disabled: disabled,
+            disabled: (currentUsername != instanceUsername),
             instance,
             ...this.props
         }
@@ -54,12 +53,11 @@ const InstanceDetail = React.createClass({
 
 
     renderInactiveInstance: function(history) {
-        let { InstanceStore } = this.props.subscriptions;
-        var instanceHistory = history.first(),
-            instance = instanceHistory.get('instance'),
-            instanceObj = InstanceStore.fetchOne(instance.id, {
-                archived: true,
-            });
+        let { InstanceStore } = this.props.subscriptions,
+            instanceObj = getInstanceObjectFrom(
+                history,
+                InstanceStore
+            );
 
         if(!instanceObj) {
             return <div className="loading" />
@@ -90,7 +88,7 @@ const InstanceDetail = React.createClass({
             ? <InstanceMetricsSection instance={instance} />
             : null;
         var allocationSourceSection = globals.USE_ALLOCATION_SOURCES
-            ? this.renderAllocationSourceSection()
+            ? this.renderAllocationSourceSection(instance)
             : null;
         let project = ProjectStore.get(instance.get('project').id);
         if (!project) {

--- a/troposphere/static/js/components/common/InstanceDetail.jsx
+++ b/troposphere/static/js/components/common/InstanceDetail.jsx
@@ -48,6 +48,7 @@ const InstanceDetail = React.createClass({
             instance,
             ...this.props
         }
+
         return (
         <AllocationSourceSection { ...props }/>
         );
@@ -117,15 +118,32 @@ const InstanceDetail = React.createClass({
     },
 
     render: function() {
-        let { params } = this.props;
-        let { InstanceStore, InstanceHistoryStore } = this.props.subscriptions;
-        let instances = InstanceStore.getAll();
-        let instance = instances && instances.get(params.id);
-        let history = InstanceHistoryStore.fetchWhere({
-            "instance": params.id
-        })
-        if (!history || !instances) {
-            return <div className="loading" />
+        let { instance } = this.props,
+            { InstanceStore, InstanceHistoryStore } = this.props.subscriptions,
+            instances = InstanceStore.getAll(),
+            history = null;
+
+        if (!instance) {
+            let { instanceId } = this.props.params,
+                instance = instances && instances.get(instanceId);
+
+            history = InstanceHistoryStore.fetchWhere({
+                "instance": instanceId
+            });
+        } else {
+            history = InstanceHistoryStore.fetchWhere({
+                "instance": instance.id
+            });
+        }
+
+        // needs to be defined after the assignment location
+        // for `history` or it'll just include `null`
+        let requires = [instances, history];
+
+        // Use truthy check to see if loaded
+        let loaded = requires.every(r => Boolean(r));
+        if (!loaded) {
+            return (<div className="loading" />);
         }
 
         // If we got back active instances, but the instance isn't a member

--- a/troposphere/static/js/components/common/InstanceDetail.jsx
+++ b/troposphere/static/js/components/common/InstanceDetail.jsx
@@ -32,6 +32,8 @@ const InstanceDetail = React.createClass({
     displayName: "InstanceDetail",
 
     propTypes: {
+        // `params` is supplied by React Router when
+        // this component participates in a <Route />:
         params: React.PropTypes.object
     },
 

--- a/troposphere/static/js/components/common/InstanceDetail.jsx
+++ b/troposphere/static/js/components/common/InstanceDetail.jsx
@@ -13,6 +13,21 @@ import InstanceInfoSection from "components/projects/resources/instance/details/
 import InstanceHistorySection from "components/common/InstanceHistorySection";
 
 
+function getInstanceObjectFrom(history, store) {
+    let instanceHistory = history.first(),
+        instance;
+
+    if (instanceHistory) {
+        let ih = instanceHistory.get('instance') || {};
+        instance = store.fetchOne(ih.id, {
+            archived: true,
+        });
+    }
+
+    return instance;
+}
+
+
 const InstanceDetail = React.createClass({
     displayName: "InstanceDetail",
 

--- a/troposphere/static/js/components/projects/InstanceDetailsPage.jsx
+++ b/troposphere/static/js/components/projects/InstanceDetailsPage.jsx
@@ -10,6 +10,12 @@ import stores from "stores";
 export default React.createClass({
     displayName: "InstanceDetailsPage",
 
+    propTypes: {
+        // `params` is supplied by React Router when
+        // this component participates in a <Route />:
+        params: React.PropTypes.object
+    },
+
     componentDidMount() {
         stores.ProjectStore.addChangeListener(this.updateState);
         stores.InstanceStore.addChangeListener(this.updateState);
@@ -54,6 +60,7 @@ export default React.createClass({
         }
 
         let props = {
+            params: this.props.params,
             project,
             instance,
             helpLinks,

--- a/troposphere/static/js/components/projects/resources/instance/details/InstanceDetailsView.jsx
+++ b/troposphere/static/js/components/projects/resources/instance/details/InstanceDetailsView.jsx
@@ -16,7 +16,7 @@ const InstanceDetailsView = React.createClass({
     },
 
     render() {
-        let { instance, project, allocationSources } = this.props;
+        let { instance, project, allocationSources, params } = this.props;
         let { HelpLinkStore } = this.props.subscriptions;
         let helpLinks = HelpLinkStore.getAll();
 
@@ -51,7 +51,8 @@ const InstanceDetailsView = React.createClass({
         }
 
         let props = {
-            params: instance,
+            params,
+            instance,
             project,
             allocationSources,
             helpLinks


### PR DESCRIPTION
## Description

When you try to view an Instance that is still "available" in the cloud ☁️, the rendering will fail.

Solution - ensure that Instances have render-able, viewable details regardless of the 'path' to viewing. 

### Background

The `<InstanceDetail />` component is used in two contexts:

1. as part of Project context views, for "available", non-end_dated instances 
2. as part of Instance History, where instance might be "historic" or available

Let's define some terms in case you're confused!

An `"available"` instance is one that is not deleted. Since we do *not* _delete_ things in Atmosphere, we could also say that there is no "End Date" present. 

An `"historic"` instance is one that has been run, and then "end-dated" (aka deleted, or - if you want to be all cloud-y ☁️ "terminated"). 

#### Why not just say "Active"? 

An "available" instance could be: `stopped`, `suspended`, `shelved`. Those are not "active" states or statuses. 

### Solution

What has been done here is to avoid "misappropriating" `this.props.params` and provide a coherent use of the `props` available to `<InstanceDetails />` (regardless of the render-tree it is in). 

See also [ATMO-2110](https://pods.iplantcollaborative.org/jira/browse/ATMO-2110).

<details>

## Steps to Reproduce

Reproduce the failure:
1. Go to Dashboard
2. Scroll down to "Instance History" section
3. Click on the "hyperlinked name" of an Instance that is "active" ("- Present" in the _Ran:_ line)
4. Observe the page fails to rendering, "loading" animation present

If you got to DevTools Console, you'll see JavaScript Uncaught errors.

"Near-cousin" to the error:
1. Go to Dashboard
2. Scroll down to "Instance History" section
3. Click on the "hyperlinked name" of an Instance that is no longer running (has an end date)
4. Observe the page renders as expected

<img width="552" alt="atmo-2110-scenario" src="https://user-images.githubusercontent.com/5923/34130126-ef8513ce-e403-11e7-9ab9-867e4ead03d0.png">

## Capture the Failure Condition 

Click to view screen capture: http://recordit.co/xmRm9POg9f

## After the Fix

Click to view screen capture: http://recordit.co/m9E9jGzTJ0

*Note:* This includes a warning that is formatted as an error with red text regarding the usage of `isMounted()` in one of the components. The solution is "clean", and does *not* introduce any errors.

</details>


## Checklist before merging Pull Requests
- [ ] ~New test(s) included to reproduce the bug/verify the feature~
- [ ] ~Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [x] Reviewed and approved by at least one other contributor.
- [ ] ~New variables supported in Clank~
- [ ] ~New variables committed to secrets repos~
