### PR TITLE
During migrating resources modal, pick a default project for user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
     - This is very similar to what we have now. It's just documented somwhere
       on the web where we can point to as a process to follow
   - Make it easy to create projects (don't require a project description) ([#777](https://github.com/cyverse/troposphere/pull/777))
+  - During migrate resources, choose a default project, so users don't have to
+    mechanically select multiple times (especially helpful for developers) ([#776](https://github.com/cyverse/troposphere/pull/776))
 
 ## [v32-0](https://github.com/cyverse/troposphere/compare/v31-0...v32-0) - 2018-04-06
 ### Added

--- a/troposphere/static/js/actions/NullProjectActions.js
+++ b/troposphere/static/js/actions/NullProjectActions.js
@@ -134,6 +134,7 @@ export default {
         });
     },
     migrateResourcesIntoProject: function(nullProject) {
+        const projects = stores.ProjectStore.getAll();
         var instances = nullProject.get("instances"),
             volumes = nullProject.get("volumes"),
             resources = new Backbone.Collection(),
@@ -156,7 +157,8 @@ export default {
 
             var props = {
                 resources: resources,
-                backdrop: "static"
+                backdrop: "static",
+                projects,
             };
 
             ModalHelpers.renderModal(NullProjectMigrateResourceModal, props, function(project_resource_list) {

--- a/troposphere/static/js/components/modals/nullProject/NullProjectMigrateResourceModal.jsx
+++ b/troposphere/static/js/components/modals/nullProject/NullProjectMigrateResourceModal.jsx
@@ -18,7 +18,8 @@ const NullProjectMigrateResourceModal = React.createClass({
     mixins: [BootstrapModalMixin],
 
     propTypes: {
-        resources: React.PropTypes.instanceOf(Backbone.Collection).isRequired
+        resources: React.PropTypes.instanceOf(Backbone.Collection).isRequired,
+        projects: React.PropTypes.instanceOf(Backbone.Collection).isRequired
     },
 
     onProjectCreated(project) {
@@ -63,11 +64,12 @@ const NullProjectMigrateResourceModal = React.createClass({
 
     getInitialState: function() {
 
+        const defaultProject = this.props.projects.first();
         let resourceProjectMap = {};
 
         this.props.resources.forEach(resource => {
             resourceProjectMap[resource.id] = {
-                project: null,
+                project: defaultProject,
                 resource
             }
         });


### PR DESCRIPTION
## Description
During migrating resources modal, pick a default project for user

In the screenshot a default project is chosen, so I could migrate, by simple clicking one button. This will be helpful primarily to developers. If it were more helpful for users, i would consider looking into picking the last used project or something.
![2018-04-17-161510_3840x2160_scrot](https://user-images.githubusercontent.com/3847314/38903728-3a15e6ec-425b-11e8-878a-3e4f6593d7d8.png)

## Checklist before merging Pull Requests
- [ ] Add an entry in the changelog
- [ ] Reviewed and approved by at least one other contributor.