### PR TITLE
Remove redundant todo item

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -9,5 +9,4 @@ Please describe your pull request. If you're solving a problem, include a onelin
 - [ ] Documentation created/updated (include links)
 - [ ] Reviewed and approved by at least one other contributor.
 - [ ] New variables supported in Clank
-- [ ] New variables committed to secrets repos
 -->


### PR DESCRIPTION
## Description
Adding clank secrets should be a part of clank's PR process not tropospheres