### PR TITLE
Enable optimistic updating in the Settings page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
   - Fix launch modal including providers where an image version is end-dated ([#775](https://github.com/cyverse/troposphere/pull/775))
+  - Fix a few bugs to enable optimistic updating on the settings page ([#783](https://github.com/cyverse/troposphere/pull/783))
+    - In the SettingsPage, get the user's preferences directly from the attributes instead of `attributes.settings`
+    - Fix usage of the ProfileStore's update method by passing it just one argument from the action payload and converting it to JSON before setting the new preferences
+    - Finally, create a clone of the profile object in ProfileActions before modifying it to show the newly-selected preferences. This allows the program to easily revert the changes by switching back to the clone if the Atmosphere API call fails
 
 ## [v32-0](https://github.com/cyverse/troposphere/compare/v31-0...v32-0) - 2018-04-06
 ### Added

--- a/troposphere/static/js/actions/ProfileActions.js
+++ b/troposphere/static/js/actions/ProfileActions.js
@@ -3,26 +3,28 @@ import NotificationController from "controllers/NotificationController";
 import Utils from "./Utils";
 
 export default {
-
     updateProfileAttributes: function(profile, newAttributes) {
+        let clonedProfile = profile.clone();
         profile.set(newAttributes);
         Utils.dispatch(ProfileConstants.UPDATE_PROFILE, {
             profile: profile
         });
 
-        profile.save(newAttributes, {
-            patch: true
-        }).done(function() {
-            //NotificationController.success(null, "Settings updated.");
-            Utils.dispatch(ProfileConstants.UPDATE_PROFILE, {
-                profile: profile
+        profile
+            .save(newAttributes, {
+                patch: true
+            })
+            .done(function() {
+                NotificationController.success(null, "Settings updated.");
+                Utils.dispatch(ProfileConstants.UPDATE_PROFILE, {
+                    profile: profile
+                });
+            })
+            .catch(function() {
+                NotificationController.error(null, "Error updating Settings.");
+                Utils.dispatch(ProfileConstants.UPDATE_PROFILE, {
+                    profile: clonedProfile
+                });
             });
-        }).fail(function() {
-            NotificationController.error(null, "Error updating Settings");
-            Utils.dispatch(ProfileConstants.UPDATE_PROFILE, {
-                profile: profile
-            });
-        });
-
     }
 }

--- a/troposphere/static/js/components/settings/SettingsPage.jsx
+++ b/troposphere/static/js/components/settings/SettingsPage.jsx
@@ -62,9 +62,9 @@ export default React.createClass({
 
     render: function() {
         var profile = this.state.profile;
-        var selectedIconSet = profile.get("settings")["icon_set"];
-        var selectedGuacamoleColor = profile.get("settings")["guacamole_color"];
-        var wantsEmails = profile.get("settings")["send_emails"];
+        var selectedIconSet = profile.get("icon_set");
+        var selectedGuacamoleColor = profile.get("guacamole_color");
+        var wantsEmails = profile.get("send_emails");
 
         return (
         <div className="settings-view">

--- a/troposphere/static/js/stores/ProfileStore.js
+++ b/troposphere/static/js/stores/ProfileStore.js
@@ -42,9 +42,7 @@ let fetchProfile = function() {
 }
 
 function update(profile) {
-    _profile.set(profile, {
-        merge: true
-    });
+    _profile.set(profile.toJSON());
 }
 
 //
@@ -61,12 +59,10 @@ let ProfileStore = {
 
 };
 
-Dispatcher.register(function(payload) {
-    var action = payload.action;
-
-    switch (action.actionType) {
+Dispatcher.register(function({action: {actionType, payload}}) {
+    switch (actionType) {
         case ProfileConstants.UPDATE_PROFILE:
-            update(action.name, action.description);
+            update(payload.profile);
             break;
 
         default:


### PR DESCRIPTION
## Description
This allows users to have a nice experience in changing settings even when the API is slow.
If the requested changes fail to update in the API, the original settings will be restored in the interface and the user notified. The user is also notified on success.

Before this PR, users would click a new preference and nothing would happen for up to up to 6 seconds depending on the response from the API, causing them to rapidly click until the change finished.

Almost forgot to mention big thanks to @cdosborn for all the help with the PR including doing most of it and teaching me about React!

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [x] Add an entry in the changelog
- [ ] Documentation created/updated (include links)
- [x] Reviewed and approved by at least one other contributor.
- [ ] New variables supported in Clank
- [ ] New variables committed to secrets repos

