### PR TITLE
Allow project delete if instances/volumes are removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
   - Make it easy to create projects (don't require a project description) ([#777](https://github.com/cyverse/troposphere/pull/777))
   - During migrate resources, choose a default project, so users don't have to
     mechanically select multiple times (especially helpful for developers) ([#776](https://github.com/cyverse/troposphere/pull/776))
+  - Allow deleting projects that still contain applications/links
+    ([#785](https://github.com/cyverse/troposphere/pull/785))
 
 ### Fixed
   - Fix launch modal including providers where an image version is end-dated ([#775](https://github.com/cyverse/troposphere/pull/775))

--- a/troposphere/static/js/components/modals/project/ProjectDeleteConditionsModal.jsx
+++ b/troposphere/static/js/components/modals/project/ProjectDeleteConditionsModal.jsx
@@ -30,16 +30,19 @@ export default React.createClass({
         <div role="form">
             <div className="form-group">
                 <p className="alert alert-info">
-                    <i className="glyphicon glyphicon-info-sign" /> 
+                    <i className="glyphicon glyphicon-info-sign" />
                     <strong> Uh-oh! </strong>
                     {"It looks like you're trying to delete this project. However, we don't currently support " +
                      "deleting projects that have resources in them."}
                 </p>
                 <p>
-                    Before you can delete this project, you first need to either <strong>DELETE</strong> all resources in this project <span style={{ "textDecoration": "underline" }}>or</span>            <strong>MOVE</strong> them into another project.
+                    Before you can delete this project, you first need to
+                    either <strong>DELETE</strong> any instances and volumes{" "}
+                    <span style={{textDecoration: "underline"}}>or</span>{" "}
+                    <strong>MOVE</strong> them into another project.
                 </p>
                 <p>
-                    Once there are no resources left in the project, you'll be able to delete it.
+                    Once these are removed, you'll be able to delete it.
                 </p>
             </div>
         </div>

--- a/troposphere/static/js/components/projects/common/SecondaryProjectNavigation.jsx
+++ b/troposphere/static/js/components/projects/common/SecondaryProjectNavigation.jsx
@@ -20,13 +20,9 @@ export default React.createClass({
 
         var project = this.props.project,
             projectInstances = stores.ProjectInstanceStore.getInstancesFor(project),
-            projectImages = stores.ProjectImageStore.getImagesCountFor(project),
-            projectExternalLinks = stores.ProjectExternalLinkStore.getExternalLinksFor(project),
             projectVolumes = stores.ProjectVolumeStore.getVolumesFor(project);
 
         if (projectInstances.length > 0
-            || projectImages.length > 0
-            || projectExternalLinks.length > 0
             || projectVolumes.length > 0) {
             modals.ProjectModals.explainProjectDeleteConditions();
         } else {


### PR DESCRIPTION
## Description

### Problem
A user who wants to delete a project has to delete unnecessary resources like linked applications/urls in the project

### Solution
Only prohibit deletion if active instances/volumes are present

Related: https://github.com/cyverse/atmosphere/pull/640

## Checklist before merging Pull Requests
- [x] Add an entry in the changelog
- [ ] Documentation created/updated (include links)