### PR TITLE
Problem: deploy scripts aren't shown in Instance details

### DIFF
--- a/troposphere/static/js/components/common/boot_script/ShowScript.jsx
+++ b/troposphere/static/js/components/common/boot_script/ShowScript.jsx
@@ -1,0 +1,219 @@
+import Backbone from "backbone";
+import React from "react";
+import RaisedButton from "material-ui/RaisedButton";
+import SelectMenu from "components/common/ui/SelectMenu";
+import actions from "actions";
+
+function doNothing() {};
+
+export default React.createClass({
+    displayName: "ShowScript",
+
+    propTypes: {
+        script: React.PropTypes.instanceOf(Backbone.Model),
+        style: React.PropTypes.object,
+        footerClassName: React.PropTypes.string,
+        onClose: React.PropTypes.func.isRequired,
+    },
+
+    getInitialState() {
+        return this.getStateFromProps(this.props);
+    },
+
+    getStateFromProps(props) {
+        let script = props.script;
+        let state = {},
+            scriptState;
+
+        if(script) {
+            scriptState = {
+                title: script.get('title'),
+                text: script.get('text'),
+                type: script.get('type'),
+                strategy: script.get('strategy'),
+                wait_for_deploy: script.get('wait_for_deploy'),
+            }
+        }
+        state = {
+            ...scriptState
+        };
+        return state;
+    },
+
+    componentWillReceiveProps(props) {
+        this.setState(this.getStateFromProps(props));
+    },
+
+    getDefaultProps: function() {
+        return {
+            style: {},
+            footerStyle: {},
+            footerClassName: "",
+            script: null
+        }
+    },
+
+    renderInputType: function() {
+        let classNames = "form-group";
+
+        if (this.state.type === "URL") {
+
+            return (
+            <div className={classNames}>
+                <label htmlFor="script-url">
+                    Script URL
+                </label>
+                <input id="script-url"
+                    className="form-control"
+                    placeholder="http://yourscript.org"
+                    readOnly
+                    value={this.state.text} />
+            </div>
+            )
+        } else {
+            return (
+            <div className={classNames} >
+                <label htmlFor="script-raw-text">
+                    Raw Text
+                </label>
+                <textarea id="script-raw-text"
+                    className="form-control"
+                    placeholder="#!/bin/bash"
+                    readOnly
+                    rows="6"
+                    value={this.state.text} />
+            </div>
+            )
+        }
+    },
+
+    renderDeploymentOptionsHint() {
+        if(this.state.wait_for_deploy) {
+            return null;
+        }
+        let stdoutPath = "/var/log/atmo/instance-scripts/"+this.state.title+".YYYY-MM-DD_HH:MM:SS.stdout",
+            stderrPath = "/var/log/atmo/instance-scripts/"+this.state.title+".YYYY-MM-DD_HH:MM:SS.stderr";
+        return (
+            <div className="help-block">
+                {"stdout will be logged on the VM at: "}
+                <br/>
+                <code>{stdoutPath}</code>
+                <br/>
+                {"stderr will be logged on the VM at: "}
+                <br/>
+                <code>{stderrPath}</code>
+            </div>
+        );
+    },
+
+    renderDeploymentOptions() {
+        // deploymentType is a key into options 'type', i.e. ("sync","async",...)
+        let options = [
+            {
+                wait_for_deploy: true,
+                type: "sync",
+                message: "Sync - wait for script to complete, ensure exit code 0, email me if there is a failure."
+            },
+            {
+                wait_for_deploy: false,
+                type: "async",
+                message: "Async - execute scripts asynchronously. Store stdout/stderr to log files."
+            }
+        ];
+        let { wait_for_deploy } = this.state;
+        let current = options.find(option => option.wait_for_deploy == wait_for_deploy);
+
+        return (
+            <SelectMenu current={ current }
+                        optionName={ o => o.message }
+                        list={ options }
+                        onSelect={ doNothing }
+                        disabled />
+        );
+    },
+
+    renderStrategyOptions() {
+        // strategyType is a key into options 'type', i.e. ("once","always",...)
+        let { strategy } = this.state;
+        let options = [
+            { type: "once", message: "Once - run script on first boot" },
+            { type: "always", message: "Always - run script on every deployment" }
+        ];
+        let current = options.find(option => option.type == strategy);
+        return (
+            <SelectMenu current={ current }
+                        optionName={ o => o.message }
+                        list={ options }
+                        onSelect={ doNothing }
+                        disabled />
+        );
+    },
+
+    renderInputOptions() {
+        let options = [
+                {type: "URL", message: "Import by URL"},
+                {type: "Raw Text", message: "Import by Text"}
+            ];
+        let {type} = this.state;
+        let current = options.find(option => option.type == type);
+
+        return (
+            <SelectMenu current={ current }
+                        optionName={ o => o.message }
+                        list={ options }
+                        onSelect={ doNothing }
+                        disabled />
+        );
+    },
+
+    render: function() {
+        let { title } = this.state;
+
+        let classNames = "form-group",
+            headerText = "Current Script",
+            errorMessage = null,
+            notSubmittable = false;
+
+        return (
+        <div style={this.props.style}>
+            <h3 className="t-subheading">{headerText}</h3>
+            <hr/>
+            <div>
+                <div className={classNames}>
+                    <label>{"Script Title"}</label>
+                    <input className="form-control"
+                           placeholder="My Script"
+                           value={title}
+                           readOnly />
+                    <span className="help-block">{errorMessage}</span>
+                </div>
+                <h4 className="t-body-2">{"Execution Strategy Type"}</h4>
+                <div className={classNames}>
+                    { this.renderStrategyOptions() }
+                </div>
+                <h4 className="t-body-2">{"Deployment Type"}</h4>
+                <div className={classNames}>
+                    { this.renderDeploymentOptions() }
+                    { this.renderDeploymentOptionsHint() }
+                </div>
+                <h4 className="t-body-2">{"Input Type"}</h4>
+                <div className={classNames}>
+                    { this.renderInputOptions() }
+                </div>
+                <div>
+                    { this.renderInputType() }
+                </div>
+            </div>
+            <div className={this.props.footerClassName} style={this.props.footerStyle}>
+                <RaisedButton
+                    primary
+                    className="pull-right"
+                    style={{ marginRight: "10px" }}
+                    onTouchTap={this.props.onClose}
+                    label="Okay"
+                />
+            </div>
+        </div>
+        );
+    }
+});

