### PR TITLE
Update requirements to use psycopg 2.7.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Added
   - Add support for CAS 5
 
+### Changed
+  - Update `psycopg` requirement to version 2.7.3.1
+    ([#795](https://github.com/cyverse/troposphere/pull/795))
+
 ### Removed
   - Remove unused SERVER_EMAIL variable
 

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -61,7 +61,7 @@ pexpect==4.2.1            # via ipython
 pickleshare==0.7.4        # via ipython
 positional==1.1.1
 prompt-toolkit==1.0.14    # via ipython
-psycopg2==2.7.1
+psycopg2==2.7.3.1
 ptyprocess==0.5.2         # via pexpect
 pyasn1-modules==0.0.9
 pyasn1==0.2.3

--- a/requirements.in
+++ b/requirements.in
@@ -12,7 +12,7 @@ Jinja2
 pycrypto
 PyJWT
 python-dateutil
-psycopg2
+psycopg2==2.7.3.1
 requests[security]
 uWSGI
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ oslo.serialization==2.20.0  # via python-keystoneclient
 oslo.utils==3.28.0        # via oslo.serialization, python-keystoneclient
 pbr==3.1.1                # via debtcollector, keystoneauth1, oslo.i18n, oslo.serialization, oslo.utils, positional, python-keystoneclient, stevedore
 positional==1.1.1         # via keystoneauth1, python-keystoneclient
-psycopg2==2.7.1
+psycopg2==2.7.3.1
 pyasn1-modules==0.0.9     # via oauth2client
 pyasn1==0.2.3             # via oauth2client, pyasn1-modules, rsa
 pycparser==2.18


### PR DESCRIPTION
## Description

This PR updates the requirements to make Troposphere run on Ubuntu 18.04.
The **only** change between 2.7.3 and 2.7.3.1 is a bug fix that prevents
a glibc incompatibility on Ubuntu 16+

This is required for PRs:
- Atmosphere [PR #696](https://github.com/cyverse/atmosphere/pull/696)
- Clank [PR #283](https://github.com/cyverse/clank/pull/283)

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Add an entry in the changelog
- [ ] Documentation created/updated (include links)
- [ ] Reviewed and approved by at least one other contributor.
- [ ] New variables supported in Clank
