### PR TITLE
JETSTREAM-237: admins can toggle filtering end dated images

### DIFF
--- a/troposphere/static/js/components/images/list/list/ImageCardList.jsx
+++ b/troposphere/static/js/components/images/list/list/ImageCardList.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import Backbone from "backbone";
 import ImageListCard from "../common/ImageListCard";
+import {Toggle} from "material-ui";
 import {filterEndDate} from "utilities/filterCollection";
 import stores from "stores";
 
@@ -9,15 +10,17 @@ export default React.createClass({
         title: React.PropTypes.string,
         images: React.PropTypes.instanceOf(Backbone.Collection).isRequired
     },
-
-    renderTitle: function() {
+    getInitialState() {
+        return {
+            showEndDated: true
+        };
+    },
+    renderTitle() {
         var title = this.props.title;
         if (!title) return;
-
         return <h3 className="t-title">{title}</h3>;
     },
-
-    renderCard: function(image) {
+    renderCard(image) {
         let isEndDated = !filterEndDate(image);
         let imageMetric = stores.ImageMetricsStore.get(image.id);
 
@@ -31,14 +34,35 @@ export default React.createClass({
             </li>
         );
     },
+    renderToggle(showEndDated) {
+        return (
+            <div style={{float: "right", width: "150px"}}>
+                <Toggle
+                    label="Show End Dated"
+                    onToggle={() =>
+                        this.setState({
+                            showEndDated: !showEndDated
+                        })
+                    }
+                />
+            </div>
+        );
+    },
 
-    render: function() {
-        var images = this.props.images;
-        var imageCards = images.map(this.renderCard);
+    render() {
+        const images = this.props.images;
+        const {showEndDated} = this.state;
+        const profile = stores.ProfileStore.get();
+        const isStaff = profile.get("is_staff");
+        const imageFilter = showEndDated ? filterEndDate : () => true;
+        const imageCards = images.filter(imageFilter).map(this.renderCard);
 
         return (
             <div>
-                {this.renderTitle()}
+                <div className="clearfix">
+                    {isStaff && this.renderToggle(showEndDated)}
+                    {this.renderTitle()}
+                </div>
                 <ul className="app-card-list">{imageCards}</ul>
             </div>
         );


### PR DESCRIPTION
## JETSTREAM-23: admins can toggle filtering end dated images
When a user is an admin they will have a toggle on image lists that allows them to toggle showing or hiding end dated images
## Screenshot shows toggle on the right of list title
![Screenshot from 2019-05-09 18-14-08](https://user-images.githubusercontent.com/7366338/57496158-5e03c400-7286-11e9-9d7b-739fb6d6f787.png)


## Checklist before merging Pull Requests
- [x] Add an entry in the changelog
- [ ] Reviewed and approved by at least one other contributor.
