### PR TITLE
Problem: cannot use multi-select delete instances

### DIFF
--- a/troposphere/settings/default.py
+++ b/troposphere/settings/default.py
@@ -114,6 +114,13 @@ SESSION_COOKIE_AGE = (2 * 24 * 60 * 60)
 # default an emulated session to # of seconds in 3 hours
 EMULATED_SESSION_COOKIE_AGE = (3 * 60 * 60)
 
+# Associated with user interface functionality for batch actions
+#
+# JIRA Context: ATMO-981
+#
+# TODO: defined in an overridable way in `local.py.j2`
+BATCH_RESOURCE_ACTIONS = True
+
 # Logging
 LOGGING_ROOT = os.path.join(os.path.dirname(BASE_DIR), 'logs')
 LOGGING = {

--- a/troposphere/static/js/actions/InstanceActions.js
+++ b/troposphere/static/js/actions/InstanceActions.js
@@ -6,12 +6,12 @@ import IReboot from "./instance/reboot";
 import IRedeploy from "./instance/redeploy";
 import IPoll from "./instance/poll";
 import ILaunch from "./instance/launch";
-import IDestroy from "./instance/destroy";
 import IUpdate from "./instance/update";
 import IReport from "./instance/report";
 import IRequest from "./instance/requestImage";
 import updateAllocationSource from "./instance/updateAllocationSource";
 
+import { destroy } from "./instance/destroy";
 import { shelve } from "./instance/shelve";
 import { unshelve } from "./instance/unshelve";
 
@@ -25,7 +25,7 @@ export default {
     redeploy: IRedeploy.redeploy,
     poll: IPoll.poll,
     launch: ILaunch.launch,
-    destroy: IDestroy.destroy,
+    destroy,
     update: IUpdate.update,
     report: IReport.report,
     requestImage: IRequest.requestImage,

--- a/troposphere/static/js/actions/instance/destroy.js
+++ b/troposphere/static/js/actions/instance/destroy.js
@@ -7,7 +7,7 @@ import { applyInstanceAction } from "./functions.js";
  * We expect `params` to be an object with an `instances` property
  * providing access to a mappable collection of instance models.
  */
-const destroy = (params) => {
+const destroy = (params, options) => {
     let instanceTerminate = applyInstanceAction(
         "terminate",
         {
@@ -15,10 +15,10 @@ const destroy = (params) => {
             status: "active",
             activity: "deleting"
         },
-        "Your instance could not be stopped"
+        "Your instance(s) could not be deleted"
     );
 
-    instanceTerminate(params);
+    instanceTerminate(params, options);
 }
 
 

--- a/troposphere/static/js/actions/instance/functions.js
+++ b/troposphere/static/js/actions/instance/functions.js
@@ -1,5 +1,4 @@
 import InstanceConstants from "constants/InstanceConstants";
-import Instance from "models/Instance";
 import InstanceState from "models/InstanceState";
 import InstanceActionRequest from "models/InstanceActionRequest";
 

--- a/troposphere/static/js/actions/instance/functions.js
+++ b/troposphere/static/js/actions/instance/functions.js
@@ -5,8 +5,95 @@ import InstanceActionRequest from "models/InstanceActionRequest";
 
 import Utils from "../Utils";
 
+import globals from "globals";
+
 // we define a "function" constructor that will create a closure for an actionName
 // and the closure will take one argument, the instance
+
+/**
+ * Creates an instance action `function` to carry out an HTTP DELETE on each
+ * instance that is passed into the resulting function.
+ *
+ * Currently, the Atmosphere API does not allow a "terminate" (aka delete, aka
+ * destroy) to be processed by the `run_instance_action` function defined in
+ * service/instance.py. It would seem since there is a convention in the API
+ * _not_ to "delete" but to "end date" - you _could_ make an
+ * InstanceActionRequest that would do a "end date" and, thus, delete. There
+ * may be some _secret_ knowledge I lack for understanding why a "terminate"
+ * is processed as a special case, and via HTTP DELETE. I wish I knew to ask
+ * this of Steve Gregory before his departure.
+ *
+ * The original design was to make "terminate" a possible InstanceActionRequest,
+ * like so: https://gist.github.com/lenards/85df742edebc596a5b86b646d8c5a145
+ *
+ * Some plans don't work and I held onto it for _too_ long.
+ *
+ * This function's _specialness_ is hidden within the instanceActionImpl(..)
+ * so that progress in supporting Delete All can be provided to the community
+ * without having to wait for a major rework/remodel/rethink.
+ *
+ * Le mieux est l'ennemi du bien.
+ *
+ * @lenards
+ */
+const deleteActionImpl = (actionName, desiredState, errorMsg, delayOptions) => {
+
+    return function(instance) {
+
+        let originalState = instance.get("state"),
+            instanceState = instanceState = new InstanceState(desiredState),
+            identity = instance.get("identity"),
+            provider = instance.get("provider"),
+            url = (
+                globals.API_ROOT +
+                "/provider/" + provider.uuid +
+                "/identity/" + identity.uuid +
+                "/instance/" + instance.get("uuid")
+            );
+
+        // Optimistic update to the desiredState ...
+        instance.set({
+            state: instanceState,
+
+        });
+        // Optimistic "delete" is really just an end-date operation
+        instance.set({
+            end_date: new Date()
+        });
+
+        // Dispatch an UPDATE INSTANCE for what was just done above
+        Utils.dispatch(InstanceConstants.UPDATE_INSTANCE, {
+            instance: instance
+        });
+
+        // Perform an HTTP DELETE on the model (why this is done &
+        // it is not just an InstanceActionRequest has not been
+        // captured in the codebase nor documentation)
+        instance.destroy({
+            url: url
+        }).done(function() {
+            Utils.dispatch(InstanceConstants.POLL_FOR_DELETED, {
+                instance: instance
+            });
+        }).fail(function(response) {
+            // if something goes bump, flip it back to original state
+            instance.set({
+                state: originalState
+            });
+            Utils.dispatch(InstanceConstants.UPDATE_INSTANCE, {
+                instance: instance
+            });
+            Utils.dispatch(InstanceConstants.POLL_INSTANCE, {
+                instance: instance
+            });
+            Utils.displayError({
+                title: errorMsg,
+                response: response
+            });
+        });
+    }
+}
+
 
 /**
  * Creates an instance action `function` to carry out `actionName`
@@ -15,6 +102,11 @@ import Utils from "../Utils";
  */
 const instanceActionImpl = (actionName, desiredState, errorMsg, delayOptions) => {
     delayOptions = delayOptions || { delay: 25*1000 };
+
+    // return a "delete" version for now ...
+    if (actionName === "terminate") {
+        return deleteActionImpl(actionName, desiredState, errorMsg, delayOptions);
+    }
 
     return function(instance) {
         let instanceState = new InstanceState(desiredState),
@@ -93,7 +185,7 @@ const applyInstanceAction = (actionName, desiredState, errorMsg, delayOptions) =
         errorMsg,
         delayOptions);
 
-    return function({ instances }) {
+    return function({ instances }, options) {
         if (!instances)
             throw new Error("Missing instances parameter");
 

--- a/troposphere/static/js/actions/instance/functions.js
+++ b/troposphere/static/js/actions/instance/functions.js
@@ -1,0 +1,104 @@
+import InstanceConstants from "constants/InstanceConstants";
+import Instance from "models/Instance";
+import InstanceState from "models/InstanceState";
+import InstanceActionRequest from "models/InstanceActionRequest";
+
+import Utils from "../Utils";
+
+// we define a "function" constructor that will create a closure for an actionName
+// and the closure will take one argument, the instance
+
+/**
+ * Creates an instance action `function` to carry out `actionName`
+ *
+ * The function returned will carry out an _action_ for a single instance.
+ */
+const instanceActionImpl = (actionName, desiredState, errorMsg, delayOptions) => {
+    delayOptions = delayOptions || { delay: 25*1000 };
+
+    return function(instance) {
+        let instanceState = new InstanceState(desiredState),
+            isDeleteAction = actionName === "terminate",
+            originalState = instance.get("state"),
+            actionRequest = new InstanceActionRequest({
+                instance: instance
+            });
+
+        instance.set({
+            state: instanceState
+        });
+
+        if (isDeleteAction) {
+            instance.set({
+                end_date: new Date()
+            });
+        }
+
+        Utils.dispatch(InstanceConstants.UPDATE_INSTANCE, {
+            instance: instance
+        });
+
+        actionRequest.save(null, {
+            attrs: {
+                action: actionName
+            }
+        }).done(function() {
+            instance.set({
+                state: instanceState
+            });
+
+            if (isDeleteAction) {
+                Utils.dispatch(InstanceConstants.POLL_FOR_DELETED, {
+                    instance: instance
+                });
+            }
+        }).fail(function(response) {
+            instance.set({
+                state: originalState
+            });
+            Utils.displayError({
+                title: errorMsg,
+                response: response
+            });
+        }).always(function() {
+            Utils.dispatch(InstanceConstants.UPDATE_INSTANCE, {
+                instance: instance
+            });
+
+            if (delayOptions.delay > 0) {
+                Utils.dispatch(InstanceConstants.POLL_INSTANCE_WITH_DELAY, {
+                    instance: instance,
+                    delay: delayOptions.delay,
+                });
+            } else {
+                Utils.dispatch(InstanceConstants.POLL_INSTANCE, {
+                    instance: instance
+                });
+            }
+        });
+    }
+}
+
+
+/**
+ * Applies the created instance action to all instances passed via `params`
+ *
+ * Expects an object with an `instances` property that is a 'mappable'
+ * collections of instances. The `actionName` is requested for all instances.
+ */
+const applyInstanceAction = (actionName, desiredState, errorMsg, delayOptions) => {
+    let instanceAction = instanceActionImpl(
+        actionName,
+        desiredState,
+        errorMsg,
+        delayOptions);
+
+    return function({ instances }) {
+        if (!instances)
+            throw new Error("Missing instances parameter");
+
+        instances.map(instanceAction)
+    }
+}
+
+export { applyInstanceAction };

--- a/troposphere/static/js/collections/FunctionalCollection.js
+++ b/troposphere/static/js/collections/FunctionalCollection.js
@@ -17,7 +17,8 @@ var fix = function(f) {
 export default {
     cmap: fix(new Backbone.Collection().map),
     cfilter: fix(new Backbone.Collection().filter),
+    creject: fix(new Backbone.Collection().reject),
     csome: fix(new Backbone.Collection().some),
     cwhere: fix(new Backbone.Collection().where),
-    csort: fix(new Backbone.Collection().sort)
+    csort: fix(new Backbone.Collection().sort),
 }

--- a/troposphere/static/js/components/modals/instance/BatchInstanceDeleteModal.jsx
+++ b/troposphere/static/js/components/modals/instance/BatchInstanceDeleteModal.jsx
@@ -1,0 +1,147 @@
+import React from "react"
+import Backbone from "backbone";
+
+import RaisedButton from "material-ui/RaisedButton";
+
+import BootstrapModalMixin from "components/mixins/BootstrapModalMixin";
+import Glyphicon from "components/common/Glyphicon";
+import InstanceModel from "models/Instance";
+
+
+export default React.createClass({
+    displayName: "BatchInstanceDeleteModal",
+
+    mixins: [BootstrapModalMixin],
+
+    propTypes: {
+        instances: React.PropTypes.instanceOf(InstanceModel).isRequired,
+        attachedVolumes: React.PropTypes.instanceOf(Backbone.Collection).isRequired,
+        attachedResults: React.PropTypes.object.isRequired,
+        onConfirm: React.PropTypes.func.isRequired,
+    },
+
+    confirm() {
+        this.hide();
+        this.props.onConfirm();
+    },
+
+    renderInstance(instance) {
+        let instanceName = instance.get("name"),
+            instanceId = instance.get("id");
+
+        return (
+            <li key={`inst-${instanceId}`}>
+                <strong>
+                    {`${instanceName} #${instanceId}`}
+                </strong>
+            </li>
+        );
+    },
+
+    renderRejected(rejected) {
+        let rejectedElements, subtree;
+
+        if (rejected && rejected.length > 0) {
+            rejectedElements = rejected.map(this.renderInstance);
+
+            subtree = (
+                <div>
+                    <p className="alert alert-info">
+                        <Glyphicon name="info-sign" />
+                        {" "}<strong>NOTE</strong>
+                        { " We cannot delete the instance(s) because they have " +
+                          "attached volumes. " }
+                    </p>
+                    <h2 style={{marginBottom: "12px"}}
+                        className="t-title">Instance(s) with Attached Volumes</h2>
+                    <p>
+                        {"If you "}<strong>wish</strong>{" to delete "}
+                        {" these instance(s), then you "}
+                        <strong>must</strong>
+                        {" detach the volumes.  After they are detached, " +
+                          "you may try again to delete them." }
+                    </p>
+                    <ul>
+                        {rejectedElements}
+                    </ul>
+                </div>
+            );
+        }
+        return subtree;
+    },
+
+    renderBody() {
+        let { instances, rejected } = this.props,
+            deleteElements;
+
+        deleteElements = instances.map(this.renderInstance);
+
+        return (
+        <div>
+            {this.renderRejected(rejected)}
+            <hr />
+            <p className="alert alert-danger">
+                <Glyphicon name="warning-sign" />
+                {" "}<strong>CAUTION</strong>
+                {"  Data will be "}<strong>lost</strong>{"."}
+            </p>
+            <div>
+                <h2 style={{marginBottom: "12px"}}
+                    className="t-title">Affected Instances</h2>
+                <p>
+                    {"If you "}<strong>choose</strong>{" to proceed, "}
+                    {"then following instance(s) will be " +
+                     "will be terminated and all data will be permanently lost: "}
+                </p>
+                <ul>
+                    {deleteElements}
+                </ul>
+            </div>
+
+            <p style={{padding: "10px 0px 10px 0p", marginBottom: "5px"}}>
+                <em>
+                    Note:
+                </em>
+                {
+                    " Your resource usage charts will not reflect changes until the " +
+                    "instance is completely deleted and has disappeared " +
+                    "from your list of instances."
+                }
+            </p>
+        </div>
+        );
+    },
+
+    render() {
+        return (
+        <div className="modal fade">
+            <div className="modal-dialog">
+                <div className="modal-content">
+                    <div className="modal-header">
+                        {this.renderCloseButton()}
+                        <h1 className="t-title">
+                            Delete Instance(s)
+                        </h1>
+                    </div>
+                    <div className="modal-body">
+                        {this.renderBody()}
+                    </div>
+                    <div className="modal-footer">
+                        <RaisedButton
+                            style={{ marginRight: "10px" }}
+                            onTouchTap={this.hide}
+                            label="Cancel"
+                        />
+                        <RaisedButton
+                            primary
+                            type="button"
+                            onTouchTap={this.confirm}
+                            label="Yes, delete instance(s)"
+                        />
+                    </div>
+                </div>
+            </div>
+        </div>
+        );
+    }
+});

--- a/troposphere/static/js/components/modals/instance/BatchInstanceDeleteModal.jsx
+++ b/troposphere/static/js/components/modals/instance/BatchInstanceDeleteModal.jsx
@@ -5,7 +5,6 @@ import RaisedButton from "material-ui/RaisedButton";
 
 import BootstrapModalMixin from "components/mixins/BootstrapModalMixin";
 import Glyphicon from "components/common/Glyphicon";
-import InstanceModel from "models/Instance";
 
 
 export default React.createClass({
@@ -14,9 +13,10 @@ export default React.createClass({
     mixins: [BootstrapModalMixin],
 
     propTypes: {
-        instances: React.PropTypes.instanceOf(InstanceModel).isRequired,
+        instances: React.PropTypes.instanceOf(Backbone.Collection).isRequired,
+        rejected: React.PropTypes.instanceOf(Backbone.Collection).isRequired,
         attachedVolumes: React.PropTypes.instanceOf(Backbone.Collection).isRequired,
-        attachedResults: React.PropTypes.object.isRequired,
+        matchedIds: React.PropTypes.array.isRequired,
         onConfirm: React.PropTypes.func.isRequired,
     },
 

--- a/troposphere/static/js/components/projects/detail/resources/ButtonBar.jsx
+++ b/troposphere/static/js/components/projects/detail/resources/ButtonBar.jsx
@@ -1,11 +1,14 @@
 import React from "react";
 import Backbone from "backbone";
-import context from "context";
+
 import Button from "./Button";
 import SubMenu from "./SubMenu";
 import RefreshButton from "./RefreshButton";
 import RequestResourcesButton from "./RequestResourcesButton";
 import ResourceActionButtons from "./ResourceActionButtons";
+
+import context from "context";
+
 
 export default React.createClass({
     displayName: "ButtonBar",
@@ -13,6 +16,7 @@ export default React.createClass({
     propTypes: {
         isVisible: React.PropTypes.bool.isRequired,
         multipleSelected: React.PropTypes.bool.isRequired,
+        selectedResources: React.PropTypes.instanceOf(Backbone.Collection),
         onMoveSelectedResources: React.PropTypes.func.isRequired,
         onDeleteSelectedResources: React.PropTypes.func.isRequired,
         onReportSelectedResources: React.PropTypes.func.isRequired,
@@ -44,6 +48,19 @@ export default React.createClass({
         //   isVisible={true}
         // />
 
+        let {
+            isVisible,
+            onMoveSelectedResources,
+            onRemoveSelectedResources,
+            onUnselect,
+            onUnselectAll,
+            previewedResource,
+            selectedResources,
+            multipleSelected,
+            project } = this.props;
+
+        let isSuperUser = context.profile.get("is_superuser");
+
         return (
         <div
             style={{
@@ -63,20 +80,23 @@ export default React.createClass({
                 <RequestResourcesButton />
                 <Button icon="folder-open"
                     tooltip="Move selected resources"
-                    onClick={this.props.onMoveSelectedResources}
-                    isVisible={this.props.isVisible} />
+                    onClick={onMoveSelectedResources}
+                    isVisible={isVisible} />
                 <Button icon="export"
                     tooltip="Remove selected resources (admin only)"
-                    onClick={this.props.onRemoveSelectedResources}
+                    onClick={onRemoveSelectedResources}
                     style={{ "backgroundColor": "bisque" }}
-                    isVisible={context.profile.get("is_superuser") && this.props.isVisible} />
+                    isVisible={isSuperUser && isVisible} />
 
             </div>
             <div>
-                <ResourceActionButtons onUnselect={this.props.onUnselect}
-                    previewedResource={this.props.previewedResource}
-                    multipleSelected={this.props.multipleSelected}
-                    project={this.props.project} />
+                <ResourceActionButtons
+                    onUnselect={onUnselect}
+                    onUnselectAll={onUnselectAll}
+                    previewedResource={previewedResource}
+                    selectedResources={selectedResources}
+                    multipleSelected={multipleSelected}
+                    project={project} />
             </div>
         </div>
         );

--- a/troposphere/static/js/components/projects/detail/resources/InstanceActionButtons.jsx
+++ b/troposphere/static/js/components/projects/detail/resources/InstanceActionButtons.jsx
@@ -8,6 +8,7 @@ export default React.createClass({
 
     propTypes: {
         multipleSelected: React.PropTypes.bool.isRequired,
+        selectedResources: React.PropTypes.instanceOf(Backbone.Collection),
         instance: React.PropTypes.instanceOf(Backbone.Model).isRequired,
         project: React.PropTypes.instanceOf(Backbone.Model).isRequired
     },

--- a/troposphere/static/js/components/projects/detail/resources/InstanceBatchActionButtons.jsx
+++ b/troposphere/static/js/components/projects/detail/resources/InstanceBatchActionButtons.jsx
@@ -1,0 +1,175 @@
+import React from "react";
+import Backbone from "backbone";
+
+import { filterInstances } from "utilities/filterCollection";
+
+import Button from "./Button";
+import modals from "modals";
+
+
+export default React.createClass({
+    displayName: "InstanceBatchActionButtons",
+
+    propTypes: {
+        multipleSelected: React.PropTypes.bool.isRequired,
+        selectedResources: React.PropTypes.instanceOf(Backbone.Collection),
+        instance: React.PropTypes.instanceOf(Backbone.Model).isRequired,
+        project: React.PropTypes.instanceOf(Backbone.Model).isRequired
+    },
+
+    onStart: function() {
+        modals.InstanceModals.start(this.props.instance);
+    },
+
+    onSuspend: function() {
+        modals.InstanceModals.suspend(this.props.instance);
+    },
+
+    onStop: function() {
+        modals.InstanceModals.stop(this.props.instance);
+    },
+
+    onReboot: function() {
+        modals.InstanceModals.reboot(this.props.instance);
+    },
+
+    onResume: function() {
+        modals.InstanceModals.resume(this.props.instance);
+    },
+
+/*
+    onStart: function() {
+        let { selectedResources } = this.props,
+            instances = selectedResources.filter(filterInstances);
+
+        modals.InstanceModals.start(instances);
+        this.props.onUnselectAll();
+    },
+
+    onSuspend: function() {
+        let { selectedResources } = this.props,
+            instances = selectedResources.filter(filterInstances);
+
+        modals.InstanceModals.suspend(instances);
+        this.props.onUnselectAll();
+    },
+
+    onStop: function() {
+        let { selectedResources } = this.props,
+            instances = selectedResources.filter(filterInstances);
+
+        modals.InstanceModals.stop(instances);
+        this.props.onUnselectAll();
+    },
+
+    onResume: function() {
+        let { selectedResources } = this.props,
+            instances = selectedResources.filter(filterInstances);
+
+        modals.InstanceModals.resume(instances);
+        this.props.onUnselectAll();
+    },
+
+    onReboot: function() {
+        // NOTE: -- @lenards
+        // Intentionally *not* supporting bulk/batch actions
+        modals.InstanceModals.reboot(this.props.instance);
+    },
+*/
+
+    onDelete: function() {
+        // *all* _on_{{action}} functions should consider unselect(ing)
+        let { selectedResources, project } = this.props,
+            instances = selectedResources.cfilter(filterInstances);
+
+        modals.InstanceModals.destroy({
+            instances,
+            project
+        });
+        this.props.onUnselectAll();
+    },
+
+    render: function() {
+        let { instance,
+              selectedResources,
+              multipleSelected } = this.props,
+            status = instance.get("state").get("status"),
+            linksArray = [],
+            style = {
+                marginRight: "10px"
+            };
+
+        if (selectedResources) {
+            if (status === "active") {
+                linksArray.push(
+                    <Button style={style}
+                        key="Suspend"
+                        icon="pause"
+                        tooltip="Suspend"
+                        onClick={this.onSuspend}
+                        isVisible={true} />
+                );
+                linksArray.push(
+                    <Button style={style}
+                        key="Stop"
+                        icon="stop"
+                        tooltip="Stop"
+                        onClick={this.onStop}
+                        isVisible={true} />
+                );
+                // NOTE: we are not going to make rebooting
+                // multiple instances *possible*, but this
+                // was an artifical decision made by me,
+                // @lenards, after discussing it with
+                // @steve-gregory - this could be done if
+                // there is any value in that bulk action
+                if (!multipleSelected) {
+                    linksArray.push(
+                        <Button style={style}
+                                key="Reboot"
+                                icon="repeat"
+                                tooltip="Reboot the selected instance"
+                                onClick={this.onReboot}
+                                isVisible={true} />
+                    );
+                }
+            } else if (status === "suspended") {
+                linksArray.push(
+                    <Button style={style}
+                        key="Resume"
+                        icon="play"
+                        tooltip="Resume"
+                        onClick={this.onResume}
+                        isVisible={true} />
+                );
+            } else if (status === "shutoff") {
+                linksArray.push(
+                    <Button style={style}
+                        key="Start"
+                        icon="play"
+                        tooltip="Start"
+                        onClick={this.onStart}
+                        isVisible={true} />
+                );
+            }
+
+            // In a crazy world with "Delete ALL"
+            linksArray.push(
+              <Button
+                  key="Delete"
+                  icon="remove"
+                  tooltip="Delete"
+                  onClick={this.onDelete}
+                  isVisible={true}
+              />
+            );
+
+        }
+
+        return (
+        <div className="clearfix u-md-pull-right">
+            {linksArray}
+        </div>
+        );
+    }
+});

--- a/troposphere/static/js/components/projects/detail/resources/InstanceBatchActionButtons.jsx
+++ b/troposphere/static/js/components/projects/detail/resources/InstanceBatchActionButtons.jsx
@@ -37,6 +37,10 @@ export default React.createClass({
         modals.InstanceModals.resume(this.props.instance);
     },
 
+    onUnshelve: function() {
+        modals.InstanceModals.unshelve(this.props.instance);
+    },
+
 /*
    // Once a data structure is available that could offer the
    // possible "actions" on an instance given it's state (and
@@ -145,7 +149,7 @@ export default React.createClass({
                                 isVisible={true} />
                     );
                 }
-            } else if (status === "suspended") {
+            } else if (status === "suspended" && !multipleSelected) {
                 linksArray.push(
                     <Button style={style}
                         key="Resume"
@@ -154,13 +158,22 @@ export default React.createClass({
                         onClick={this.onResume}
                         isVisible={true} />
                 );
-            } else if (status === "shutoff") {
+            } else if (status === "shutoff" && !multipleSelected) {
                 linksArray.push(
                     <Button style={style}
                         key="Start"
                         icon="play"
                         tooltip="Start"
                         onClick={this.onStart}
+                        isVisible={true} />
+                );
+            } else if (status === "shelved_offloaded" && !multipleSelected){
+                linksArray.push(
+                    <Button style={style}
+                        key="Unshelve"
+                        icon="log-out"
+                        tooltip="Unshelve the selected instance"
+                        onClick={this.onResume}
                         isVisible={true} />
                 );
             }

--- a/troposphere/static/js/components/projects/detail/resources/InstanceBatchActionButtons.jsx
+++ b/troposphere/static/js/components/projects/detail/resources/InstanceBatchActionButtons.jsx
@@ -173,7 +173,7 @@ export default React.createClass({
                         key="Unshelve"
                         icon="log-out"
                         tooltip="Unshelve the selected instance"
-                        onClick={this.onResume}
+                        onClick={this.onUnshelve}
                         isVisible={true} />
                 );
             }

--- a/troposphere/static/js/components/projects/detail/resources/InstanceBatchActionButtons.jsx
+++ b/troposphere/static/js/components/projects/detail/resources/InstanceBatchActionButtons.jsx
@@ -38,6 +38,14 @@ export default React.createClass({
     },
 
 /*
+   // Once a data structure is available that could offer the
+   // possible "actions" on an instance given it's state (and
+   // in the future, the provider's allowed actions), then you
+   // could allow the selection of multiple instance, and with
+   // each selection perform a "set intersect" on the possible
+   // actions to show ... With that, you could then offer up
+   // the following event handlers:
+
     onStart: function() {
         let { selectedResources } = this.props,
             instances = selectedResources.filter(filterInstances);
@@ -84,9 +92,9 @@ export default React.createClass({
 
         modals.InstanceModals.destroy({
             instances,
-            project
+            project,
+            onUnselect: this.props.onUnselectAll
         });
-        this.props.onUnselectAll();
     },
 
     render: function() {
@@ -101,29 +109,33 @@ export default React.createClass({
 
         if (selectedResources) {
             if (status === "active") {
-                linksArray.push(
-                    <Button style={style}
-                        key="Suspend"
-                        icon="pause"
-                        tooltip="Suspend"
-                        onClick={this.onSuspend}
-                        isVisible={true} />
-                );
-                linksArray.push(
-                    <Button style={style}
-                        key="Stop"
-                        icon="stop"
-                        tooltip="Stop"
-                        onClick={this.onStop}
-                        isVisible={true} />
-                );
-                // NOTE: we are not going to make rebooting
-                // multiple instances *possible*, but this
-                // was an artifical decision made by me,
-                // @lenards, after discussing it with
-                // @steve-gregory - this could be done if
-                // there is any value in that bulk action
+                // NOTE: again, we could allow "valid"
+                // action buttons when multiple resources
+                // are selected if we had a way to determine
+                // a set of valid actions.
+                // I, lenards, think a state machine that models
+                // the valid transitions could be statically
+                // defined in the UI to enable this, and then
+                // **later** replace by a dynamic STM data
+                // structure that was driven by when was enabled
+                // by the SiteOperator, per Cloud Provider.
                 if (!multipleSelected) {
+                    linksArray.push(
+                        <Button style={style}
+                                key="Suspend"
+                                icon="pause"
+                                tooltip="Suspend"
+                                onClick={this.onSuspend}
+                                isVisible={true} />
+                    );
+                    linksArray.push(
+                        <Button style={style}
+                                key="Stop"
+                                icon="stop"
+                                tooltip="Stop"
+                                onClick={this.onStop}
+                                isVisible={true} />
+                    );
                     linksArray.push(
                         <Button style={style}
                                 key="Reboot"

--- a/troposphere/static/js/components/projects/detail/resources/ProjectDetails.jsx
+++ b/troposphere/static/js/components/projects/detail/resources/ProjectDetails.jsx
@@ -88,6 +88,7 @@ export default React.createClass({
 
     deselectAllResources: function() {
         this.setState({
+            previewedResource: null,
             selectedResources: new Backbone.Collection()
         });
     },

--- a/troposphere/static/js/components/projects/detail/resources/ResourceActionButtons.jsx
+++ b/troposphere/static/js/components/projects/detail/resources/ResourceActionButtons.jsx
@@ -1,13 +1,60 @@
 import React from "react";
 import Backbone from "backbone";
+
 import Instance from "models/Instance";
 import Image from "models/Image";
 import ExternalLink from "models/ExternalLink";
 import Volume from "models/Volume";
+
 import ImageActionButtons from "./ImageActionButtons";
 import ExternalLinkActionButtons from "./ExternalLinkActionButtons";
+import InstanceBatchActionButtons from "./InstanceBatchActionButtons";
 import InstanceActionButtons from "./InstanceActionButtons";
 import VolumeActionButtons from "./VolumeActionButtons";
+
+import features from "utilities/featureFlags";
+
+
+/**
+ * Decides the component rendered based on "feature flag"
+ *
+ * During the evaluation period of this work, we will use
+ * a simple "flag" to decide if the "actions" component
+ * supports "bulk" (aka _batch_) operations over resources,
+ * specifically Instances to begin with.
+ *
+ * Relates to: ATMO-981
+ */
+function selectInstanceActionButtons(props) {
+    let {
+        onUnselect,
+        onUnselectAll,
+        multipleSelected,
+        selectedResources,
+        previewedResource,
+        project } = props;
+
+    if (features.BATCH_RESOURCE_ACTIONS) {
+        return (
+            <InstanceBatchActionButtons
+                onUnselect={onUnselect}
+                onUnselectAll={onUnselectAll}
+                multipleSelected={multipleSelected}
+                selectedResources={selectedResources}
+                instance={previewedResource}
+                project={project} />
+        );
+    } else {
+        return (
+            <InstanceActionButtons
+                onUnselect={onUnselect}
+                multipleSelected={multipleSelected}
+                selectedResources={selectedResources}
+                instance={previewedResource}
+                project={project} />
+        );
+    }
+}
 
 
 export default React.createClass({
@@ -16,23 +63,23 @@ export default React.createClass({
     propTypes: {
         multipleSelected: React.PropTypes.bool.isRequired,
         previewedResource: React.PropTypes.instanceOf(Backbone.Model),
+        selectedResources: React.PropTypes.instanceOf(Backbone.Collection),
+        onUnselect: React.PropTypes.func.isRequired,
+        onUnselectAll: React.PropTypes.func,
         project: React.PropTypes.instanceOf(Backbone.Model),
         volume: React.PropTypes.instanceOf(Backbone.Model),
     },
 
     render: function() {
-        var resource = this.props.previewedResource,
-            project = this.props.project;
+        let { previewedResource: resource,
+              project } = this.props;
 
-        if (!resource) return <span/>;
+        if (!resource) {
+            return (<span/>);
+        }
 
         if (resource instanceof Instance) {
-            return (
-            <InstanceActionButtons onUnselect={this.props.onUnselect}
-                multipleSelected={this.props.multipleSelected}
-                instance={resource}
-                project={project} />
-            );
+            return selectInstanceActionButtons(this.props);
         } else if (resource instanceof Image) {
             return (
             <ImageActionButtons onUnselect={this.props.onUnselect}

--- a/troposphere/static/js/modals/instance/destroy.js
+++ b/troposphere/static/js/modals/instance/destroy.js
@@ -44,6 +44,7 @@ export default {
 
         let project = payload.project,
             instances = payload.instances,
+            onUnselect = payload.onUnselect,
             attachedResults = VolumeStore.getVolumesAttachedToInstances(instances),
             { volumes: attachedVolumes,
               matchedIds } = attachedResults,
@@ -58,6 +59,9 @@ export default {
             // destroy all instances without attached volumes ...
             actions.InstanceActions.destroy(props, options);
 
+            if (onUnselect) {
+                onUnselect();
+            }
             if (project) {
                 appBrowserHistory.push(`/projects/${project.id}/resources`);
             }

--- a/troposphere/static/js/modals/instance/destroy.js
+++ b/troposphere/static/js/modals/instance/destroy.js
@@ -6,33 +6,58 @@ import VolumeStore from "stores/VolumeStore";
 
 import ModalHelpers from "components/modals/ModalHelpers";
 
+import BatchInstanceDeleteModal from "components/modals/instance/BatchInstanceDeleteModal";
 import InstanceDeleteModal from "components/modals/instance/InstanceDeleteModal";
 import ExplainInstanceDeleteConditionsModal from "components/modals/instance/ExplainInstanceDeleteConditionsModal";
 
 import actions from "actions";
+import features from "utilities/featureFlags";
+
+
+function selectModal(props) {
+    let { attachedVolumes } = props;
+
+    if (features.BATCH_RESOURCE_ACTIONS) {
+        // offer a "best offer" approach to deleting
+        // the instances selected that don't have
+        // attached volumes; here, "best offer" means
+        // to delete what we can & apologize/explain
+        // why we don't be deleting the others
+        return BatchInstanceDeleteModal;
+    } else {
+        // when batch resource actions are disabled,
+        // if we have volumes attached to the instance
+        // targeted for deletion, we offer a "polite"
+        // explanation for why the UI doesn't let that
+        // happen; otherwise, delete delete delete!
+        return (attachedVolumes && attachedVolumes.length > 0)
+            ? ExplainInstanceDeleteConditionsModal
+            : InstanceDeleteModal;
+    }
+}
 
 
 export default {
     destroy: function(payload, options) {
-        if (!payload.instance)
-            throw new Error("Missing instance");
+        if (!payload.instances)
+            throw new Error("Missing instance(s)");
 
-        var project = payload.project,
-            instance = payload.instance,
-            attachedVolumes = VolumeStore.getVolumesAttachedToInstance(instance),
-            ModalComponent,
+        let project = payload.project,
+            instances = payload.instances,
+            attachedResults = VolumeStore.getVolumesAttachedToInstances(instances),
+            { volumes: attachedVolumes,
+              matchedIds } = attachedResults,
             props = {
-                instance,
-                attachedVolumes
+                instances: instances.creject((i) => matchedIds.includes(i.get("uuid"))),
+                rejected: instances.cfilter((i) => matchedIds.includes(i.get("uuid"))),
+                attachedVolumes,
+                matchedIds
             };
 
-        ModalComponent = attachedVolumes.length > 0
-            ? ExplainInstanceDeleteConditionsModal
-            : InstanceDeleteModal;
+        ModalHelpers.renderModal(selectModal(props), props, function() {
+            // destroy all instances without attached volumes ...
+            actions.InstanceActions.destroy(props, options);
 
-        ModalHelpers.renderModal(ModalComponent, props, function() {
-            attachedVolumes.forEach((volume) => VolumeStore.pollUntilDetached(volume));
-            actions.InstanceActions.destroy(payload, options);
             if (project) {
                 appBrowserHistory.push(`/projects/${project.id}/resources`);
             }

--- a/troposphere/static/js/stores/VolumeStore.js
+++ b/troposphere/static/js/stores/VolumeStore.js
@@ -31,7 +31,6 @@ let VolumeStore = BaseStore.extend({
         return new VolumeCollection(volumes);
     },
 
-
     getVolumesAttachedToInstance: function(instance) {
         if (!this.models) return this.fetchModels();
 
@@ -43,6 +42,30 @@ let VolumeStore = BaseStore.extend({
         });
 
         return new VolumeCollection(attachedVolumes);
+    },
+
+    getVolumesAttachedToInstances: function(instances) {
+        if (!this.models) return this.fetchModels();
+
+        let uuids = instances.pluck("uuid") || [],
+            matches = [];
+
+        let attachedVolumes = this.models.filter(function(volume) {
+            let attachData = volume.get("attach_data"),
+                isAttached = attachData.instance_id && uuids.includes(attachData.instance_id);
+
+            // generate a matched list of UUIDs of the instances with attached volumes
+            if (isAttached) {
+                matches.push(attachData.instance_id);
+            }
+
+            return isAttached
+        });
+
+        return {
+            matchedIds: matches,
+            volumes: new VolumeCollection(attachedVolumes)
+        };
     },
 
     // Makes a clean list of attached resources from volume information for easy reference

--- a/troposphere/static/js/utilities/featureFlags.js
+++ b/troposphere/static/js/utilities/featureFlags.js
@@ -49,6 +49,7 @@ const shouldReportVolumeViaIntercom = () => {
 
 export default {
     WEB_DESKTOP: !!window.WEB_DESKTOP_ENABLED || false,
+    BATCH_RESOURCE_ACTIONS: !!window.BATCH_RESOURCE_ACTIONS || false,
     hasIntercomActive,
     showIdentityView,
     shouldReportInstanceViaIntercom,

--- a/troposphere/static/js/utilities/filterCollection.js
+++ b/troposphere/static/js/utilities/filterCollection.js
@@ -1,5 +1,8 @@
 import moment from "moment";
 
+import Instance from "models/Instance";
+
+
 const filterEndDate = (version) => {
     let dateNow = moment(new Date()).format();
     let endDate = version.get("end_date")
@@ -15,4 +18,8 @@ const filterEndDate = (version) => {
     return false
 }
 
-export { filterEndDate }
+const filterInstances = (resource) => {
+    return resource instanceof Instance;
+}
+
+export { filterEndDate, filterInstances }

--- a/troposphere/templates/index.html
+++ b/troposphere/templates/index.html
@@ -165,6 +165,12 @@
     var EXTERNAL_ALLOCATION = false;
 {% endif %}
 
+{% if BATCH_RESOURCE_ACTIONS %}
+    var BATCH_RESOURCE_ACTIONS = true;
+{%  else %}
+    var BATCH_RESOURCE_ACTIONS = false;
+{% endif %}
+
 var ALLOCATION_UNIT_NAME = "{{ ALLOCATION_UNIT_NAME }}";
 var ALLOCATION_UNIT_ABBREV = "{{ ALLOCATION_UNIT_ABBREV }}";
 

--- a/troposphere/views/app.py
+++ b/troposphere/views/app.py
@@ -183,6 +183,10 @@ def _populate_template_params(request, maintenance_records, notice_t, disabled_l
     template_params['GUACAMOLE_ENABLED'] = \
         settings.GUACAMOLE_ENABLED
 
+    # ATMO-981 Feature Flag - Toggle Batch Actions for Resources
+    template_params['BATCH_RESOURCE_ACTIONS'] = \
+        settings.BATCH_RESOURCE_ACTIONS
+
     if metadata:
         template_params['DISPLAY_STATUS_PAGE'] = \
             metadata.display_status_page_link


### PR DESCRIPTION
## Description

This is a provisional feature branch showing how "batch" actions might work for the narrow case of enabling batch delete, aka "delete all". 

See "multi-delete" in action: http://recordit.co/Bj9aggQyWm

See commit messages for more context. 

This includes a fix to handle showing "unshelve" `onSelect` for Shelved Instances in ProjectDetails view. 

This is feature flagged from `settings` out to the SPA, but is not wired for the Clank-to-`variables.ini` part. 

<details>

I'd write more, but I'm not really sure it'll be read. I figure if I offer these screenshots, someone might get excited about what a relief it would be for a community member to _not_ have to click three times for every instance they wish to delete.

I can defend my choice to dis-allow the deletion of instances with attached volumes. I have not likely arrived at the optimal copy-text for that modal, I thank you in advance for helping to improve that.

## Optimal Case - No Instances w/ Attached Volumes

![screen shot 2018-02-27 at 9 35 14 am](https://user-images.githubusercontent.com/5923/36742963-4c98664a-1ba6-11e8-8b01-4a6602fdeae7.png)

## Possible Case - A Mix of Instances w/ No Attached and Attached Volumes
![screen shot 2018-02-27 at 9 35 29 am](https://user-images.githubusercontent.com/5923/36742962-4c7c4f8c-1ba6-11e8-804b-f9a5d96616ce.png)

</details>

## Checklist before merging Pull Requests
- [ ] ~New test(s) included to reproduce the bug/verify the feature~
- [ ] ~Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Reviewed and approved by at least one other contributor.
- [ ] ~New variables supported in Clank~
- [ ] ~New variables committed to secrets repos~