--- a/troposphere/static/js/components/modals/script/ScriptShowModal.jsx
+++ b/troposphere/static/js/components/modals/script/ScriptShowModal.jsx
@@ -1,0 +1,55 @@
+import Backbone from "backbone";
+import React from "react";
+import BootstrapModalMixin from "components/mixins/BootstrapModalMixin";
+import ShowScript from "components/common/boot_script/ShowScript";
+
+import stores from "stores";
+
+
+export default React.createClass({
+    displayName: "ScriptShowModal",
+
+    mixins: [BootstrapModalMixin],
+
+    propTypes: {
+        script: React.PropTypes.instanceOf(Backbone.Model),
+    },
+
+
+
+    onClose: function() {
+        this.hide();
+    },
+
+    renderBody: function() {
+        let { script } = this.props;
+
+        return (
+            <ShowScript
+                script={script}
+                footerClassName={"modal-footer"}
+                onClose={this.onClose}
+            />
+        );
+    },
+
+    render: function() {
+        return (
+        <div className="modal fade">
+            <div className="modal-dialog">
+                <div className="modal-content">
+                    <div className="modal-header">
+                        {this.renderCloseButton()}
+                        <h1 className="t-title">
+                            {"View Deployment Script"}
+                        </h1>
+                    </div>
+                    <div className="modal-body">
+                        {this.renderBody()}
+                    </div>
+                </div>
+            </div>
+        </div>
+        );
+    }
+});

--- a/troposphere/static/js/components/projects/resources/instance/details/sections/InstanceDetailsSection.jsx
+++ b/troposphere/static/js/components/projects/resources/instance/details/sections/InstanceDetailsSection.jsx
@@ -11,6 +11,7 @@ import IpAddress from "./details/IpAddress";
 import LaunchDate from "./details/LaunchDate";
 import CreatedFrom from "./details/CreatedFrom";
 import Identity from "./details/Identity";
