### PR TITLE
Fix incorrect  provider list in launch modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
   - During migrate resources, choose a default project, so users don't have to
     mechanically select multiple times (especially helpful for developers) ([#776](https://github.com/cyverse/troposphere/pull/776))
 
+### Fixed
+  - Fix launch modal including providers where an image version is end-dated ([#775](https://github.com/cyverse/troposphere/pull/775))
+
 ## [v32-0](https://github.com/cyverse/troposphere/compare/v31-0...v32-0) - 2018-04-06
 ### Added
   - Add confirmation modal to admin resource request ([#750](https://github.com/cyverse/troposphere/pull/750))

--- a/troposphere/static/js/stores/ProviderStore.js
+++ b/troposphere/static/js/stores/ProviderStore.js
@@ -11,7 +11,10 @@ let ProviderStore = BaseStore.extend({
             this.fetchModels();
         } else {
             let providers = this.models;
-            let versionProviders = version.get("machines").map(m => m.provider.id);
+            let versionProviders = version
+                .get("machines")
+                .filter(m => !m.end_date)
+                .map(m => m.provider.id);
 
             // Return version providers (but prefer our models)
             return providers.cfilter(prov => {


### PR DESCRIPTION
## Description
### Problem
Launching an instance would result in an api error "No boot source exists for <uuid>"

### Solution
Filter providers to those that have a non-enddated image version

An image has many versions, and each version has a provider machine, and each
machine can be enddated, which is how an image version can be disabled for a
provider.

We were populating the list of providers with any provider with an image
version, rather than any provider with a non-enddated version.

## Checklist before merging Pull Requests
- [ ] Reviewed and approved by at least one other contributor.