### PR TITLE
Problem: terminology/display labels inconsistent for Deployment Scripts

### DIFF
--- a/troposphere/static/js/components/common/boot_script/EditScript.jsx
+++ b/troposphere/static/js/components/common/boot_script/EditScript.jsx
@@ -226,11 +226,13 @@ export default React.createClass({
             wait_for_deploy
         });
     },
+
     onChangeStrategyType: function(strategyOpt) {
         this.setState({
             strategy: strategyOpt.type
         })
     },
+
     onChangeInputType: function(inputOpt) {
         this.setState({
             type: inputOpt.type
@@ -239,17 +241,17 @@ export default React.createClass({
 
     renderDeploymentOptionsHint() {
         if(this.state.wait_for_deploy) {
-            return;
+            return null;
         }
         let stdoutPath = "/var/log/atmo/instance-scripts/"+this.state.title+".YYYY-MM-DD_HH:MM:SS.stdout",
             stderrPath = "/var/log/atmo/instance-scripts/"+this.state.title+".YYYY-MM-DD_HH:MM:SS.stderr";
         return (
             <div className="help-block">
-                {"Stdout will be logged on the VM at: "}
+                {"stdout will be logged on the VM at: "}
                 <br/>
                 <code>{stdoutPath}</code>
                 <br/>
-                {"Stderr will be logged on the VM at: "}
+                {"stderr will be logged on the VM at: "}
                 <br/>
                 <code>{stderrPath}</code>
             </div>
@@ -259,8 +261,16 @@ export default React.createClass({
     renderDeploymentOptions() {
         // deploymentType is a key into options 'type', i.e. ("sync","async",...)
         let options = [
-            { wait_for_deploy: true, type: "sync", message: "Wait for script to complete, ensure exit code 0, email me if there is a failure." },
-            { wait_for_deploy: false, type: "async", message: "Execute scripts asynchronously. Store stdout/stderr to log files." }
+            {
+                wait_for_deploy: true,
+                type: "sync",
+                message: "Sync - wait for script to complete, ensure exit code 0, email me if there is a failure."
+            },
+            {
+                wait_for_deploy: false,
+                type: "async",
+                message: "Async - execute scripts asynchronously. Store stdout/stderr to log files."
+            }
         ];
         let { wait_for_deploy } = this.state;
         let current = options.find(option => option.wait_for_deploy == wait_for_deploy);
@@ -278,8 +288,8 @@ export default React.createClass({
         // strategyType is a key into options 'type', i.e. ("once","always",...)
         let { strategy } = this.state;
         let options = [
-            { type: "once", message: "Run Script on first boot" },
-            { type: "always", message: "Run script on every deployment" }
+            { type: "once", message: "Once - run script on first boot" },
+            { type: "always", message: "Always - run script on every deployment" }
         ];
         let current = options.find(option => option.type == strategy);
         return (
@@ -335,11 +345,11 @@ export default React.createClass({
                         onBlur={this.onBlurTitle} />
                     <span className="help-block">{errorMessage}</span>
                 </div>
-                <h4 className="t-body-2">{"Strategy"}</h4>
+                <h4 className="t-body-2">{"Execution Strategy Type"}</h4>
                 <div className={classNames}>
                 { this.renderStrategyOptions() }
                 </div>
-                <h4 className="t-body-2">{"Deployment"}</h4>
+                <h4 className="t-body-2">{"Deployment Type"}</h4>
                 <div className={classNames}>
                 { this.renderDeploymentOptions() }
                 { this.renderDeploymentOptionsHint() }

--- a/troposphere/static/js/components/settings/advanced/ScriptListView.jsx
+++ b/troposphere/static/js/components/settings/advanced/ScriptListView.jsx
@@ -5,6 +5,21 @@ import ScriptCreateModal from "components/modals/script/ScriptCreateModal";
 
 const ScriptListView = React.createClass({
 
+    getInitialState: function() {
+        return {
+            displayMoreInfo: false,
+        };
+    },
+
+    style() {
+        return {
+            td: {
+                wordWrap: "break-word",
+                whiteSpace: "normal"
+            }
+        }
+    },
+
     launchCreateScriptModal: function() {
         //Open modal, new script
         let props = {};
@@ -44,13 +59,65 @@ const ScriptListView = React.createClass({
         });
     },
 
-    style() {
-        return {
-            td: {
-                wordWrap: "break-word",
-                whiteSpace: "normal"
-            }
+    onDisplayMoreInfo(e) {
+        let { displayMoreInfo } = this.state;
+        e.preventDefault();
+        this.setState({
+            displayMoreInfo: !displayMoreInfo
+        });
+    },
+
+    renderMoreInfo() {
+        let { displayMoreInfo } = this.state;
+
+        if (displayMoreInfo) {
+            let dd = { paddingLeft: "25px" };
+
+            return (
+            <div>
+                <p>
+                    Deployment Scripts have extended functionality that our
+                    community may wish to leverage in new instances or images.
+                </p>
+                <dl style={{margin: "5px 0 10px auto"}}>
+                    <dt>Script Title</dt>
+                    <dd style={dd}>name that will appear when selecting the deployment script</dd>
+                    <dt>Execution Strategy Type</dt>
+                    <dd style={dd}>
+                        <u>Sync</u> - wait for script to complete, ensure
+                        exit code 0, email me if there is a failure.
+                    </dd>
+                    <dd style={dd}>
+                        <u>Async</u> - execute scripts asynchronously.
+                        Store <code>stdout/stderr</code> to log files.
+                    </dd>
+                    <dt>Deployment Type</dt>
+                    <dd style={dd}>
+                        <u>Once</u> - run script on first boot
+                    </dd>
+                    <dd style={dd}>
+                        <u>Always</u> - run script on every deployment
+                    </dd>
+                    <dt>Input Type</dt>
+                    <dd style={dd}>
+                        <u>URL</u> - import script using the provided URL
+                    </dd>
+                    <dd style={dd}>
+                        <u>Text</u> - import script using provided text
+                    </dd>
+                </dl>
+                <p>
+                    Click to <a onClick={this.onDisplayMoreInfo}>hide</a> more information.
+                </p>
+            </div>
+            )
         }
+
+        return (
+            <p>
+                Click <a onClick={this.onDisplayMoreInfo}>here</a> to learn more.
+            </p>
+        );
     },
 
     renderScriptRow: function(script) {
@@ -65,7 +132,9 @@ const ScriptListView = React.createClass({
                 {script.get("title")}
             </td>
             <td style={td}>
-                {script.get("strategy")}
+                <span style={{textTransform:"capitalize"}}>
+                    {script.get("strategy")}
+                </span>
             </td>
             <td style={td}>
                 {script.get("wait_for_deploy") ? "Sync" : "Async" }
@@ -82,6 +151,7 @@ const ScriptListView = React.createClass({
         </tr>
         );
     },
+
     render: function() {
         let {ScriptStore} = this.props.subscriptions,
             boot_scripts = ScriptStore.getAll();
@@ -96,18 +166,19 @@ const ScriptListView = React.createClass({
                 <div style={{maxWidth: "600px"}}>
                     <p>
                         Use the table below to create and/or edit existing
-                        boot scripts. These scripts can be selected
+                        deployment scripts. These scripts can be selected
                         when you launch an instance.
                     </p>
+                    {this.renderMoreInfo()}
                 </div>
                 <div style={{maxWidth: "80%"}}>
                     <table className="clearfix table" style={{ tableLayout: "fixed" }}>
                         <thead>
                             <tr>
-                                <th>Name</th>
-                                <th>Strategy</th>
-                                <th>Deployment</th>
-                                <th>Type</th>
+                                <th>Script Title</th>
+                                <th>Execution Strategy Type</th>
+                                <th>Deployment Type</th>
+                                <th>Input Type</th>
                                 <th style={{ width: "60px"}}>Actions</th>
                             </tr>
                         </thead>


### PR DESCRIPTION
## Description

This pull requests makes the suggested changes (in ATMO-2071) while including some extra information to make it slightly more clear that the options means. 

This work does not make the Script URL visible unless you click to edit the script.

See also [ATMO-2071](https://pods.iplantcollaborative.org/jira/browse/ATMO-2071)

<details>

An example interaction can be seen here: http://recordit.co/jFca5tAtcB

## After the fix is merged

### "terms" list closed; table headings fixed
![atmo-2071-scripts-headings-table](https://user-images.githubusercontent.com/5923/34275149-35686bdc-e659-11e7-88b5-59217b7f0c38.png)

### "terms" list open
![atmo-2071-scripts-terms-list](https://user-images.githubusercontent.com/5923/34275114-108c1368-e659-11e7-8b5d-6e175764bc95.png)

### section headings fix; dropdowns include option "term"

![atmo-2071-new-script-headings-dropdowns](https://user-images.githubusercontent.com/5923/34275127-20297220-e659-11e7-9c3c-2ce5e573f2ba.png)
![atmo-2071-edit-script-headings-dropdowns](https://user-images.githubusercontent.com/5923/34275128-203f888a-e659-11e7-880f-662d51616898.png)

</details>

## Checklist before merging Pull Requests
- [ ] ~New test(s) included to reproduce the bug/verify the feature~
- [ ] ~Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [x] Reviewed and approved by at least one other contributor.
- [ ] ~New variables supported in Clank~
- [ ] ~New variables committed to secrets repos~
