### PR TITLE
JETSTREAM-208: Don't close code block when clicked

### DIFF
--- a/troposphere/static/js/components/common/ui/CollapsibleOutput.jsx
+++ b/troposphere/static/js/components/common/ui/CollapsibleOutput.jsx
@@ -1,6 +1,7 @@
+import React from "react";
 import {ShowMoreEllipsis} from "cyverse-ui";
 import {marg} from "cyverse-ui/styles";
-import React from "react";
+import CopyButton from "components/common/ui/CopyButton";
 
 /**
  * A consistently styled `<code/>` element
@@ -26,6 +27,18 @@ const Code = props => {
 
     return <pre style={style}>{text}</pre>;
 };
+
+const NoStyleButton = props => (
+    <button
+        {...props}
+        style={{
+            display: "inline",
+            background: "none",
+            outline: "none",
+            border: "none"
+        }}
+    />
+);
 
 /**
  * Allow a region to be collapsed and expanded to avoid
@@ -60,21 +73,26 @@ const CollapsibleOutput = React.createClass({
 
         if (!open) {
             content = (
-                <span onClick={this.onEllipsisClick}>
-                    {` ${partial} `}
-                    <ShowMoreEllipsis />
+                <span>
+                    <span>{` ${partial} `}</span>
+                    <NoStyleButton onClick={this.onEllipsisClick}>
+                        <ShowMoreEllipsis />
+                    </NoStyleButton>
                 </span>
             );
         } else {
             content = (
-                <span onClick={this.onEllipsisClick}>
-                    <ShowMoreEllipsis />
+                <span>
+                    <NoStyleButton onClick={this.onEllipsisClick}>
+                        <ShowMoreEllipsis />
+                    </NoStyleButton>
+                    <CopyButton text={output} />
                     <Code text={output} />
                 </span>
             );
         }
 
-        return <div style={{display: "inline-block"}}>{content}</div>;
+        return <span>{content}</span>;
     }
 });
 


### PR DESCRIPTION
## Problem: User can't copy "Error Output" on admin/ image-requests

An error output can be reveled by clicking on an ellipsis, however when a user clicks on the code block to copy the text, the code block is closed before the contents can be selected.

This PR moves the handler to the ellipsis so that the ellipses must be clicked to close the code block. It addition, for convenience, a quick copy button was added. 

### Reproduce:
Go to `./admin/imaging-requests` and find an image request with "(ERROR) next to the name. in the list on the left. click on it to view its details and find "Request state" and the ellipsis button in question to the right.

### Checklist before merging Pull Requests
- [ ] Add an entry in the changelog
- [ ] Reviewed and approved by at least one other contributor.
