### PR TITLE
Add confirmation modal to admin resource request

### DIFF
--- a/troposphere/static/js/components/admin/ResourceRequest/ConfirmApproveModal.jsx
+++ b/troposphere/static/js/components/admin/ResourceRequest/ConfirmApproveModal.jsx
@@ -1,0 +1,61 @@
+import React from "react";
+
+import BootstrapModalMixin from "components/mixins/BootstrapModalMixin";
+
+
+const ConfirmApproveModal = React.createClass({
+    propTypes: {
+        onApprove: React.PropTypes.func.isRequired,
+        onCancel: React.PropTypes.func.isRequired
+    },
+    onCancel() {
+        this.hide();
+        this.props.onCancel();
+    },
+    onApprove() {
+        this.hide();
+        this.props.onApprove();
+    },
+    mixins: [BootstrapModalMixin],
+    render() {
+        return (
+        <div className="modal fade">
+            <div className="modal-dialog" style={{ minWidth: "600px"}}>
+                <div className="modal-content">
+                    <div className="modal-header">
+                        {this.renderCloseButton()}
+                        <h1 className="t-title">Confirm Request Approval</h1>
+                    </div>
+                    <div style={{ minHeight: "300px" }} className="modal-body">
+                        <div className="alert alert-warning">
+                            <p>
+                                The user's resources have not been updated!
+                            </p>
+                        </div>
+                        <p>
+                           Both quota and allocation must be manually updated.
+                        </p>
+                        <p>
+                            Click cancel if you have not yet updated the user's resources, otherwise click approve anyways.
+                        </p>
+                    </div>
+                    <div className="modal-footer">
+                        <button type="button"
+                                className="btn"
+                                onClick={this.onApprove}>
+                            Approve Anyways
+                        </button>
+                        <button type="button"
+                                className="btn btn-primary"
+                                onClick={this.onCancel}>
+                            Cancel
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+        );
+    }
+});
+
+export default ConfirmApproveModal;

--- a/troposphere/static/js/components/admin/ResourceRequest/ResourceRequest.jsx
+++ b/troposphere/static/js/components/admin/ResourceRequest/ResourceRequest.jsx
@@ -22,6 +22,8 @@ export default React.createClass({
     getInitialState() {
         return {
             actionPending: false,
+            allocationsSavedOnce: false,
+            identitiesSavedOnce: false,
         };
     },
 
@@ -55,6 +57,7 @@ export default React.createClass({
                     allocation: allocationSource,
                     username: request.get("created_by").username
                 })
+                this.setState({ allocationsSavedOnce: true });
             })
             .catch(errorHandler);
         return promise;
@@ -81,6 +84,7 @@ export default React.createClass({
                     identity,
                     username
                 });
+                this.setState({ identitiesSavedOnce: true });
             })
             .catch(errorHandler);
         return promise;
@@ -189,7 +193,7 @@ export default React.createClass({
     render() {
         let { allocationSources, identities } = this.fetch();
         let { selectedRequest } = this.props;
-        let { actionPending } = this.state;
+        let { actionPending, allocationsSavedOnce, identitiesSavedOnce } = this.state;
 
         if (actionPending) {
             return (
@@ -199,6 +203,7 @@ export default React.createClass({
 
         let viewProps = {
             request: selectedRequest,
+            resourcesChanged: allocationsSavedOnce || identitiesSavedOnce,
             allocationSources,
             identities,
             onAllocationSave: this.onAllocationSave,

--- a/troposphere/static/js/components/admin/ResourceRequest/ResourceRequestView.jsx
+++ b/troposphere/static/js/components/admin/ResourceRequest/ResourceRequestView.jsx
@@ -3,6 +3,9 @@ import React from "react";
 import globals from "globals";
 import AllocationSourceView from "./AllocationSourceView";
 import IdentityView from "./IdentityView";
+import ModalHelpers from "components/modals/ModalHelpers";
+import ConfirmApproveModal from "./ConfirmApproveModal";
+
 
 // This is the view for the admin Resource Requests panel. This view shouldn't
 // fetch or retrieve any data, just renders props.
@@ -10,6 +13,7 @@ export default React.createClass({
 
     propTypes: {
         request: React.PropTypes.object.isRequired,
+        resourcesChanged: React.PropTypes.bool.isRequired,
         allocationSources: React.PropTypes.object,
         identities: React.PropTypes.object,
         onApprove: React.PropTypes.func.isRequired,
@@ -43,6 +47,20 @@ export default React.createClass({
                 paddingLeft: "2em",
                 flexGrow: 1
             }
+        }
+    },
+
+    onApprove() {
+        let { resourcesChanged, onApprove } = this.props;
+        if (resourcesChanged) {
+            onApprove();
+        } else {
+            // Confirm first that the user want to approve a request when
+            // resources haven't changed
+            ModalHelpers.renderModal(
+                ConfirmApproveModal,
+                { onApprove }
+            );
         }
     },
 
@@ -146,7 +164,7 @@ export default React.createClass({
                 <p>On close, the user will not be notified</p>
                 <div style={{ display: "flex" }}>
                     <div style={{ padding: "20px", borderRight: "solid 1px #eee" }} >
-                        <button onClick={this.props.onApprove}
+                        <button onClick={this.onApprove}
                             type="button"
                             className="btn btn-default btn-sm">
                             Approve


### PR DESCRIPTION
Depends on https://github.com/cyverse/troposphere/pull/749
JIRA: [ATMO-2131](https://pods.iplantcollaborative.org/jira/browse/ATMO-2131)

Problem: Requests were being 'approved' while the resources were not being updated
Solution: Add a confirmation step/modal if resources havn't changed

This is a band-aid solution. Need to make the correct-flow obvious.

![2018-01-19-145722_2880x1800_scrot](https://user-images.githubusercontent.com/3847314/35174447-b619f6ee-fd2c-11e7-8222-07ae05ea87f9.png)