+import DeployScripts from "./details/DeployScripts";
 
 export default React.createClass({
     displayName: "InstanceDetailsSection",
@@ -20,7 +21,8 @@ export default React.createClass({
     },
 
     render: function() {
-        var instance = this.props.instance;
+        var instance = this.props.instance,
+            deployScripts = instance ? instance.get("scripts") : [];
 
         return (
         <div className="resource-details-section section">
@@ -35,6 +37,7 @@ export default React.createClass({
                 <Identity instance={instance} />
                 <Id instance={instance} />
                 <Alias instance={instance} />
+                <DeployScripts scripts={deployScripts} />
             </ul>
         </div>
         );

--- a/troposphere/static/js/components/projects/resources/instance/details/sections/details/DeployScripts.jsx
+++ b/troposphere/static/js/components/projects/resources/instance/details/sections/details/DeployScripts.jsx
@@ -1,0 +1,122 @@
+import _ from "underscore";
+import React from "react";
+import Backbone from "backbone";
+
+import DeployScript from "models/Script";
+import Glyphicon from "components/common/Glyphicon";
+import ModalHelpers from "components/modals/ModalHelpers";
+import ResourceDetail from "components/projects/common/ResourceDetail";
+import ScriptShowModal from "components/modals/script/ScriptShowModal";
+
+import stores from "stores";
+
+
+const DeployScripts = React.createClass({
+    displayName: "DeployScripts",
+
+    propTypes: {
+        scripts: React.PropTypes.array.isRequired
+    },
+
+    getInitialState() {
+        return {
+            scriptModels: null
+        };
+    },
+
+    componentWillReceiveProps(newProps) {
+        this.setState(newProps, this.updateState);
+    },
+
+    updateState: function() {
+        let { scriptModels, allUserScripts } = this.state;
+
+
+        if (!scriptModels) {
+            allUserScripts = stores.ScriptStore.getAll();
+        }
+
+        if (allUserScripts && !scriptModels) {
+            // We received data from the store ...
+            scriptModels = scriptModels || [];
+
+            // transfer from bare script data to models
+            this.props.scripts.forEach((s) => {
+                scriptModels.push(allUserScripts.get(s));
+            });
+        }
+
+        this.setState({
+            scriptModels,
+            allUserScripts
+        });
+
+    },
+
+    componentDidMount: function() {
+        stores.ScriptStore.addChangeListener(this.updateState);
+
+        // Prime the data pump, yo
+        this.updateState();
+    },
+
+    componentWillUnmount: function() {
+        stores.ScriptStore.removeChangeListener(this.updateState);
+    },
+
+
+    renderScript(script) {
+        let scriptName = script.get("title") || "unknown",
+            key = script.get("uuid") || scriptName;
+
+        let showScriptModal = function (scriptInfo) {
+            let modalProps = {
+                script: scriptInfo
+            }
+
+            ModalHelpers.renderModal(
+                ScriptShowModal,
+                modalProps,
+                function() { /* do nothing onSuccess */ }
+            );
+        };
+
+        return (
+            <li key={`li-${key}`}>
+                <Glyphicon name="file" />{` `}
+                <a key={`anchor-${key}`}
+                   onClick={showScriptModal.bind(this, script)}>
+                    {scriptName}</a>
+            </li>
+        );
+    },
+
+    render() {
+        let { scriptModels } = this.state,
+            { scripts: rawScripts } = this.props,
+            container = null;
+
+        if (scriptModels && scriptModels.length > 0) {
+            container = (
+                <ResourceDetail label="Deploy Scripts">
+                    <ul  style={{ paddingLeft: 0 }}>
+                    {scriptModels.map(this.renderScript)}
+                    </ul>
+                </ResourceDetail>
+            );
+        } else if (rawScripts && rawScripts.length > 0) {
+            // if there were scripts passed via props,
+            // we want to load the full model data, so
+            // toss that inline spinner out that ...
+            container = (
+                <ResourceDetail label="Deploy Scripts">
+                    <div className="loading-tiny-inline"></div>
+                </ResourceDetail>
+            );
+        }
+
+        return container;
+    }
+});
+
+export default DeployScripts;


### PR DESCRIPTION
## Description

This adds a `<DeployScripts/>` resource detail component to the InstanceDetails page, specifically `<InstanceDetailsSection />` so that the "deploy scripts" included at "launch-time" can be seen by a community members.

It allows the script to be seen, by script title in the details. And, it gives a "read only" view of the deployment script. This non-editable view is chosen to avoid someone modifying the script in the model and potentially expecting the changes to immediately take place on the active instance.

Note, this "ResourceDetail" has _not_ been added to "past" InstanceDetails views. It is technically possible to show the included deployment scripts for historical instance launches. It is not clear as an implementor if that is desirable. But should be straightforward to add.

<details>

## Deploy Scripts shown in InstanceDetails

<img width="813" alt="screen shot 2018-02-20 at 3 49 26 pm" src="https://user-images.githubusercontent.com/5923/36453907-0b82bdf8-1657-11e8-8238-2bc8be485dda.png">

## Read-only view of the Deploy Script

This is shown when clicking on the script title hyperlink ... 
<img width="750" alt="screen shot 2018-02-20 at 3 49 47 pm" src="https://user-images.githubusercontent.com/5923/36453906-0b60fc18-1657-11e8-80a5-ddde5a9af92f.png">

## No Deploy Scripts shown because none given 

<img width="841" alt="screen shot 2018-02-20 at 4 01 44 pm" src="https://user-images.githubusercontent.com/5923/36454008-6cdc7a58-1657-11e8-9bb8-dc7699a28dcb.png">

</details>

## Checklist before merging Pull Requests
- [ ] ~New test(s) included to reproduce the bug/verify the feature~
- [ ] ~Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Reviewed and approved by at least one other contributor.
- [ ] ~New variables supported in Clank~
- [ ] ~New variables committed to secrets repos~
