### PR TITLE
Problem: cannot copying IP from the Project Details view

### DIFF
--- a/troposphere/static/js/components/projects/detail/resources/instance/InstanceRow.jsx
+++ b/troposphere/static/js/components/projects/detail/resources/instance/InstanceRow.jsx
@@ -6,10 +6,12 @@ import Status from "../tableData/instance/Status";
 import Activity from "../tableData/instance/Activity"
 import IpAddress from "../tableData/instance/IpAddress";
 import Size from "../tableData/instance/Size";
+import OptionInfoMenu from "../tableData/instance/OptionInfoMenu";
 import Identity from "../tableData/common/Identity";
 import CryptoJS from "crypto-js";
 import Gravatar from "components/common/Gravatar";
 import stores from "stores";
+
 
 export default React.createClass({
     displayName: "InstanceRow",
@@ -55,6 +57,9 @@ export default React.createClass({
             </td>
             <td className="sm-cell" data-label="Identity">
                 <Identity project_resource={instance} />
+            </td>
+            <td className="sm-cell" data-label="Option Info">
+                <OptionInfoMenu instance={instance} />
             </td>
         </SelectableRow>
         );

--- a/troposphere/static/js/components/projects/detail/resources/instance/InstanceTable.jsx
+++ b/troposphere/static/js/components/projects/detail/resources/instance/InstanceTable.jsx
@@ -66,6 +66,9 @@ export default React.createClass({
             <th className="sm-header">
                 {featureFlags.hasProjectSharing() ? "Identity" : "Provider"}
             </th>
+            <th>
+                {" "}
+            </th>
         </SelectableTable>
         )
     }

--- a/troposphere/static/js/components/projects/detail/resources/tableData/instance/OptionInfoMenu.jsx
+++ b/troposphere/static/js/components/projects/detail/resources/tableData/instance/OptionInfoMenu.jsx
@@ -1,0 +1,51 @@
+import React from "react";
+import Backbone from "backbone";
+
+import CopyButton from "components/common/ui/CopyButton";
+
+
+export default React.createClass({
+    displayName: "OptionInfoMenu",
+
+    propTypes: {
+        instance: React.PropTypes.instanceOf(Backbone.Model).isRequired
+    },
+
+    render: function() {
+        let { instance } = this.props,
+            alias = instance.get("uuid"),
+            address = instance.get("ip_address"),
+            ipCopyElement = null;
+
+        if (!instance.hasIpAddress()) {
+            address = "N/A";
+        } else {
+            ipCopyElement = (
+                <span className="pull-right">
+                    <CopyButton text={address} />
+                </span>
+            );
+        }
+
+        return (
+            <div className="dropdown text-center">
+                <a className="dropdown-toggle" href="#" data-toggle="dropdown">
+                    <i className={'glyphicon glyphicon-option-vertical'} />
+                </a>
+                <ul className="dropdown-menu dropdown-menu-right"
+                    style={{minWidth: "365px"}}>
+                    <li style={{padding: "0px 10px 0px 10px"}}>
+                        <strong>IP:</strong> {address}{" "}
+                        {ipCopyElement}
+                    </li>
+                    <li style={{padding: "0px 10px 0px 10px"}}>
+                        <strong>Alias:</strong> {alias}{" "}
+                        <span className="pull-right">
+                            <CopyButton text={alias} />
+                        </span>
+                    </li>
+                </ul>
+            </div>
+        );
+    }
+});

--- a/troposphere/static/js/models/Instance.js
+++ b/troposphere/static/js/models/Instance.js
@@ -156,6 +156,11 @@ export default Backbone.Model.extend({
         });
     },
 
+    hasIpAddress: function() {
+        return (this.get("ip_address") &&
+                this.get("ip_address").charAt(0) != "0");
+    },
+
     getCreds: function() {
         return {
             provider_id: this.get("identity").provider,


### PR DESCRIPTION
## Description

This adds a vertical-option, clickable submenu for copying data without having to navigate away from the ProjectDetails view. 

The vertical-option is used since it is an "extended attributes" visual indicated in Material Design applications (like Google's Inbox). And, it allows other data beyond just the IP address to be included (for support, the provider-alias is present; Image info could be shown too).

This replaces some of the "side-panel" view that was in Troposphere circa Incana-Incana around September 2015. 

### Example

<img width="954" alt="screen shot 2018-02-21 at 4 43 52 pm" src="https://user-images.githubusercontent.com/5923/36512387-6dd49776-1727-11e8-971a-61ab2464d44d.png">


<details>

## No available IP address 
<img width="977" alt="screen shot 2018-02-21 at 4 52 36 pm" src="https://user-images.githubusercontent.com/5923/36512461-b5229eb6-1727-11e8-88b8-76289315accf.png">

## Full ProjectDetails view
<img width="1008" alt="screen shot 2018-02-21 at 4 43 40 pm" src="https://user-images.githubusercontent.com/5923/36512412-8af85fd6-1727-11e8-9580-db7c774161e3.png">

## Both data values available
<img width="965" alt="screen shot 2018-02-21 at 4 28 51 pm" src="https://user-images.githubusercontent.com/5923/36512413-8b14f9ac-1727-11e8-813b-7ac7cc86e5cb.png">

</details>

## Checklist before merging Pull Requests
- [ ] ~New test(s) included to reproduce the bug/verify the feature~
- [ ] ~Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Reviewed and approved by at least one other contributor.
- [ ] ~New variables supported in Clank~
- [ ] ~New variables committed to secrets repos~
