### PR TITLE
Improve delete instance when volumes are attached warning message and format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Changed
   - Change ./manage.py maintenance to be non-interactive
     ([#769](https://github.com/cyverse/troposphere/pull/769))
+  - Improve Delete Instance while Volumes Attached warning message
+    ([#809](https://github.com/cyverse/troposphere/pull/809))
 
 ### Fixed
   - Admin request panel can view older requests

--- a/troposphere/static/js/components/modals/instance/ExplainInstanceDeleteConditionsModal.jsx
+++ b/troposphere/static/js/components/modals/instance/ExplainInstanceDeleteConditionsModal.jsx
@@ -37,26 +37,27 @@ export default React.createClass({
                 <div className="form-group">
                     <div className="alert alert-danger" role="alert">
                         <Glyphicon name="exclamation-sign" />
-                        {" Cannot delete while volumes are attached."}
+                        {
+                            " It is not advised to delete while volumes are attached"
+                        }
                     </div>
                     <p>
+                        {`If volumes are being read or written to, instance deletion can corrupt them.
+                        Please first detach the volume(s) before deleting this instance`}
+                    </p>
+                    <p>
                         {
-                            "This instance currently has the following volumes attached to it:"
+                            "This following volumes are attached to this instance:"
                         }
                     </p>
-                    <ul>{this.renderAttachedVolumes()}</ul>
-                    <p>
-                        {"Detach the above volumes to safely delete this instance. " +
-                            "If volumes are being read or written to, instance deletion can corrupt volumes. "}
-                        <a
-                            style={{
-                                color: "black",
-                                textDecoration: "underline"
-                            }}
-                            onClick={this.confirm}>
-                            Delete anyway
-                        </a>.
-                    </p>
+                    <ul style={{marginBottom: "48px"}}>
+                        {this.renderAttachedVolumes()}
+                    </ul>
+                    <button
+                        className="btn btn-danger pull-right"
+                        onClick={this.confirm}>
+                        <Glyphicon name="exclamation-sign" /> DELETE ANYWAY
+                    </button>
                 </div>
             </div>
         );
@@ -75,9 +76,9 @@ export default React.createClass({
                         <div className="modal-body">{this.renderBody()}</div>
                         <div className="modal-footer">
                             <RaisedButton
-                                primary
+                                default
                                 onTouchTap={this.hide}
-                                label="Okay"
+                                label="Cancel"
                             />
                         </div>
                     </div>


### PR DESCRIPTION
The delete instance when volumes are attached warning message wasn't concise and the formatting was clunky. This PR improves the message and formatting.

## Before
![image](https://user-images.githubusercontent.com/7366338/58845570-95208780-8630-11e9-9ebd-46f2e108868f.png)

## After
![Screenshot from 2019-06-03 18-41-57](https://user-images.githubusercontent.com/7366338/58845542-80dc8a80-8630-11e9-91b0-634fdd981625.png)

## Checklist before merging Pull Requests
- [x] Add an entry in the changelog
- [x] Reviewed and approved by at least one other contributor.
