### PR TITLE
Problem: shelved instances don't have unshelve action in button bar

### DIFF
--- a/troposphere/static/js/components/projects/detail/resources/InstanceActionButtons.jsx
+++ b/troposphere/static/js/components/projects/detail/resources/InstanceActionButtons.jsx
@@ -32,6 +32,10 @@ export default React.createClass({
         modals.InstanceModals.resume(this.props.instance);
     },
 
+    onUnshelve: function() {
+        modals.InstanceModals.unshelve(this.props.instance);
+    },
+
     onDelete: function() {
         this.props.onUnselect(this.props.instance);
         modals.InstanceModals.destroy({
@@ -89,6 +93,15 @@ export default React.createClass({
                         icon="play"
                         tooltip="Start"
                         onClick={this.onStart}
+                        isVisible={true} />
+                );
+            } else if (status === "shelved_offloaded") {
+               linksArray.push(
+                    <Button style={style}
+                        key="Unshelve"
+                        icon="log-out"
+                        tooltip="Unshelve the selected instance"
+                        onClick={this.onUnshelve}
                         isVisible={true} />
                 );
             }


### PR DESCRIPTION
## Description

This will show the "Unshelve" action for any "shelved_offloaded" instance within the ProjectDetails view. 

Not having this option present is likely why we get support questions about how to "fix" an instance in a "Shelved" state. 

<details>

## Error shown in Production ... 

![screen shot 2018-02-27 at 9 41 23 am](https://user-images.githubusercontent.com/5923/36742961-4c4ca5ca-1ba6-11e8-8b64-22b7b5f52b03.png)

## After the fix ... 

![screen shot 2018-02-27 at 10 19 16 am](https://user-images.githubusercontent.com/5923/36743888-9d9f1d52-1ba8-11e8-8de0-edd2b0bcece1.png)

</details>

## Checklist before merging Pull Requests
- [ ] ~New test(s) included to reproduce the bug/verify the feature~
- [ ] ~Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Reviewed and approved by at least one other contributor.
- [ ] ~New variables supported in Clank~
- [ ] ~New variables committed to secrets repos~
