### PR TITLE
Allow closing of resource and image requests

### DIFF
--- a/troposphere/static/js/components/admin/ImageMaster.jsx
+++ b/troposphere/static/js/components/admin/ImageMaster.jsx
@@ -5,6 +5,9 @@ import stores from "stores";
 
 
 const ImageMaster = React.createClass({
+    propTypes: {
+        params: React.PropTypes.object
+    },
 
     getInitialState: function() {
         return {
@@ -56,8 +59,27 @@ const ImageMaster = React.createClass({
         );
     },
 
+    renderRequestView() {
+        let { params } = this.props;
+        let { requests } = this.state;
+        if (!("id" in params)) {
+            return (
+                <p>Please select a request.</p>
+            );
+        }
+
+        let request = requests.find(r => r.get('id') == params.id)
+        if (!request) {
+            return (
+                <p>This request is no longer active. Please select a request.</p>
+            );
+        }
+
+        return  this.props.children;
+    },
+
     render: function() {
-        var requests = this.state.requests;
+        let { requests } = this.state;
         if (requests == null) {
             return <div className="loading"></div>
         }
@@ -102,7 +124,7 @@ const ImageMaster = React.createClass({
             <ul className="requests-list pull-left">
                 {imageRequestRows}
             </ul>
-            {this.props.children}
+            { this.renderRequestView() }
         </div>
         );
     }

--- a/troposphere/static/js/components/admin/ImageMaster.jsx
+++ b/troposphere/static/js/components/admin/ImageMaster.jsx
@@ -14,7 +14,6 @@ const ImageMaster = React.createClass({
     },
 
     componentDidMount: function() {
-        stores.StatusStore.getAll();
         stores.ImageRequestStore.fetchFirstPageWhere(
             {
                 "active": "true"

--- a/troposphere/static/js/components/admin/ImageMaster.jsx
+++ b/troposphere/static/js/components/admin/ImageMaster.jsx
@@ -1,12 +1,14 @@
 import React from "react";
 import { withRouter } from "react-router";
 
-import stores from "stores";
+import subscribe from "utilities/subscribe";
 
 
 const ImageMaster = React.createClass({
+
     propTypes: {
-        params: React.PropTypes.object
+        params: React.PropTypes.object,
+        subscriptions: React.PropTypes.object.isRequired
     },
 
     getInitialState: function() {
@@ -17,30 +19,32 @@ const ImageMaster = React.createClass({
     },
 
     componentDidMount: function() {
-        stores.ImageRequestStore.fetchFirstPageWhere(
+        let { ImageRequestStore } = this.props.subscriptions;
+        ImageRequestStore.fetchFirstPageWhere(
             {
                 "active": "true"
             },
             {},
             function() {
                 this.setState({
-                    requests: stores.ImageRequestStore.getAll()
+                    requests: ImageRequestStore.getAll()
                 });
             }.bind(this));
     },
 
     onRefresh: function() {
+        let { ImageRequestStore } = this.props.subscriptions;
         this.setState({
             refreshing: true
         });
-        stores.ImageRequestStore.fetchFirstPageWhere({
+        ImageRequestStore.fetchFirstPageWhere({
             "active": "true"
         },
             {},
             function() {
                 this.setState({
                     refreshing: false,
-                    requests: stores.ImageRequestStore.getAll()
+                    requests: ImageRequestStore.getAll()
                 });
             }.bind(this));
     },
@@ -130,4 +134,4 @@ const ImageMaster = React.createClass({
     }
 });
 
-export default withRouter(ImageMaster);
+export default withRouter(subscribe(ImageMaster, ["ImageRequestStore"]));

--- a/troposphere/static/js/components/admin/ImageRequest.jsx
+++ b/troposphere/static/js/components/admin/ImageRequest.jsx
@@ -67,9 +67,15 @@ const ImageRequest = React.createClass({
     },
 
     render: function() {
-        let { ImageRequestStore } = this.props.subscriptions,
-            request = ImageRequestStore.get(this.props.params.id),
-            machine = request.get("parent_machine"),
+        let { ImageRequestStore, StatusStore } = this.props.subscriptions;
+        let statuses = StatusStore.getAll();
+        let request = ImageRequestStore.get(this.props.params.id);
+
+        if (!statuses || !request) {
+            return <div className="loading" />;
+        }
+
+        let machine = request.get("parent_machine"),
             new_machine = request.get("new_machine"),
             new_provider = request.get("new_machine_provider"),
             instance = request.get("instance"),

--- a/troposphere/static/js/components/admin/ImageRequest.jsx
+++ b/troposphere/static/js/components/admin/ImageRequest.jsx
@@ -54,6 +54,10 @@ const ImageRequest = React.createClass({
         });
     },
 
+    close: function() {
+        this.submitUpdate("closed");
+    },
+
     approve: function() {
         this.submitUpdate("approved");
     },
@@ -270,6 +274,12 @@ const ImageRequest = React.createClass({
                     type="button"
                     className="btn btn-default btn-sm">
                     Re-Submit
+                </button>
+                <button disabled={request.get("status").name == "closed"}
+                    onClick={this.close}
+                    type="button"
+                    className="btn btn-default btn-sm">
+                    Close
                 </button>
             </div>
         </div>

--- a/troposphere/static/js/components/admin/ResourceRequest/ResourceRequest.jsx
+++ b/troposphere/static/js/components/admin/ResourceRequest/ResourceRequest.jsx
@@ -135,6 +135,32 @@ export default React.createClass({
         return promise;
     },
 
+    onClose() {
+        let { selectedRequest: request } = this.props;
+        let { statuses } = this.fetch();
+
+        let status = statuses.findWhere({
+            name: "closed"
+        });
+
+        this.setState({ actionPending: true });
+        let promise = Promise.resolve(
+            AdminResourceRequestActions.updateRequest(request, status)
+        );
+        promise
+            .then(
+                // onSuccess, navigate away
+                () => browserHistory.push("/application/admin/resource-requests"),
+
+                // onFailure, action is no longer pending, trigger error handler
+                err => {
+                    this.setState({ actionPending: false });
+                    errorHandler(err);
+                }
+            )
+        return promise;
+    },
+
     fetch() {
         let { selectedRequest: request } = this.props;
         let statuses = stores.StatusStore.getAll();
@@ -179,6 +205,7 @@ export default React.createClass({
             onIdentitySave: this.onIdentitySave,
             onApprove: this.onApprove,
             onDeny: this.onDeny,
+            onClose: this.onClose,
         };
 
         return (

--- a/troposphere/static/js/components/admin/ResourceRequest/ResourceRequestView.jsx
+++ b/troposphere/static/js/components/admin/ResourceRequest/ResourceRequestView.jsx
@@ -13,6 +13,7 @@ export default React.createClass({
         allocationSources: React.PropTypes.object,
         identities: React.PropTypes.object,
         onApprove: React.PropTypes.func.isRequired,
+        onClose: React.PropTypes.func.isRequired,
         onDeny: React.PropTypes.func.isRequired,
         onAllocationSave: React.PropTypes.func.isRequired,
         onIdentitySave: React.PropTypes.func.isRequired
@@ -136,12 +137,13 @@ export default React.createClass({
                 <h5 className="t-title">Quota</h5>
                 { this.renderIdentitiesSection() }
             </div>
-            <h4 className="t-title">2. Approve or Deny the request</h4>
+            <h4 className="t-title">2. Approve/Deny/Close the request</h4>
             <div style={section}>
                 <p>On approve or deny, the user will be notified by email and
                 encouraged to reach out to support if they have questions.
                 Under <a href="//application/my-requests/resources">my requests</a>, users can track the status of each
                 request.</p>
+                <p>On close, the user will not be notified</p>
                 <div style={{ display: "flex" }}>
                     <div style={{ padding: "20px", borderRight: "solid 1px #eee" }} >
                         <button onClick={this.props.onApprove}
@@ -150,13 +152,20 @@ export default React.createClass({
                             Approve
                         </button>
                     </div>
-                    <div style={{ padding: "20px" }} >
+                    <div style={{ padding: "20px", borderRight: "solid 1px #eee" }}>
                         <span style={{ paddingRight: "10px" }}>Provide a reason: <input onChange={this.handleResponseChange} value={ denyReason } /></span>
                         <button onClick={() => this.props.onDeny(this.state.denyReason)}
                             disabled={ this.state.denyReason == "" }
                             type="button"
                             className="btn btn-default btn-sm">
                             Deny
+                        </button>
+                    </div>
+                    <div style={{ padding: "20px" }}>
+                        <button onClick={this.props.onClose}
+                            type="button"
+                            className="btn btn-default btn-sm">
+                            Close
                         </button>
                     </div>
                 </div>


### PR DESCRIPTION
Add a close button so admins can close MachineRequests and Resource Requests

## Close button for MachineRequest
![peek 2018-01-12 12-53](https://user-images.githubusercontent.com/3847314/34892821-e3607050-f797-11e7-90f5-0c91ea4aba21.gif)

## Close Button for ResourceRequest
![clos-resource-request](https://user-images.githubusercontent.com/3847314/34893417-5bc3bb54-f79a-11e7-9c56-8c4baa1d4785.gif)


- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature
- [x] Reviewed and approved by at least one other contributor.
- [ ] New variables supported in Clank
- [ ] New variables committed to secrets repos