### PR TITLE
ATMO-2143: Image Request not populating base image tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Fixed
   - Fix `python-ldap` dependency's broken version (now using 3.1.0)
     ([#798](https://github.com/cyverse/troposphere/pull/798))
+  - ATMO-2143: Image Request not populating base image tags
+    ([#808](https://github.com/cyverse/troposphere/pull/808))
 
 ## [v34-0](https://github.com/cyverse/troposphere/compare/v33-0...v34-0) - 2018-09-17
 ### Added

--- a/troposphere/static/js/components/modals/instance/image/steps/ImageInfoStep.jsx
+++ b/troposphere/static/js/components/modals/instance/image/steps/ImageInfoStep.jsx
@@ -7,7 +7,6 @@ import Name from "../components/Name";
 import CreateUpdateFlag from "../components/CreateUpdateFlag";
 import Description from "../components/Description";
 import Tags from "../components/Tags";
-import TagCollection from "collections/TagCollection";
 
 import {captureMessage} from "utilities/capture";
 
@@ -25,14 +24,11 @@ export default React.createClass({
 
     componentDidMount: function() {
         stores.ImageStore.addChangeListener(this.updateState);
-        stores.TagStore.addChangeListener(this.updateState);
-
         this.updateState();
     },
 
     componentWillUnmount: function() {
         stores.ImageStore.removeChangeListener(this.updateState);
-        stores.TagStore.removeChangeListener(this.updateState);
     },
 
     getInitialState: function() {
@@ -43,14 +39,13 @@ export default React.createClass({
             defaultName = instance.get("image").name;
             defaultDescription = instance.get("image").description;
         }
-        let imageTags = new TagCollection(instance.get("image").tags);
 
         return {
             name: defaultName,
             nameError: this.setNameError(defaultName),
             description: defaultDescription,
             newImage: true,
-            imageTags
+            imageTags: this.props.tags
         };
     },
 
@@ -153,7 +148,6 @@ export default React.createClass({
                 component: this.displayName
             });
         }
-
         return (
             <div>
                 <div className="alert alert-danger">


### PR DESCRIPTION
# ATMO-2143: Image Request not populating base image tags
When a opens the Image Request Modal the basic info has an option to set tags. Tags from the base image should be added by default for the users convenience and a message states so. Instead there are no images added. This PR fixes that so the tag list is populated as expected.
 
## Checklist before merging Pull Requests
- [x] Add an entry in the changelog
- [x] Reviewed and approved by at least one other contributor.