### PR TITLE
Multi instance launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 -->
 
 ## [Unreleased](https://github.com/cyverse/troposphere/compare/v36-4...HEAD) - YYYY-MM-DD
+### Added
+  - Add instance count field in launch wizard to support multi-instance-launch
+    ([#832](https://github.com/cyverse/troposphere/pull/832))
 
-
-## [Unreleased](https://github.com/cyverse/troposphere/compare/v36-2...v36-4) - 2019-09-10
+## [v36-4](https://github.com/cyverse/troposphere/compare/v36-2...v36-4) - 2019-09-10
 ### Fixed
   - Patched style issue with XSEDE button
     ([#818](https://github.com/cyverse/troposphere/pull/818))

--- a/troposphere/static/js/actions/InstanceActions.js
+++ b/troposphere/static/js/actions/InstanceActions.js
@@ -6,6 +6,7 @@ import IReboot from "./instance/reboot";
 import IRedeploy from "./instance/redeploy";
 import IPoll from "./instance/poll";
 import ILaunch from "./instance/launch";
+import IMultiLaunch from "./instance/multiLaunch";
 import IDestroy from "./instance/destroy";
 import IUpdate from "./instance/update";
 import IReport from "./instance/report";
@@ -24,6 +25,7 @@ export default {
     redeploy: IRedeploy.redeploy,
     poll: IPoll.poll,
     launch: ILaunch.launch,
+    multiLaunch: IMultiLaunch.multiLaunch,
     destroy: IDestroy.destroy,
     update: IUpdate.update,
     report: IReport.report,

--- a/troposphere/static/js/actions/instance/launch.js
+++ b/troposphere/static/js/actions/instance/launch.js
@@ -35,13 +35,17 @@ function launch(params) {
         params.machine = selected_machines[0];
     }
     if (!params.machine) throw new Error("Missing machine");
-    if (params.instanceCount) {
-        if (!Number.isInteger(params.instanceCount)) {
-            throw new Error("Instance count should be an integer");
-        }
-        if (params.instanceCount < 1) {
-            throw new Error("Instance count should be a postive integer");
-        }
+    if (!params.instanceCount) {
+        throw new Error("missing instanceCount");
+    }
+    if (!Number.isInteger(params.instanceCount)) {
+        throw new Error("Instance count should be an integer");
+    }
+    if (params.instanceCount < 1) {
+        throw new Error("Instance count should be a postive integer");
+    }
+    if (params.instanceCount != 1) {
+        throw new Error("Single launch require instance count of 1");
     }
 
     let {

--- a/troposphere/static/js/actions/instance/launch.js
+++ b/troposphere/static/js/actions/instance/launch.js
@@ -35,6 +35,14 @@ function launch(params) {
         params.machine = selected_machines[0];
     }
     if (!params.machine) throw new Error("Missing machine");
+    if (params.instanceCount) {
+        if (!Number.isInteger(params.instanceCount)) {
+            throw new Error("Instance count should be an integer");
+        }
+        if (params.instanceCount < 1) {
+            throw new Error("Instance count should be a postive integer");
+        }
+    }
 
     let {
         project,
@@ -43,6 +51,7 @@ function launch(params) {
         size,
         machine,
         scripts,
+        instanceCount,
         onSuccess,
         onFail
     } = params;
@@ -92,7 +101,8 @@ function launch(params) {
         source_alias: machine.uuid,
         scripts: scripts,
         project: project,
-        allocation_source_id: params.allocation_source_uuid
+        allocation_source_id: params.allocation_source_uuid,
+        instance_count: instanceCount
     };
 
     // Create Instance using the v2 API endpoint

--- a/troposphere/static/js/actions/instance/multiLaunch.js
+++ b/troposphere/static/js/actions/instance/multiLaunch.js
@@ -173,13 +173,16 @@ function multiLaunch(params) {
             appBrowserHistory.push(`/projects/${project.id}/resources`);
         })
         .fail(function(response) {
-            // Remove instance from stores
-            Utils.dispatch(InstanceConstants.REMOVE_INSTANCE, {
-                instance: instances[0]
-            });
-            Utils.dispatch(ProjectInstanceConstants.REMOVE_PROJECT_INSTANCE, {
-                projectInstance: projectInstances[0]
-            });
+
+            // Remove instances from stores
+            for(let i = 0; i < instanceCount; i++) {
+                Utils.dispatch(InstanceConstants.REMOVE_INSTANCE, {
+                    instance: instances[i]
+                });
+                Utils.dispatch(ProjectInstanceConstants.REMOVE_PROJECT_INSTANCE, {
+                    projectInstance: projectInstances[i]
+                });
+            }
             Utils.displayError({
                 title: "Instances could not be launched",
                 response: response

--- a/troposphere/static/js/actions/instance/multiLaunch.js
+++ b/troposphere/static/js/actions/instance/multiLaunch.js
@@ -1,0 +1,194 @@
+import {appBrowserHistory} from "utilities/historyFunctions";
+
+import Utils from "../Utils";
+
+//
+// Constants
+//
+import InstanceConstants from "constants/InstanceConstants";
+import ProjectInstanceConstants from "constants/ProjectInstanceConstants";
+
+//
+// Models
+//
+import Instance from "models/Instance";
+import ProjectInstance from "models/ProjectInstance";
+
+function multiLaunch(params) {
+    if (!params.project) throw new Error("Missing project");
+    if (!params.instanceName) throw new Error("Missing instanceName");
+    if (!params.identity) throw new Error("Missing identity");
+    if (!params.size) throw new Error("Missing size");
+    if (params.version) {
+        let machines = params.version.get("machines"),
+            selected_machines = machines.filter(function(machine) {
+                return (
+                    machine.provider.uuid ===
+                    params.identity.get("provider").uuid
+                );
+            });
+        if (!selected_machines.length) {
+            throw new Error(
+                "Machine could not be filtered-down based on selected version & identity"
+            );
+        }
+        params.machine = selected_machines[0];
+    }
+    if (!params.machine) throw new Error("Missing machine");
+    if (!params.instanceCount) {
+        throw new Error("missing instanceCount");
+    }
+    if (!Number.isInteger(params.instanceCount)) {
+        throw new Error("Instance count should be an integer");
+    }
+    if (params.instanceCount < 1) {
+        throw new Error("Instance count should be a postive integer");
+    }
+    if (params.instanceCount <= 1) {
+        throw new Error("Multi launch require instance count > 1");
+    }
+
+    let {
+        project,
+        instanceName,
+        identity,
+        size,
+        machine,
+        scripts,
+        instanceCount,
+        onSuccess,
+        onFail
+    } = params;
+
+
+    let instances = [];
+    let projectInstances = [];
+
+    for(let i = 0; i < instanceCount; i++) {
+
+        // Create Instance
+        let instance = new Instance(
+            {
+                name: instanceName,
+                size: {
+                    id: size.id,
+                    alias: size.get("alias")
+                },
+                status: "build - requesting_launch",
+                provider: {
+                    id: identity.get("provider").id,
+                    uuid: identity.get("provider").uuid
+                },
+                project: project.id,
+                identity: {
+                    id: identity.id,
+                    uuid: identity.get("uuid")
+                }
+            },
+            {
+                parse: true
+            }
+        );
+        // Create ProjectInstance
+        let projectInstance = new ProjectInstance({
+            project: project.toJSON(),
+            instance: instance.toJSON()
+        });
+        instances.push(instance);
+        projectInstances.push(projectInstance);
+    }
+
+    for(let i = 0; i < instanceCount; i++) {
+
+        // Add instance to InstanceStore
+        Utils.dispatch(InstanceConstants.ADD_INSTANCE, {
+            instance: instances[i]
+        });
+
+        // Add to ProjectInstanceStore
+        Utils.dispatch(ProjectInstanceConstants.ADD_PROJECT_INSTANCE, {
+            projectInstance: projectInstances[i]
+        });
+
+    }
+
+    let payload = {
+        name: instanceName,
+        size_alias: size.get("alias"),
+        source_alias: machine.uuid,
+        scripts: scripts,
+        project: project,
+        allocation_source_id: params.allocation_source_uuid,
+        instance_count: instanceCount
+    };
+
+    // Create Instance using the v2 API endpoint
+    instances[0]
+        .create(payload)
+        .done(function(attrs, status, response) {
+
+            // Response to a multi-launch must be an array
+            if (! Array.isArray(attrs)) {
+                throw new Error("Response does not contain array");
+            }
+
+            // launched fewer instances than requsted
+            if(attrs.length < instances.length) {
+            }
+
+            // if multi launch, attrs is an array
+            for (let i = 0; i < attrs.length; i++) {
+
+                instances[i].set("id", attrs[i].id);
+                instances[i].set("uuid", attrs[i].alias);
+                console.log("instances[" + i + "]:");
+                console.log(instances[i]);
+
+                // Get the instance from the cloud, ignore our local copy
+                instances[i].fetch().then(
+                    function() {
+                        console.log("fetch");
+                        console.log(instances[i]);
+                        Utils.dispatch(InstanceConstants.POLL_INSTANCE, {
+                            instance: instances[i]
+                        });
+                    },
+                    function() {
+                        console.log("fetch failed");
+                        /**
+                         * this can have the same function signature as a `fail`
+                         *
+                         * the arguments would be: (jqXHR, textStatus, errorThrown)
+                         */
+                        Utils.dispatch(InstanceConstants.POLL_INSTANCE, {
+                            instance: instances[i]
+                        });
+                    }
+                );
+            }
+
+            onSuccess();
+
+            // only change _context_ if we have succeeded in launching
+            appBrowserHistory.push(`/projects/${project.id}/resources`);
+        })
+        .fail(function(response) {
+            // Remove instance from stores
+            Utils.dispatch(InstanceConstants.REMOVE_INSTANCE, {
+                instance: instances[0]
+            });
+            Utils.dispatch(ProjectInstanceConstants.REMOVE_PROJECT_INSTANCE, {
+                projectInstance: projectInstances[0]
+            });
+            Utils.displayError({
+                title: "Instances could not be launched",
+                response: response
+            });
+
+            onFail();
+        });
+}
+
+export default {
+    multiLaunch
+};

--- a/troposphere/static/js/actions/instance/multiLaunch.js
+++ b/troposphere/static/js/actions/instance/multiLaunch.js
@@ -136,7 +136,10 @@ function multiLaunch(params) {
             if(attrs.length < instances.length) {
                 Utils.displayError({
                     title: "Some instances failed to launch",
-                    response: "Only launched ${attrs.length} out of ${instances.length} instances"
+                    response: {
+                        status: status,
+                        responseText: "Only launched " + attrs.length + " out of " + instances.length + " instances"
+                    }
                 });
             }
 

--- a/troposphere/static/js/actions/instance/multiLaunch.js
+++ b/troposphere/static/js/actions/instance/multiLaunch.js
@@ -60,12 +60,10 @@ function multiLaunch(params) {
         onFail
     } = params;
 
-
     let instances = [];
     let projectInstances = [];
 
-    for(let i = 0; i < instanceCount; i++) {
-
+    for (let i = 0; i < instanceCount; i++) {
         // Create Instance
         let instance = new Instance(
             {
@@ -98,8 +96,7 @@ function multiLaunch(params) {
         projectInstances.push(projectInstance);
     }
 
-    for(let i = 0; i < instanceCount; i++) {
-
+    for (let i = 0; i < instanceCount; i++) {
         // Add instance to InstanceStore
         Utils.dispatch(InstanceConstants.ADD_INSTANCE, {
             instance: instances[i]
@@ -109,7 +106,6 @@ function multiLaunch(params) {
         Utils.dispatch(ProjectInstanceConstants.ADD_PROJECT_INSTANCE, {
             projectInstance: projectInstances[i]
         });
-
     }
 
     let payload = {
@@ -126,26 +122,29 @@ function multiLaunch(params) {
     instances[0]
         .create(payload)
         .done(function(attrs, status, response) {
-
             // Response to a multi-launch must be an array
-            if (! Array.isArray(attrs)) {
+            if (!Array.isArray(attrs)) {
                 throw new Error("Response does not contain array");
             }
 
             // launched fewer instances than requsted
-            if(attrs.length < instances.length) {
+            if (attrs.length < instances.length) {
                 Utils.displayError({
                     title: "Some instances failed to launch",
                     response: {
                         status: status,
-                        responseText: "Only launched " + attrs.length + " out of " + instances.length + " instances"
+                        responseText:
+                            "Only launched " +
+                            attrs.length +
+                            " out of " +
+                            instances.length +
+                            " instances"
                     }
                 });
             }
 
             // if multi launch, attrs is an array
             for (let i = 0; i < attrs.length; i++) {
-
                 instances[i].set("id", attrs[i].id);
                 instances[i].set("uuid", attrs[i].alias);
 
@@ -175,15 +174,17 @@ function multiLaunch(params) {
             appBrowserHistory.push(`/projects/${project.id}/resources`);
         })
         .fail(function(response) {
-
             // Remove instances from stores
-            for(let i = 0; i < instanceCount; i++) {
+            for (let i = 0; i < instanceCount; i++) {
                 Utils.dispatch(InstanceConstants.REMOVE_INSTANCE, {
                     instance: instances[i]
                 });
-                Utils.dispatch(ProjectInstanceConstants.REMOVE_PROJECT_INSTANCE, {
-                    projectInstance: projectInstances[i]
-                });
+                Utils.dispatch(
+                    ProjectInstanceConstants.REMOVE_PROJECT_INSTANCE,
+                    {
+                        projectInstance: projectInstances[i]
+                    }
+                );
             }
             Utils.displayError({
                 title: "Instances could not be launched",

--- a/troposphere/static/js/actions/instance/multiLaunch.js
+++ b/troposphere/static/js/actions/instance/multiLaunch.js
@@ -134,6 +134,10 @@ function multiLaunch(params) {
 
             // launched fewer instances than requsted
             if(attrs.length < instances.length) {
+                Utils.displayError({
+                    title: "Some instances failed to launch",
+                    response: "Only launched ${attrs.length} out of ${instances.length} instances"
+                });
             }
 
             // if multi launch, attrs is an array

--- a/troposphere/static/js/actions/instance/multiLaunch.js
+++ b/troposphere/static/js/actions/instance/multiLaunch.js
@@ -148,20 +148,15 @@ function multiLaunch(params) {
 
                 instances[i].set("id", attrs[i].id);
                 instances[i].set("uuid", attrs[i].alias);
-                console.log("instances[" + i + "]:");
-                console.log(instances[i]);
 
                 // Get the instance from the cloud, ignore our local copy
                 instances[i].fetch().then(
                     function() {
-                        console.log("fetch");
-                        console.log(instances[i]);
                         Utils.dispatch(InstanceConstants.POLL_INSTANCE, {
                             instance: instances[i]
                         });
                     },
                     function() {
-                        console.log("fetch failed");
                         /**
                          * this can have the same function signature as a `fail`
                          *

--- a/troposphere/static/js/components/modals/instance/InstanceLaunchWizardModal.jsx
+++ b/troposphere/static/js/components/modals/instance/InstanceLaunchWizardModal.jsx
@@ -367,8 +367,10 @@ export default React.createClass({
 
     onCountChange: function(e) {
         let instanceCount = parseInt(e.target.value);
-        instanceCount = Number.isNaN(instanceCount) || instanceCount < 1
-            ? 1 : instanceCount;
+        instanceCount =
+            Number.isNaN(instanceCount) || instanceCount < 1
+                ? 1
+                : instanceCount;
         this.setState({
             instanceCount
         });
@@ -376,8 +378,10 @@ export default React.createClass({
 
     onCountBlur: function(e) {
         let instanceCount = parseInt(e.target.value);
-        instanceCount = Number.isNaN(instanceCount) || instanceCount < 1
-            ? 1 : instanceCount;
+        instanceCount =
+            Number.isNaN(instanceCount) || instanceCount < 1
+                ? 1
+                : instanceCount;
         e.target.value = instanceCount;
         this.setState({
             instanceCount
@@ -562,7 +566,7 @@ export default React.createClass({
                 "uuid"
             );
 
-            if(launchData.instanceCount == 1) {
+            if (launchData.instanceCount == 1) {
                 actions.InstanceActions.launch(launchData);
             } else {
                 actions.InstanceActions.multiLaunch(launchData);
@@ -669,8 +673,12 @@ export default React.createClass({
             Boolean(this.state[prop])
         );
 
-        return requiredExist && !this.exceedsResources()
-            && !this.invalidName() && !this.invalidInstanceCount();
+        return (
+            requiredExist &&
+            !this.exceedsResources() &&
+            !this.invalidName() &&
+            !this.invalidInstanceCount()
+        );
     },
 
     //==================

--- a/troposphere/static/js/components/modals/instance/InstanceLaunchWizardModal.jsx
+++ b/troposphere/static/js/components/modals/instance/InstanceLaunchWizardModal.jsx
@@ -562,7 +562,11 @@ export default React.createClass({
                 "uuid"
             );
 
-            actions.InstanceActions.launch(launchData);
+            if(launchData.instanceCount == 1) {
+                actions.InstanceActions.launch(launchData);
+            } else {
+                actions.InstanceActions.multiLaunch(launchData);
+            }
 
             // enter into a "waiting" state to determine
             // result of launch operation

--- a/troposphere/static/js/components/modals/instance/InstanceLaunchWizardModal.jsx
+++ b/troposphere/static/js/components/modals/instance/InstanceLaunchWizardModal.jsx
@@ -80,7 +80,8 @@ export default React.createClass({
             identityProvider: null,
             attachedScripts: [],
             allocationSource: null,
-            waitingOnLaunch: false
+            waitingOnLaunch: false,
+            instanceCount: 1
         };
     },
 
@@ -361,6 +362,19 @@ export default React.createClass({
     onProjectChange: function(project) {
         this.setState({
             project
+        });
+    },
+
+    onCountChange: function(e) {
+        this.setState({
+            instanceCount: e.target.value
+        });
+    },
+
+    onCountBlur: function(e) {
+        let instanceCount = this.state.instanceCount.trim();
+        this.setState({
+            instanceCount
         });
     },
 
@@ -783,7 +797,10 @@ export default React.createClass({
                     hasAdvancedOptions: this.hasAdvancedOptions(),
                     allocationSource: this.state.allocationSource,
                     allocationSourceList,
-                    waitingOnLaunch
+                    waitingOnLaunch,
+                    instanceCount: this.state.instanceCount,
+                    onCountChange: this.onCountChange,
+                    onCountBlur: this.onCountBlur
                 }}
             />
         );

--- a/troposphere/static/js/components/modals/instance/InstanceLaunchWizardModal.jsx
+++ b/troposphere/static/js/components/modals/instance/InstanceLaunchWizardModal.jsx
@@ -366,13 +366,19 @@ export default React.createClass({
     },
 
     onCountChange: function(e) {
+        let instanceCount = parseInt(e.target.value);
+        instanceCount = Number.isNaN(instanceCount) || instanceCount < 1
+            ? 1 : instanceCount;
         this.setState({
-            instanceCount: e.target.value
+            instanceCount
         });
     },
 
     onCountBlur: function(e) {
-        let instanceCount = this.state.instanceCount.trim();
+        let instanceCount = parseInt(e.target.value);
+        instanceCount = Number.isNaN(instanceCount) || instanceCount < 1
+            ? 1 : instanceCount;
+        e.target.value = instanceCount;
         this.setState({
             instanceCount
         });
@@ -543,6 +549,7 @@ export default React.createClass({
                 size: this.state.providerSize,
                 version: this.state.imageVersion,
                 scripts: this.state.attachedScripts,
+                instanceCount: this.state.instanceCount,
                 onSuccess: () => {
                     this.onLaunchSuccess();
                 },
@@ -631,6 +638,16 @@ export default React.createClass({
         return this.state.instanceName.match(regex);
     },
 
+    invalidInstanceCount: function() {
+        if (!Number.isInteger(this.state.instanceCount)) {
+            return true;
+        }
+        if (this.state.instanceCount < 1) {
+            return true;
+        }
+        return false;
+    },
+
     canLaunch: function() {
         let requiredFields = [
             "instanceName",
@@ -639,7 +656,8 @@ export default React.createClass({
             "providerSize",
             "imageVersion",
             "attachedScripts",
-            "allocationSource"
+            "allocationSource",
+            "instanceCount"
         ];
 
         // All required fields are truthy
@@ -647,7 +665,8 @@ export default React.createClass({
             Boolean(this.state[prop])
         );
 
-        return requiredExist && !this.exceedsResources() && !this.invalidName();
+        return requiredExist && !this.exceedsResources()
+            && !this.invalidName() && !this.invalidInstanceCount();
     },
 
     //==================

--- a/troposphere/static/js/components/modals/instance/launch/components/BasicInfoForm.jsx
+++ b/troposphere/static/js/components/modals/instance/launch/components/BasicInfoForm.jsx
@@ -17,7 +17,10 @@ export default React.createClass({
         instanceName: React.PropTypes.string,
         onNameChange: React.PropTypes.func,
         onVersionChange: React.PropTypes.func,
-        onProjectChange: React.PropTypes.func
+        onProjectChange: React.PropTypes.func,
+        instanceCount: React.PropTypes.number,
+        onCountChange: React.PropTypes.func,
+        onCountBlur: React.PropTypes.func
     },
 
     componentDidMount: function() {
@@ -60,7 +63,8 @@ export default React.createClass({
             projectList,
             instanceName,
             showValidationErr,
-            waitingOnLaunch
+            waitingOnLaunch,
+            instanceCount
         } = this.props;
         let hasErrorClass;
         let errorMessage = null;
@@ -136,6 +140,21 @@ export default React.createClass({
                     <p className="t-caption" style={{display: "block"}}>
                         {projectType}
                     </p>
+                </div>
+                <div className={"form-group " + hasErrorClass}>
+                    <label htmlFor="instanceCount">Instance Count</label>
+                    <input
+                        required
+                        disabled={waitingOnLaunch}
+                        type="number"
+                        className="form-control"
+                        id="instanceCount"
+                        value={instanceCount}
+                        ref="countInput"
+                        onChange={this.props.onCountChange}
+                        onBlur={this.props.onCountBlur}
+                    />
+                    <span className="help-block">{errorMessage}</span>
                 </div>
             </form>
         );

--- a/troposphere/static/js/components/modals/instance/launch/components/ResourceGraphs.jsx
+++ b/troposphere/static/js/components/modals/instance/launch/components/ResourceGraphs.jsx
@@ -8,7 +8,7 @@ export default React.createClass({
         resourcesUsed: React.PropTypes.object,
         identityProvider: React.PropTypes.instanceOf(Backbone.Model),
         providerSize: React.PropTypes.instanceOf(Backbone.Model),
-        instanceCount: React.PropTypes.number	
+        instanceCount: React.PropTypes.number
     },
 
     // This is what we show if the instance will exceed our resources.

--- a/troposphere/static/js/components/modals/instance/launch/components/ResourceGraphs.jsx
+++ b/troposphere/static/js/components/modals/instance/launch/components/ResourceGraphs.jsx
@@ -7,7 +7,8 @@ export default React.createClass({
         onRequestResources: React.PropTypes.func,
         resourcesUsed: React.PropTypes.object,
         identityProvider: React.PropTypes.instanceOf(Backbone.Model),
-        providerSize: React.PropTypes.instanceOf(Backbone.Model)
+        providerSize: React.PropTypes.instanceOf(Backbone.Model),
+        instanceCount: React.PropTypes.number	
     },
 
     // This is what we show if the instance will exceed our resources.
@@ -32,6 +33,7 @@ export default React.createClass({
         let identityProvider = this.props.identityProvider;
         let size = this.props.providerSize;
         let resourcesUsed = this.props.resourcesUsed;
+        let instanceCount = this.props.instanceCount;
 
         // Here we are declaring all of our variables that require 'if' check below before using our backbone methods.
         // If we don't have models yet, we still want to pass these empty declarations down to our child.
@@ -62,7 +64,7 @@ export default React.createClass({
             // CPU's have used + will use
             allocationCpu = identityProvider.get("quota").cpu;
             cpuUsed = resourcesUsed.cpu;
-            cpuWillUse = size.get("cpu");
+            cpuWillUse = size.get("cpu") * instanceCount;
             cpuWillTotal = cpuUsed + cpuWillUse;
             percentOfCpuUsed = Math.round(cpuUsed / allocationCpu * 100);
             percentOfCpuWillUse = Math.round(cpuWillUse / allocationCpu * 100);
@@ -70,7 +72,7 @@ export default React.createClass({
             // Memory have used + will use
             allocationGb = identityProvider.get("quota").memory;
             gbUsed = resourcesUsed.mem / 1024;
-            gbWillUse = size.get("mem");
+            gbWillUse = size.get("mem") * instanceCount;
             gbWillTotal = gbUsed + gbWillUse;
             percentOfGbUsed = Math.round(gbUsed / allocationGb * 100);
             percentOfGbWillUse = Math.round(gbWillUse / allocationGb * 100);

--- a/troposphere/static/js/models/Instance.js
+++ b/troposphere/static/js/models/Instance.js
@@ -100,8 +100,10 @@ export default Backbone.Model.extend({
                       return script.get("uuid");
                   })
                 : [],
-            extra = options.instance_count > 1
-                ? {instance_count: options.instance_count} : {};
+            extra =
+                options.instance_count > 1
+                    ? {instance_count: options.instance_count}
+                    : {};
 
         var url = globals.API_V2_ROOT + "/instances";
 

--- a/troposphere/static/js/models/Instance.js
+++ b/troposphere/static/js/models/Instance.js
@@ -80,6 +80,14 @@ export default Backbone.Model.extend({
         if (!options.allocation_source_id) {
             throw new Error("Missing allocation_source_id");
         }
+        if (options.instance_count) {
+            if (!Number.isInteger(options.instance_count)) {
+                throw new Error("Instance count should be an integer");
+            }
+            if (options.instance_count < 1) {
+                throw new Error("Instance count should be a postive integer");
+            }
+        }
 
         let identity = this.get("identity").uuid,
             name = options.name,
@@ -91,7 +99,9 @@ export default Backbone.Model.extend({
                 ? options.scripts.map(function(script) {
                       return script.get("uuid");
                   })
-                : [];
+                : [],
+            extra = options.instance_count > 1
+                ? {instance_count: options.instance_count} : {};
 
         var url = globals.API_V2_ROOT + "/instances";
 
@@ -102,7 +112,8 @@ export default Backbone.Model.extend({
             name,
             scripts,
             project,
-            identity
+            identity,
+            extra
         };
 
         return Backbone.sync("create", this, {


### PR DESCRIPTION
## Description

Add a new field in the Launch Instance Wizard for number of instance to be launched, make use of the multi-instance-launch from Atmosphere

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [x] Add an entry in the changelog
- [ ] Documentation created/updated (include links)
- [x] Reviewed and approved by at least one other contributor.
- [ ] New variables supported in Clank