### PR TITLE
Problem: Invalid date shown for Active Instances

### DIFF
--- a/troposphere/static/js/components/projects/resources/instance/details/sections/details/EndDate.jsx
+++ b/troposphere/static/js/components/projects/resources/instance/details/sections/details/EndDate.jsx
@@ -11,11 +11,18 @@ var EndDate = React.createClass({
     },
 
     render: function() {
-        return (
-        <ResourceDetail label="Deleted">
-            <Time date={this.props.instance.get("end_date")} />
-        </ResourceDetail>
-        );
+        let endDate = this.props.instance.get("end_date"),
+            element = null;
+
+        if (endDate) {
+            element = (
+                <ResourceDetail label="Deleted">
+                    <Time date={endDate} />
+                </ResourceDetail>
+            );
+        }
+
+        return element;
     }
 });
 


### PR DESCRIPTION
## Description

Hide the "Deleted" resource detail on active Instances.

The <EndDate /> component appears with the label "Deleted" on any VM that is navigated to via the Instance Status History section of the Dashboard. If a VM (Instance) is Active, it will have an end_date of null ... and this appears than via moment.js's constructor as an invalid
date.

Reported to me by @julianpistorius.

<details>

## Example of the problem, "Invalid Date"
<img width="857" alt="showing-invalid-date-for-deleted" src="https://user-images.githubusercontent.com/5923/36455329-d8998970-165c-11e8-88b4-c4ac387298e6.png">

## After the PR is applied ...

### Showing the "Deleted" resource detail is hidden for Active

<img width="822" alt="showing-deleted-hidden-when-active" src="https://user-images.githubusercontent.com/5923/36455328-d8814a7c-165c-11e8-83c4-8190a9135b02.png">

### Showing the "Deleted" resource detail is shown for Deleted

<img width="646" alt="show-deleted-when-deleted" src="https://user-images.githubusercontent.com/5923/36455326-d865cca2-165c-11e8-8023-dd80e1f58711.png">

</details>

## Checklist before merging Pull Requests
- [ ] ~New test(s) included to reproduce the bug/verify the feature~
- [ ] ~Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Reviewed and approved by at least one other contributor.
- [ ] ~New variables supported in Clank~
- [ ] ~New variables committed to secrets repos~
