### PR TITLE
Fix submit on license step in launch wizard

### DIFF
--- a/troposphere/static/js/components/modals/instance/InstanceLaunchWizardModal.jsx
+++ b/troposphere/static/js/components/modals/instance/InstanceLaunchWizardModal.jsx
@@ -816,6 +816,7 @@ export default React.createClass({
                 onSubmitLaunch={this.onSubmitLaunch}
                 onBack={this.viewBasic}
                 onCancel={this.hide}
+                waitingOnLaunch={this.state.waitingOnLaunch}
             />
         );
     },

--- a/troposphere/static/js/components/modals/instance/launch/steps/LicenseStep.jsx
+++ b/troposphere/static/js/components/modals/instance/launch/steps/LicenseStep.jsx
@@ -33,17 +33,13 @@ export default React.createClass({
     },
 
     onAgree: function() {
-        let signedList = this.state.signedList;
+        let {signedList, license} = this.state;
+        // Toggle State: remove or add license to list
+        const newSignedList = signedList.includes(license)
+            ? signedList.filter(item => item !== license)
+            : [...signedList, license];
 
-        if (signedList.length === 0) {
-            signedList = [...this.props.licenseList];
-        } else {
-            signedList = [];
-        }
-
-        this.setState({
-            signedList
-        });
+        this.setState({signedList: newSignedList});
     },
 
     renderLicense: function(item) {


### PR DESCRIPTION
## Description

Problem: When launching an image with a required license, after user checks to confirm agreement and launches the modal hangs indefinitely without user feedback even though image launches successfully.

Expected: Now in the above context user sees "launching" message with spinner until image has deployed.

## Checklist before merging Pull Requests
- [ ] Reviewed and approved by at least one other contributor.
